### PR TITLE
feat: mapping path and pattern in the dictionary

### DIFF
--- a/server/fabric_api_keys.json
+++ b/server/fabric_api_keys.json
@@ -3,7 +3,7 @@
     "eJ4f1e0b-25wO-47f9-97ec-6b5335b2": "Daniel Miessler",
     "test": "user2"
   },
-  "/summarise": {
+  "/summarize": {
     "eJ4f1e0b-25wO-47f9-97ec-6b5335b2": "Daniel Miessler",
     "test": "user2"
   }

--- a/server/fabric_api_keys.json
+++ b/server/fabric_api_keys.json
@@ -2,5 +2,9 @@
   "/extwis": {
     "eJ4f1e0b-25wO-47f9-97ec-6b5335b2": "Daniel Miessler",
     "test": "user2"
+  },
+  "/summarise": {
+    "eJ4f1e0b-25wO-47f9-97ec-6b5335b2": "Daniel Miessler",
+    "test": "user2"
   }
 }

--- a/server/fabric_api_server.py
+++ b/server/fabric_api_server.py
@@ -161,13 +161,19 @@ def fetch_content_from_url(url):
 
 
 ## APIs
+# Make path mapping flexible and scalable
+pattern_path_mappings = {
+    "extwis": {"system_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/system.md",
+               "user_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/user.md"},
+    "summarise": {"system_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/summarize/system.md",
+                  "user_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/summarize/user.md"}
+} # Add more pattern with your desire path as a key in this dictionary
 
-
-# /extwis
-@app.route("/extwis", methods=["POST"])
+# /<pattern>
+@app.route("/<pattern>", methods=["POST"])
 @auth_required  # Require authentication
-def extwis():
-    """    Extract wisdom from user input using OpenAI's GPT-4 model.
+def milling(pattern):
+    """    Combine fabric pattern with input from user and send to OpenAI's GPT-4 model.
 
     Returns:
         JSON: A JSON response containing the generated response or an error message.
@@ -186,8 +192,8 @@ def extwis():
     input_data = data["input"]
 
     # Set the system and user URLs
-    system_url = "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/system.md"
-    user_url = "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/user.md"
+    urls = pattern_path_mappings[pattern]
+    system_url, user_url = urls["system_url"], urls["user_url"]
 
     # Fetch the prompt content
     system_content = fetch_content_from_url(system_url)

--- a/server/fabric_api_server.py
+++ b/server/fabric_api_server.py
@@ -165,7 +165,7 @@ def fetch_content_from_url(url):
 pattern_path_mappings = {
     "extwis": {"system_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/system.md",
                "user_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/extract_wisdom/user.md"},
-    "summarise": {"system_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/summarize/system.md",
+    "summarize": {"system_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/summarize/system.md",
                   "user_url": "https://raw.githubusercontent.com/danielmiessler/fabric/main/patterns/summarize/user.md"}
 } # Add more pattern with your desire path as a key in this dictionary
 


### PR DESCRIPTION
Here I added path and pattern mapping dictionary in the server code. This will allow the milling function more dynamic and can be easily scale as mention in #52 #64 #44 

This is not breaking change, if you try to send a HTTP call to `/extwis` you can still do it. I also add more path, `/summarize` that use summarize pattern in the pattern directory, without changing anything in the milling function.