### PR TITLE
Update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,6 +241,9 @@ options:
 
 The client, by default, runs Fabric patterns without needing a server (the Patterns were downloaded during setup). This means the client connects directly to OpenAI using the input given and the Fabric pattern used.
 
+> [!NOTE]
+> `pbpaste` is the Linux/bash command to read from the clipboard. In PowerShell, use `Get-Clipboard`, or in WSL use `powershell.exe -c Get-Clipboard` in place of `pbpaste` in the following commands
+
 1. Run the `summarize` Pattern based on input from `stdin`. In this case, the body of an article.
 
 ```bash
@@ -259,10 +262,15 @@ pbpaste | fabric --stream --pattern analyze_claims
 yt --transcript https://youtube.com/watch?v=uXs-zPc63kM | fabric --stream --pattern extract_wisdom
 ```
 
-4. **new** All of the patterns have been added as aliases to your bash (or zsh) config file
+4. All of the patterns have been added as aliases to your bash (or zsh) config file
 
 ```bash
 pbpaste | analyze_claims --stream
+```
+5. Run patterns on a local Ollama instance. Note that Ollama must be running with `ollama serve` on localhost with the default port, or the host and port should be configured with `--remoteOllamaServer`. This example assumes that the codellama model has already been pulled by Ollama (ie `ollama pull codellama:latest`)
+
+```bash
+pbpaste | fabric --pattern explain_code --model codellama:latest
 ```
 
 > [!NOTE]

--- a/README.md
+++ b/README.md
@@ -209,38 +209,7 @@ Once you have it all set up, here's how to use it.
    `fabric -h`
 
 ```bash
-us the results in
-                        realtime. NOTE: You will not be able to pipe the
-                        output into another command.
-  --list, -l            List available patterns
-  --clear               Clears your persistent model choice so that you can
-                        once again use the --model flag
-  --update, -u          Update patterns. NOTE: This will revert the default
-                        model to gpt4-turbo. please run --changeDefaultModel
-                        to once again set default model
-  --pattern PATTERN, -p PATTERN
-                        The pattern (prompt) to use
-  --setup               Set up your fabric instance
-  --changeDefaultModel CHANGEDEFAULTMODEL
-                        Change the default model. For a list of available
-                        models, use the --listmodels flag.
-  --model MODEL, -m MODEL
-                        Select the model to use. NOTE: Will not work if you
-                        have set a default model. please use --clear to clear
-                        persistence before using this flag
-  --listmodels          List all available models
-  --remoteOllamaServer REMOTEOLLAMASERVER
-                        The URL of the remote ollamaserver to use. ONLY USE
-                        THIS if you are using a local ollama server in an non-
-                        deault location or port
-  --context, -c         Use Context file (context.md) to add context to your
-                        pattern
-age: fabric [-h] [--text TEXT] [--copy] [--agents {trip_planner,ApiKeys}]
-              [--output [OUTPUT]] [--stream] [--list] [--clear] [--update]
-              [--pattern PATTERN] [--setup]
-              [--changeDefaultModel CHANGEDEFAULTMODEL] [--model MODEL]
-              [--listmodels] [--remoteOllamaServer REMOTEOLLAMASERVER]
-              [--context]
+usage: fabric [-h] [--text TEXT] [--copy] [--agents {trip_planner,ApiKeys}] [--output [OUTPUT]] [--stream] [--list] [--update] [--pattern PATTERN] [--setup] [--changeDefaultModel CHANGEDEFAULTMODEL] [--model MODEL] [--listmodels] [--remoteOllamaServer REMOTEOLLAMASERVER] [--context]
 
 An open source framework for augmenting humans using AI.
 
@@ -249,12 +218,23 @@ options:
   --text TEXT, -t TEXT  Text to extract summary from
   --copy, -C            Copy the response to the clipboard
   --agents {trip_planner,ApiKeys}, -a {trip_planner,ApiKeys}
-                        Use an AI agent to help you with a task. Acceptable
-                        values are 'trip_planner' or 'ApiKeys'. This option
-                        cannot be used with any other flag.
+                        Use an AI agent to help you with a task. Acceptable values are 'trip_planner' or 'ApiKeys'. This option cannot be used with any other flag.
   --output [OUTPUT], -o [OUTPUT]
                         Save the response to a file
-  --stream, -s          Use this option if you want to see
+  --stream, -s          Use this option if you want to see the results in realtime. NOTE: You will not be able to pipe the output into another command.
+  --list, -l            List available patterns
+  --update, -u          Update patterns. NOTE: This will revert the default model to gpt4-turbo. please run --changeDefaultModel to once again set default model
+  --pattern PATTERN, -p PATTERN
+                        The pattern (prompt) to use
+  --setup               Set up your fabric instance
+  --changeDefaultModel CHANGEDEFAULTMODEL
+                        Change the default model. For a list of available models, use the --listmodels flag.
+  --model MODEL, -m MODEL
+                        Select the model to use. NOTE: Will not work if you have set a default model. please use --clear to clear persistence before using this flag
+  --listmodels          List all available models
+  --remoteOllamaServer REMOTEOLLAMASERVER
+                        The URL of the remote ollamaserver to use. ONLY USE THIS if you are using a local ollama server in an non-deault location or port
+  --context, -c         Use Context file (context.md) to add context to your pattern
 ```
 
 #### Example commands

--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -53,7 +53,7 @@ def main():
         "--listmodels", help="List all available models", action="store_true"
     )
     parser.add_argument('--remoteOllamaServer',
-                        help='The URL of the remote ollamaserver to use. ONLY USE THIS if you are using a local ollama server in an non-deault location or port')
+                        help='The URL of the remote ollamaserver to use. ONLY USE THIS if you are using a local ollama server in an non-default location or port')
     parser.add_argument('--context', '-c',
                         help="Use Context file (context.md) to add context to your pattern", action="store_true")
 


### PR DESCRIPTION
## What this Pull Request (PR) does
Updates the readme to include some instructions on how to use fabric more easily in Windows (PowerShell and WSL). Corrects the portion of the readme which has the output of `fabric -h`. Corrects a minor typo in the help text for the --remoteOllamaServer flag. 

## Related issues
Usage updates in the readme reference #269 and #268. It *may* close both issues. 

## Screenshots
N/A - easier to see in the code I think. 