### PR TITLE
Use ConfigParser to parse user config file

### DIFF
--- a/client/utils.py
+++ b/client/utils.py
@@ -28,7 +28,7 @@ class UserConfig:
 class Standalone:
     def __init__(self, args, pattern=''):
         try:
-            c = UserConfig.from_env_file(env_file).openai_api_key
+            c = UserConfig.from_env_file(env_file)
             self.client = OpenAI(api_key=c.openai_api_key)
         except FileNotFoundError:
             print("No API key found. Use the --apikey option to set the key")


### PR DESCRIPTION
This fixes a bug caused by extra characters (e.g. newline) leading to an invalid `~/.config/fabric/.env` file (according to the current parsing logic, that is). A newline should be allowed yet causes an exception to be raised with a traceback pointing elsewhere in the code. Such a traceback could be difficult to fix for some users and turn them away from fabric rather quickly. Plus, sometimes text editors will automatically add the newline.

```shell
Traceback (most recent call last):
  File "/Users/ryan/fabric/client/fabric", line 68, in <module>
    standalone.sendMessage(text)
  File "/Users/ryan/fabric/client/utils.py", line 100, in sendMessage
    print(response)
          ^^^^^^^^
UnboundLocalError: cannot access local variable 'response' where it is not associated with a value
```

Separately, I would also argue that the code around the traceback needs some changes too, but this change does fix the issue I first encountered.