### PR TITLE
fix: The variable 'wisdomFilePath' is already a complete path constru…

### DIFF
--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -172,7 +172,7 @@ class Standalone:
         else:
             user = input_data
         user_message = {"role": "user", "content": f"{input_data}"}
-        wisdom_File = os.path.join(current_directory, wisdomFilePath)
+        wisdom_File = wisdomFilePath
         buffer = ""
         system = ""
         if self.pattern:


### PR DESCRIPTION
The variable 'wisdomFilePath' is already a complete path constructed with 'config_directory'. Joining it again with 'current_directory' could lead to an incorrect path.
