### PR TITLE
Add New "create_command" Pattern

### DIFF
--- a/patterns/create_command/README.md
+++ b/patterns/create_command/README.md
@@ -1,0 +1,75 @@
+# Create Command
+
+During penetration tests, many different tools are used, and often they are run with different parameters and switches depending on the target and circumstances. Because there are so many tools, it's easy to forget how to run certain tools, and what the different parameters and switches are. Most tools include a "-h" help switch to give you these details, but it's much nicer to have AI figure out all the right switches with you just providing a brief description of your objective with the tool. 
+
+# Requirements
+
+You must have the desired tool installed locally that you want Fabric to generate the command for. For the examples above, the tool must also have help documentation at "tool -h", which is the case for most tools.
+
+# Examples
+
+For example, here is how it can be used to generate different commands
+
+
+## sqlmap
+
+**prompt**
+```
+tool=sqlmap;echo -e "use $tool target https://example.com?test=id url, specifically the test endpoint. use a random user agent and do the scan aggressively with the highest risk and level\n\n$($tool -h 2>&1)" | fabric --pattern create_command
+```
+
+**result**
+
+```
+python3 sqlmap -u https://example.com?test=id --random-agent --level=5 --risk=3
+```
+
+## nmap
+**prompt**
+
+```
+tool=nmap;echo -e "use $tool to target all hosts in the host.lst file even if they don't respond to pings. scan the top 10000 ports and save the ouptut to a text file and an xml file\n\n$($tool -h 2>&1)" | fabric --pattern create_command
+```
+
+**result**
+
+```
+nmap -iL host.lst -Pn --top-ports 10000 -oN output.txt -oX output.xml
+```
+
+## gobuster
+
+**prompt**
+```
+tool=gobuster;echo -e "use $tool to target example.com for subdomain enumeration and use a wordlist called big.txt\n\n$($tool -h 2>&1)" | fabric --pattern create_command
+```
+**result**
+
+```
+gobuster dns -u example.com -w big.txt
+```
+
+
+## dirsearch
+**prompt**
+
+```
+tool=dirsearch;echo -e "use $tool to enumerate https://example.com. ignore 401 and 404 status codes. perform the enumeration recursively and crawl the website. use 50 threads\n\n$($tool -h 2>&1)" | fabric --pattern create_command
+```
+
+**result**
+
+```
+dirsearch -u https://example.com -x 401,404 -r --crawl -t 50
+```
+
+## nuclei
+
+**prompt**
+```
+tool=nuclei;echo -e "use $tool to scan https://example.com. use a max of 10 threads. output result to a json file. rate limit to 50 requests per second\n\n$($tool -h 2>&1)" | fabric --pattern create_command
+```
+**result**
+```
+nuclei -u https://example.com -c 10 -o output.json -rl 50 -j
+```

--- a/patterns/create_command/README.md
+++ b/patterns/create_command/README.md
@@ -15,13 +15,13 @@ For example, here is how it can be used to generate different commands
 
 **prompt**
 ```
-tool=sqlmap;echo -e "use $tool target https://example.com?test=id url, specifically the test endpoint. use a random user agent and do the scan aggressively with the highest risk and level\n\n$($tool -h 2>&1)" | fabric --pattern create_command
+tool=sqlmap;echo -e "use $tool target https://example.com?test=id url, specifically the test parameter. use a random user agent and do the scan aggressively with the highest risk and level\n\n$($tool -h 2>&1)" | fabric --pattern create_command
 ```
 
 **result**
 
 ```
-python3 sqlmap -u https://example.com?test=id --random-agent --level=5 --risk=3
+python3 sqlmap -u https://example.com?test=id --random-agent --level=5 --risk=3 -p test
 ```
 
 ## nmap

--- a/patterns/create_command/system.md
+++ b/patterns/create_command/system.md
@@ -1,0 +1,22 @@
+# IDENTITY and PURPOSE
+
+You are a penetration tester that is extremely good at reading and understanding command line help instructions. You are responsible for generating CLI commands for various tools that can be run to perform certain tasks based on documentation given to you.
+
+Take a step back and analyze the help instructions thoroughly to ensure that the command you provide performs the expected actions. It is crucial that you only use switches and options that are explicitly listed in the documentation passed to you. Do not attempt to guess. Instead, use the documentation passed to you as your primary source of truth. It is very important the the commands you generate run properly and do not use fake or invalid options and switches.
+
+# OUTPUT INSTRUCTIONS
+
+- Output the requested command using the documentation provided with the provided details inserted. The input will include the prompt on the first line and then the tool documentation for the command will be provided on subsequent lines.
+- Do not add additional options or switches unless they are explicitly asked for.
+- Only use switches that are explicitly stated in the help documentation that is passed to you as input.
+
+# OUTPUT FORMAT
+
+- Output a full, bash command with all relevant parameters and switches.
+- Refer to the provided help documentation.
+- Only output the command. Do not output any warning or notes.
+- Do not output any Markdown or other formatting. Only output the command itself.
+
+# INPUT:
+
+INPUT:


### PR DESCRIPTION
## What this Pull Request (PR) does
This adds a new "create_command" pattern that generates CLI commands for any locally installed tool (including appropriate options and switches) based on a description of what the user wants the tool to do. The user describes what the specified tool should do and the documentation from the "-h" help switch that most commands have. The pattern then acts as an individual who is reading the help documentation and selecting the correct options and switches to add to the command to achieve the specified goal. 

For example, if the user wants to know how to run `sqlmap` under specific conditions, they may use `fabric` with the `create_command` pattern as follows (specify the tool, description of what the tool should do, and the help documentation via the "-h" switch for the tool):

```
tool=sqlmap; echo -e "use $tool target https://example.com?test=id url, specifically the test parameter. use a random user agent and do the scan aggressively with the highest risk and level\n\n$($tool -h 2>&1)" | fabric --pattern create_command
```

`fabric` responds with:

```
python3 sqlmap -u https://example.com?test=id --random-agent --level=5 --risk=3 -p test
```

The inspiration for this comes from penetration testing, where many CLI tools are used, but it can be difficult to remember all of the options and switches.

Details and examples can be found in the README.
