### PR TITLE
turns module import into package import

### DIFF
--- a/client/fabric/fabric.py
+++ b/client/fabric/fabric.py
@@ -1,4 +1,4 @@
-from utils import Standalone, Update, Setup
+from .utils import Standalone, Update, Setup
 import argparse
 import sys
 import os


### PR DESCRIPTION
I thought I had turned this into a package relative import when I introduced the poetry PR, perhaps it got lost in one of the merges?

Fixes and closes #99 

From `git blame` I see it was turned into an absolute import [on this commit](https://github.com/danielmiessler/fabric/commit/4c09fa3769140496d785db45f16a2a1dfe2ac32d). I wouldn't agree to it though. Happy to discuss further if necessary.