### PR TITLE
Feature/general client

### DIFF
--- a/infrastructure/client/general_client.py
+++ b/infrastructure/client/general_client.py
@@ -1,0 +1,42 @@
+#!/usr/bin/python3
+
+import argparse
+import json
+import requests
+import sys
+
+def send_request(prompt, pattern):
+    """sends a pattern and the associated prompt to our general api
+
+    Args:
+        prompt (string): stdin string of context we will send to openai
+        pattern (string): list a pattern you would like the general client to run
+    """
+    
+    url = "http://localhost:13337/general"
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": "b246f5c2-6b45-492a-a230-52f2d04b3dc0",
+    }
+    data = json.dumps({"input": prompt, "pattern": pattern})
+    response = requests.post(url, headers=headers, data=data)
+
+    try:
+        print(response.json()["response"])
+    except KeyError:
+        print("Error: The API response does not contain a 'response' key.")
+        print("Received response:", response.json())
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description='Send a request to the API.')
+    parser.add_argument('-p', '--pattern', default='extract_wisdom', help='Specify the pattern to use')
+    parser.add_argument('prompt', nargs='?', default=sys.stdin, help='The prompt to send to the API')
+    
+    args = parser.parse_args()
+
+    if args.prompt == sys.stdin:
+        prompt = sys.stdin.read()
+    else:
+        prompt = args.prompt
+    
+    send_request(prompt, args.pattern)

--- a/infrastructure/client/general_client.py
+++ b/infrastructure/client/general_client.py
@@ -12,7 +12,7 @@ def list_patterns():
     # Gets the location of this script and ensures we resolve the right pattern path
     pattern_directory = f"{Path(__file__).resolve().parent}/../../patterns"  
     try:
-        return os.listdir(pattern_directory)
+        return sorted(os.listdir(pattern_directory))
     except FileNotFoundError:
         print("Pattern directory not found.")
         return []

--- a/infrastructure/client/general_client.py
+++ b/infrastructure/client/general_client.py
@@ -4,6 +4,19 @@ import argparse
 import json
 import requests
 import sys
+import os
+from pathlib import Path
+
+
+def list_patterns():
+    # Gets the location of this script and ensures we resolve the right pattern path
+    pattern_directory = f"{Path(__file__).resolve().parent}/../../patterns"  
+    try:
+        return os.listdir(pattern_directory)
+    except FileNotFoundError:
+        print("Pattern directory not found.")
+        return []
+
 
 def send_request(prompt, pattern):
     """sends a pattern and the associated prompt to our general api
@@ -30,13 +43,15 @@ def send_request(prompt, pattern):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Send a request to the API.')
     parser.add_argument('-p', '--pattern', default='extract_wisdom', help='Specify the pattern to use')
-    parser.add_argument('prompt', nargs='?', default=sys.stdin, help='The prompt to send to the API')
+    parser.add_argument('-l', '--list', action='store_true', help='List all available patterns')
     
     args = parser.parse_args()
 
-    if args.prompt == sys.stdin:
-        prompt = sys.stdin.read()
+    if args.list:
+        patterns = list_patterns()
+        print("Available patterns:")
+        for pattern in patterns:
+            print(pattern)
     else:
-        prompt = args.prompt
-    
-    send_request(prompt, args.pattern)
+        prompt = sys.stdin.read()
+        send_request(prompt, args.pattern)

--- a/infrastructure/server/fabric_api_keys.json
+++ b/infrastructure/server/fabric_api_keys.json
@@ -1,5 +1,8 @@
 {
   "/extwis": {
-    "eJ4f1e0b-25wO-47f9-97ec-6b5335b2": "Daniel Miessler"
+    "b246f5c2-6b45-492a-a230-52f2d04b3dc0": "Scott Behrens"
+  },
+  "/general": {
+    "b246f5c2-6b45-492a-a230-52f2d04b3dc0": "Scott Behrens"
   }
 }

--- a/infrastructure/server/fabric_api_server.py
+++ b/infrastructure/server/fabric_api_server.py
@@ -31,7 +31,7 @@ with open("openai.key", "r") as key_file:
     openai.api_key = key_file.read().strip()
 
 ## Define our own client
-client = openai.OpenAI(api_key = api_key)
+client = openai.OpenAI(api_key = openai.api_key)
 
 
 # Read API tokens from the apikeys.json file

--- a/infrastructure/server/requirements.txt
+++ b/infrastructure/server/requirements.txt
@@ -1,2 +1,3 @@
 openai
 requests
+flask


### PR DESCRIPTION
This provides a simple general client and API endpoint for simple patterns.

```
usage: general_client.py [-h] [-p PATTERN] [prompt]

Send a request to the API.

positional arguments:
  prompt                The prompt to send to the API

options:
  -h, --help            show this help message and exit
  -p PATTERN, --pattern PATTERN
                        Specify the pattern to use
```

The general API parses the github URL for the pattern name, and then executes those associated system and user prompts. More complex patterns may require additional client or API code. 

Note, I have modified the client and server IP addresses to default to localhost, enabling users to test out the tool without requiring code change. The API key which I have provided can be removed/redacted (it's a local UUID will change in production). 