### PR TITLE
feat: Add supported Claude models

### DIFF
--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -251,7 +251,7 @@ class Standalone:
     def fetch_available_models(self):
         gptlist = []
         fullOllamaList = []
-        claudeList = ['claude-3-opus-20240229']
+        claudeList = ['claude-3-opus-20240229', 'claude-3-sonnet-20240229', 'claude-2.1']
         try:
             headers = {
                 "Authorization": f"Bearer {self.client.api_key}"


### PR DESCRIPTION
## What this Pull Request (PR) does
Currently, only the opus model is supported by fabric.
This PR adds `claude-3-sonnet-20240229` and `claude-2.1`, both support system prompts as required by fabric.

This way there is more flexibility when using fabric with the Anthropic provider.

## Related issues
As this is a quick add, I haven't created a dedicated issue for it.
Happy to create one and link it, if required.

## Screenshots

Example usage of `create_aphorisms` with Claude-2.1:

<img width="981" alt="open-source-aphorisms-claude-2 1" src="https://github.com/danielmiessler/fabric/assets/5006784/4d72f79d-93c4-4f3d-980b-572b197a8449">

Example usage of the same pattern with Claude-3 Sonnet:

<img width="933" alt="open-source-aphorisms-claude-3-sonnet" src="https://github.com/danielmiessler/fabric/assets/5006784/601012ce-f0db-49e5-be23-67e8f6e2a475">
