### PR TITLE
Language choice option when pulling a transcript from yt

### DIFF
--- a/installer/client/cli/yt.py
+++ b/installer/client/cli/yt.py
@@ -88,11 +88,11 @@ def main_function(url, options):
 
         # Get video transcript
         try:
-            transcript_list = YouTubeTranscriptApi.get_transcript(video_id)
+            transcript_list = YouTubeTranscriptApi.get_transcript(video_id, languages=[options.lang])
             transcript_text = " ".join([item["text"] for item in transcript_list])
             transcript_text = transcript_text.replace("\n", " ")
         except Exception as e:
-            transcript_text = f"Transcript not available. ({e})"
+            transcript_text = f"Transcript not available in the selected language ({options.lang}). ({e})"
 
         # Get comments if the flag is set
         comments = []
@@ -126,7 +126,8 @@ def main():
     parser.add_argument('--duration', action='store_true', help='Output only the duration')
     parser.add_argument('--transcript', action='store_true', help='Output only the transcript')
     parser.add_argument('--comments', action='store_true', help='Output the comments on the video')
-
+    parser.add_argument('--lang', default='en', help='Language for the transcript (default: English)')
+    
     args = parser.parse_args()
 
     if args.url is None:


### PR DESCRIPTION
## What this Pull Request (PR) does
I've added the option to select the language in which the video is recorded on youtube and later through the script transcribed.
Default is English.

## Related issues
None found.

## Screenshots
Now I can use it for example with pl language videos:
<img width="877" alt="obraz" src="https://github.com/danielmiessler/fabric/assets/65460644/9cc9d4c4-bc46-4c37-8fe0-27d0f4163b2c">


