### PR TITLE
Improved system.md to avoid pattern from being overridden by user input

### DIFF
--- a/patterns/improve_prompt/system.md
+++ b/patterns/improve_prompt/system.md
@@ -512,3 +512,7 @@ END PROMPT WRITING KNOWLEDGE
 
 1. Output the prompt in clean, human-readable Markdown format.
 2. Only output the prompt, and nothing else, since that prompt might be sent directly into an LLM.
+
+# INPUT
+
+The following is the prompt you will improve:


### PR DESCRIPTION
Additional instructions for Fabric to improve the prompt instead of overriding fabric's pattern with the input prompt.

## Issue this PR solves
When we use the original `improve_prompt` pattern to improve a prompt by, for example `cat prompt_to_be_improved.md | fabric -p improve_prompt` , Fabric interprets the text of the prompt to be improved (User input) as the actual prompt instructions, and the result is Fabric's pattern being overridden by the user input (Which is itself a prompt, hence the confusion).

## How the issue is resolved
I just included additional instructions at the end of the pattern's system.md to stop Fabric (OpenAI GPT LLM) from overriding the "pattern" with the user prompt

## Related issues
No related open issues

## Screenshot of the issue

ISSUE: In the following image, I have a poorly written prompt, and when I use fabric's pattern "improve_prompt", it takes my "bad prompt" as its actual prompt instructions, essentially overriding the pattern's system.md prompt:

<img width="1324" alt="image" src="https://github.com/Argandov/fabric/assets/67169222/2219b836-438f-414a-a3bf-b379f253b614">

FIX: Here is how my change solves the issue, and Fabric (OpenAI) takes the user input (A prompt), not as its instruction prompt, but as a prompt to be improved:

<img width="1417" alt="image" src="https://github.com/Argandov/fabric/assets/67169222/42e93420-5174-4db0-a713-e8ae2a70fe4e">
