### PR TITLE
Add support for running local models via LM Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -241,7 +241,9 @@ options:
                         Select the model to use. NOTE: Will not work if you have set a default model. please use --clear to clear persistence before using this flag
   --listmodels          List all available models
   --remoteOllamaServer REMOTEOLLAMASERVER
-                        The URL of the remote ollamaserver to use. ONLY USE THIS if you are using a local ollama server in an non-deault location or port
+                        The URL of the remote ollamaserver to use. ONLY USE THIS if you are using a local ollama server in a non-deault location or port.
+  --openAiBaseUrl       Base URL for OpenAI calls. Use this for when you want to use a local model via LM Studio.
+                        Alternatively, you can set OPENAI_API_BASE_URL in the environment.
   --context, -c         Use Context file (context.md) to add context to your pattern
 ```
 

--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -64,6 +64,8 @@ def main():
     )
     parser.add_argument('--remoteOllamaServer',
                         help='The URL of the remote ollamaserver to use. ONLY USE THIS if you are using a local ollama server in an non-deault location or port')
+    parser.add_argument('--openAiBaseUrl',
+                        help='Base URL for OpenAI calls. Use this for when you want to use a local model via LM Studio. Alternatively, you can set OPENAI_API_BASE_URL in the environment.')
     parser.add_argument('--context', '-c',
                         help="Use Context file (context.md) to add context to your pattern", action="store_true")
 

--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -40,9 +40,16 @@ class Standalone:
         env_file = os.path.expanduser(env_file)
         self.client = None
         load_dotenv(env_file)
+        if args.openAiBaseUrl:
+            self.openai_base_url = args.openApiBaseUrl
+        else:
+            self.openai_base_url = os.environ.get("OPENAI_API_BASE_URL", None)
         if "OPENAI_API_KEY" in os.environ:
             api_key = os.environ['OPENAI_API_KEY']
-            self.client = OpenAI(api_key=api_key)
+            if self.openai_base_url:
+                self.client = OpenAI(api_key=api_key, base_url=self.openai_base_url)
+            else:
+                self.client = OpenAI(api_key=api_key)
         self.local = False
         self.config_pattern_directory = config_directory
         self.pattern = pattern

--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -41,7 +41,7 @@ class Standalone:
         self.client = None
         load_dotenv(env_file)
         if args.openAiBaseUrl:
-            self.openai_base_url = args.openApiBaseUrl
+            self.openai_base_url = args.openAiBaseUrl
         else:
             self.openai_base_url = os.environ.get("OPENAI_API_BASE_URL", None)
         if "OPENAI_API_KEY" in os.environ:


### PR DESCRIPTION
## Summary
This pull request adds support for using local OpenAI models via LM Studio. Users can now specify a custom base URL for OpenAI API calls, allowing them to use locally hosted models instead of the default OpenAI API.

## Files Changed

### README.md
- Updated the command line options section to include the new `--openAiBaseUrl` flag.
- Clarified that the flag is used for specifying a local model via LM Studio.
- Mentioned the alternative of setting the `OPENAI_API_BASE_URL` environment variable.

### installer/client/cli/fabric.py
- Added a new command line argument `--openAiBaseUrl` to allow users to specify a custom base URL for OpenAI API calls.

### installer/client/cli/utils.py
- Modified the `Standalone` class constructor to handle the new `--openAiBaseUrl` flag.
- If the flag is provided, it sets `self.openai_base_url` to the specified value.
- If the flag is not provided, it checks for the `OPENAI_API_BASE_URL` environment variable.
- When creating an instance of the `OpenAI` client, it now checks if `self.openai_base_url` is set and passes it as the `base_url` parameter.

## Reason for Changes
The purpose of these changes is to enable users to use locally hosted OpenAI models via LM Studio. By allowing users to specify a custom base URL for OpenAI API calls, they can point the client to their local model instead of relying on the default OpenAI API.

Users who want to experiment with custom models or who have particular needs that the default OpenAI models cannot satisfy will particularly benefit from this flexibility. This adds to the already existing support for Ollama.

## Impact of Changes
These changes introduce a new feature that expands the capabilities of the client. Users now have the option to use local OpenAI models, providing them with more control and customization options.

The changes are backward compatible and do not affect existing functionality. If the `--openAiBaseUrl` flag or `OPENAI_API_BASE_URL` environment variable is not set, the client will continue to use the default OpenAI API.

## Test Plan
To test these changes:
1. Set up a local OpenAI model using LM Studio.
2. Run the client with the `--openAiBaseUrl` flag, specifying the URL of the local model.
3. Verify that the client successfully connects to the local model and generates responses based on the local model.
4. Alternatively, set the `OPENAI_API_BASE_URL` environment variable to the URL of the local model and run the client without the `--openAiBaseUrl` flag.
5. Verify that the client uses the local model specified in the environment variable.

## Test Results

Running without `--openAiBaseUrl`:

```
PS C:\Users\kayvan\src\fabric> fabric --listmodels
GPT Models:
gpt-3.5-turbo
gpt-3.5-turbo-0125
[...]
```

Running with the new option:

```
PS C:\Users\kayvan\src\fabric> fabric --openAiBaseUrl http://localhost:1234/v1 --listmodels
GPT Models:
mistral_ai_cyberbrain.Q4_K_M.gguf

Local Models:
codellama:13b
codellama:latest
[...]

Claude Models:
claude-3-opus-20240229
[...]

PS C:\Users\kayvan\src\fabric> fabric --openAiBaseUrl http://localhost:1234/v1 --pattern ai --text 'What is the tallest tree in the world?'
1. The tallest tree is a coast redwood named Hyperion, located in California's Redwood National and State Parks.
2. It stands at an impressive height of 379.7 feet (115.6 meters).
3. Hyperion surpassed the previous record holder, a tree named Helicopters, in 2008.
```

Running in WSL with `OPENAI_API_BASE_URL` environment variable. The LM Studio server is running on the Windows host, which is why we access it via the gateway host in WSL.

```
kayvan@SHAKTI:/mnt/c/Users/kayvan/src/fabric$ ip route
default via 172.26.96.1 dev eth0 
10.42.0.0/24 dev cni0 proto kernel scope link src 10.42.0.1 
172.17.0.0/16 dev docker0 proto kernel scope link src 172.17.0.1 
172.26.96.0/20 dev eth0 proto kernel scope link src 172.26.105.111 

kayvan@SHAKTI:/mnt/c/Users/kayvan/src/fabric$ env | grep OPENAI
OPENAI_API_BASE_URL=http://172.26.96.1:1234/v1

kayvan@SHAKTI:/mnt/c/Users/kayvan/src/fabric$ fabric --listmodels
GPT Models:
mistral_ai_cyberbrain.Q4_K_M.gguf

Local Models:
codellama:13b
codellama:latest
dolphin-mistral:latest
dolphincoder:latest
llama2:13b
llama2:latest
mistral:latest
mxbai-embed-large:latest
starcoder2:15b

Claude Models:
claude-3-opus-20240229
claude-3-sonnet-20240229
claude-3-haiku-20240307
claude-2.1
```

And running the same query:

```
kayvan@SHAKTI:/mnt/c/Users/kayvan/src/fabric$ fabric --pattern ai --text 'What is the tallest tree in the world?'
1. The tallest tree is a coast redwood named Hyperion, located in California's Redwood National and State Parks.
2. It stands at an impressive height of 379.7 feet (115.6 meters).
3. Hyperion surpassed the previous record holder, a tree named Helicopters, by over 40 feet in 2008.
```

