### PR TITLE
feature: make path-pattern mapping dynamic and scalable

### DIFF
--- a/server/fabric_api_server.py
+++ b/server/fabric_api_server.py
@@ -93,12 +93,16 @@ def fetch_content_from_url(url):
 
 
 ## APIs
-
+# Make path mapping flexible and scalable
+pattern_path_mappings = {
+    "extwis": {"system_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/system.md",
+               "user_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/user.md"}
+}
 
 # /extwis
-@app.route("/extwis", methods=["POST"])
+@app.route("/<pattern>", methods=["POST"])
 @auth_required  # Require authentication
-def extwis():
+def mill(pattern):
     data = request.get_json()
 
     # Warn if there's no input
@@ -109,8 +113,8 @@ def extwis():
     input_data = data["input"]
 
     # Set the system and user URLs
-    system_url = "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/system.md"
-    user_url = "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/user.md"
+    urls = pattern_path_mappings[pattern]
+    system_url, user_url = urls["system_url"], urls["user_url"]
 
     # Fetch the prompt content
     system_content = fetch_content_from_url(system_url)

--- a/server/fabric_api_server.py
+++ b/server/fabric_api_server.py
@@ -99,7 +99,7 @@ pattern_path_mappings = {
                "user_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/user.md"}
 }
 
-# /extwis
+# /<pattern> in mapping dictionary
 @app.route("/<pattern>", methods=["POST"])
 @auth_required  # Require authentication
 def mill(pattern):

--- a/server/openai.key
+++ b/server/openai.key
@@ -1,1 +1,1 @@
-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
+sk-somethingsomethingnumbersandstuff

--- a/server/openai.key
+++ b/server/openai.key
@@ -1,1 +1,1 @@
-sk-somethingsomethingnumbersandstuff
+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


### PR DESCRIPTION
Currently your back-end API have only one, static path for external_wisdom pattern which is too rigid and hard to scale. As mentioned in #44 

I added a new way to dynamically map each path to each pattern and easy to scale further.

This is not a breaking change, It still compatible with the original code, you will be able to run the same HTTP call without error. But now you will have more flexibility on the back-end side.