### PR TITLE
process enhancement: adds templates to the repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,37 @@
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "I was doing THIS, when THAT happened. I was expecting THAT_OTHER_THING to happen instead."
+    validations:
+      required: true
+  - type: checkboxes
+    id: version
+    attributes:
+      label: Version check
+      description: Please make sure you were using the latest version of this project available in the `main` branch.
+      options:
+        - label: Yes I was.
+          required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    id: screens
+    attributes:
+      label: Relevant screenshots (optional)
+      description: Please upload any screenshots that may help us reproduce and/or understand the issue.

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,13 @@
+name: Feature Request
+description: Suggest features for this project.
+title: "[Feature request]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What do you need?
+      description: Tell us what functionality you would like added/modified?
+      value: "I want the CLI to do my homework for me."
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,12 @@
+name: Question
+description: Ask us questions about this project.
+title: "[Question]: "
+labels: ["question"]
+body:
+  - type: textarea
+    id: description
+    attributes:
+      label: What is your question?
+      value: "After reading the documentation, I am still not clear how to get X working. I tried this, this, and that."
+    validations:
+      required: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,9 @@
+## What this Pull Request (PR) does
+Please briefly describe what this PR does.
+
+## Related issues
+Please reference any open issues this PR relates to in here.
+If it closes an issue, type `closes #[ISSUE_NUMBER]`.
+
+## Screenshots
+Provide any screenshots you may find relevant to facilitate us understanding your PR.


### PR DESCRIPTION
## What this Pull Request (PR) does
This PR adds a few templates to the repo to facilitate collaboration and communication with the community of contributors and users.

## Related issues
Closes #109 

## Screenshots
This is what it should look like after merged. Starting from the `New Issue` button under the `Issues` tab.
 
![Screenshot 2024-02-17 143333](https://github.com/danielmiessler/fabric/assets/10410523/ff45732c-828a-487d-98cf-636b634c3a56)

![Screenshot 2024-02-17 143404](https://github.com/danielmiessler/fabric/assets/10410523/66183d17-9274-485e-841f-d51ac3247c08)

![Screenshot 2024-02-17 143419](https://github.com/danielmiessler/fabric/assets/10410523/050adcb7-7ebb-41bc-9747-b0ed15286c1e)

![Screenshot 2024-02-17 143431](https://github.com/danielmiessler/fabric/assets/10410523/3c4dd454-542a-4ff1-beac-e9f4bb3b2a18)
