### PR TITLE
bugfix: Add failover functionality to setup

### DIFF
--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -430,8 +430,8 @@ class Setup:
             openaiapikey = os.environ["OPENAI_API_KEY"]
             self.openaiapi_key = openaiapikey
         except KeyError:
-            print("OPENAI_API_KEY not found in environment variables.")
-            sys.exit()
+            print("OPENAI_API_KEY not found in environment variables. ")
+            self.run()
         self.fetch_available_models()
 
     def fetch_available_models(self):


### PR DESCRIPTION
## What this Pull Request (PR) does
-Updates the `fabric --setup` to ask for an OPENAI_API_KEY if none is found.

## Related issues
None identified.

## Screenshots
Previously default setup was causing an issue as can be seen below. With the update `fabric --setup` correctly asks for the OPENAI_API_KEY if none was found
Issue:
<img width="840" alt="before" src="https://github.com/danielmiessler/fabric/assets/22076146/e799a77e-10ee-4bf8-b497-6ceb6da2f224">

After applying the fix:
<img width="849" alt="after" src="https://github.com/danielmiessler/fabric/assets/22076146/f5dba315-db59-4dea-a8ee-b03acfc937a1">