### PR TITLE
add requirements.txt (from release 1.0.0) back to the client directory

### DIFF
--- a/client/requirements.txt
+++ b/client/requirements.txt
@@ -1,0 +1,17 @@
+pyyaml
+requests
+pyperclip
+python-socketio
+websocket-client
+flask
+flask_sqlalchemy
+flask_login
+flask_jwt_extended
+python-dotenv
+openai
+flask-socketio
+flask-sock
+gunicorn
+gevent
+httpx
+tqdm


### PR DESCRIPTION
I noticed that the requirements.txt file was missing in the `client` folder, and saw that an issue had been opened about this as well (https://github.com/danielmiessler/fabric/issues/67). I have pushed a fix where I just copied back the `requirements.txt`  file from the v1.0.0 release into the `client folder`