### PR TITLE
Only list on localhost by default for fabric_api_server.py

### DIFF
--- a/infrastructure/server/fabric_api_server.py
+++ b/infrastructure/server/fabric_api_server.py
@@ -136,4 +136,4 @@ def extwis():
 
 # Run the application
 if __name__ == "__main__":
-    app.run(host="1.1.1.1", port=13337, debug=True)
+    app.run(host="::1", port=13337, debug=True)


### PR DESCRIPTION
1.1.1.1 is owned by another company, so the example IP should probably either be a local ip only (to prevent external use) or 0.0.0.0 if the assumption is that the server should be public.