### PR TITLE
Fix typo in Markdown bold

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Here are the three `fabric` ecosystem pieces, and how they work together.
 
 - The **Mill** is the (optional) server that makes **Patterns** available.
 - **Patterns** are the actual AI use cases.
-- **Looms** are the modular, client-side apps that call a specific **Pattern** hosted by a **Mill\*\*.
+- **Looms** are the modular, client-side apps that call a specific **Pattern** hosted by a **Mill**.
 
 ## Usage
 


### PR DESCRIPTION
This PR fixes a typo in `README.md` where the Markdown syntax for **bold** was shown as **bold\*\*.

Before:

![Screenshot 2024-02-01 at 14-06-11 eliot-akira_fabric fabric is an open-source framework for augmenting humans using AI](https://github.com/danielmiessler/fabric/assets/5352434/ba105e81-0491-40e2-acfe-77ea45e49cda)

After:

![Screenshot 2024-02-01 at 14-08-32 eliot-akira_fabric at fix-markdown-typo](https://github.com/danielmiessler/fabric/assets/5352434/49904d24-dce7-43f0-94dc-357e01e08fc7)

---

Maybe this was intentional in the original text, since the latter two asterisks were escaped, but it seemed inconsistent with the rest of the text where all bold text are actually bold without using `**` literally.

Anyway, I love the concept behind `fabric`, looking forward to learning more and following the project grow.