### PR TITLE
Add clear option to fabric.py CLI and fix changing default model

### DIFF
--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -56,6 +56,7 @@ def main():
                         help='The URL of the remote ollamaserver to use. ONLY USE THIS if you are using a local ollama server in an non-deault location or port')
     parser.add_argument('--context', '-c',
                         help="Use Context file (context.md) to add context to your pattern", action="store_true")
+    parser.add_argument('--clear', help="Clear the default model and other persisted settings", action="store_true")
 
     args = parser.parse_args()
     home_holder = os.path.expanduser("~")
@@ -79,6 +80,9 @@ def main():
     if args.changeDefaultModel:
         Setup().default_model(args.changeDefaultModel)
         sys.exit()
+    if args.clear:
+        os.remove(env_file)
+        sys.exit()        
     if args.agents:
         # Handle the agents logic
         if args.agents == 'trip_planner':

--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -46,7 +46,7 @@ class Standalone:
         self.pattern = pattern
         self.args = args
         self.model = None
-        if args.model:
+        if args and args.model:
             self.model = args.model
         else:
             try:
@@ -534,7 +534,7 @@ class Setup:
         """
         model = model.strip()
         env = os.path.expanduser("~/.config/fabric/.env")
-        standalone = Standalone(args=[], pattern="")
+        standalone = Standalone(args=None, pattern="")
         gpt, ollama, claude = standalone.fetch_available_models()
         allmodels = gpt + ollama + claude
         if model not in allmodels:


### PR DESCRIPTION
## What this Pull Request (PR) does
This PR:
- adds the missing --clear argument
- allows changing the default model when you have a valid open ai key. (with #225 this works without an api key for local models)

**Summary**

This pull request introduces two changes to the `installer/client/cli/fabric.py` and `installer/client/cli/utils.py` files. The first change adds a new command-line flag `--clear` to the `fabric.py` file that clears the default model and other persisted settings. The second change is in `utils.py` where an additional check for the existence of `args.model` before attempting to assign it to the instance variable `self.model`.

**Files Changed**

1. `installer/client/cli/fabric.py`: This file was modified to add a new command-line flag `--clear` and update the help message accordingly. The existing code for changing the default model was left unchanged.
2. `installer/client/cli/utils.py`: In this file, an additional check was added to ensure that `args.model` is truthy before assigning it to `self.model`. This change prevents an error when running the script without providing a model argument.


## Related issues
This closes #252 
