### PR TITLE
Update .gitignore and fabric server IP configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,7 @@ celerybeat.pid
 # Environments
 .env
 env/
+.venv/
 venv/
 ENV/
 env.bak/

--- a/client/p.py
+++ b/client/p.py
@@ -1,4 +1,4 @@
-#!/Users/jonathandunn/myAugmented/.venv/bin/python
+#!/usr/bin/env python3
 
 import pyperclip
 

--- a/server/fabric_api_server.py
+++ b/server/fabric_api_server.py
@@ -136,4 +136,4 @@ def extwis():
 
 # Run the application
 if __name__ == "__main__":
-    app.run(host="1.1.1.1", port=13337, debug=True)
+    app.run(host="127.0.0.1", port=13337, debug=True)

--- a/server/fabric_web_interface/fabric_web_server.py
+++ b/server/fabric_web_interface/fabric_web_server.py
@@ -2,6 +2,7 @@ from flask import Flask, render_template, request, redirect, url_for, flash, ses
 import requests
 import json
 from flask import send_from_directory
+import os
 
 ##################################################
 ##################################################
@@ -15,7 +16,7 @@ from flask import send_from_directory
 
 
 def send_request(prompt, endpoint):
-    base_url = "http://hostorip.tld:13337"
+    base_url = "http://127.0.0.1:13337"
     url = f"{base_url}{endpoint}"
     headers = {
         "Content-Type": "application/json",
@@ -54,4 +55,4 @@ def index():
 
 
 if __name__ == "__main__":
-    app.run(host="172.30.0.176", port=13338, debug=True)
+    app.run(host="127.0.0.1", port=13338, debug=True)


### PR DESCRIPTION
This PR proposes the following small fixes/changes

1. Change the `fabric_web_server`and `fabric_api_server` default IP to `127.0.0.1`

2. Add `.venv/` to `.gitignore`

3. Change shebang in `client/p.py` to standard `#!/usr/bin/env python3`
