### PR TITLE
[Feature] Added Dockerfile which takes base Python image, installed pipx & fabric

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM python:3.12.2-slim
+
+# Install required packages
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        git \
+        build-essential \
+        ffmpeg \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install pipx
+RUN python3 -m pip install --upgrade pip \
+    && python3 -m pip install --user pipx \
+    && python3 -m pipx ensurepath
+
+# Set up work directory
+WORKDIR /app
+
+# Clone the repository and install its dependencies
+RUN git clone https://github.com/danielmiessler/fabric.git \
+    && python3 -m pipx install ./fabric
+
+# Set the entrypoint
+ENTRYPOINT ["/usr/bin/bash"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,19 +6,37 @@ RUN apt-get update \
         git \
         build-essential \
         ffmpeg \
-    && rm -rf /var/lib/apt/lists/*
+        sudo\
+    && rm -rf /var/lib/apt/lists/* \
+    && apt-get clean
+
+# Create a non-root user
+RUN useradd --create-home appuser \
+    && echo "appuser ALL=(ALL) NOPASSWD: ALL" > /etc/sudoers.d/appuser \
+    && chmod 0440 /etc/sudoers.d/appuser
+
+# Switch to the non-root user
+USER appuser
+
+# Set up work directory
+WORKDIR /home/appuser/app
 
 # Install pipx
 RUN python3 -m pip install --upgrade pip \
     && python3 -m pip install --user pipx \
     && python3 -m pipx ensurepath
 
-# Set up work directory
-WORKDIR /app
 
 # Clone the repository and install its dependencies
 RUN git clone https://github.com/danielmiessler/fabric.git \
     && python3 -m pipx install ./fabric
+
+
+# Set file permissions for the app directory
+RUN chmod -R 755 /home/appuser/app
+
+# Switch back to the non-root user
+USER appuser
 
 # Set the entrypoint
 ENTRYPOINT ["/usr/bin/bash"]


### PR DESCRIPTION
## What this Pull Request (PR) does
Introduces a Dockerfile configured to set up environment for working with Fabric.

- Installs, git, build-essential, ffmpeg. 
- Installs and Congifures pipx
- Clones fabric repo
- Sets working dir to `/app `
- Set entry point to /`usr/bin/bash/`

*Note:*
This Dockerfile is not hardened for security purposes. If you mount this container to your file system you expose yourself highly to the container. Any users should probably made aware of this before suggesting it's use.

Feedback and suggestions for improvements and hardening are welcome! 🐱 

## Related issues
#25 
closes #275 
