### PR TITLE
Fix for broken link pointing to /client

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ https://github.com/danielmiessler/fabric/blob/main/patterns/extract_wisdom/syste
 
 ## Quickstart
 
-The most feature-rich way to use Fabric is to use the `fabric` client, which can be found under <a href="https://github.com/danielmiessler/fabric/tree/main/client">`/client`</a> directory in this repository.
+The most feature-rich way to use Fabric is to use the `fabric` client, which can be found under <a href="https://github.com/danielmiessler/fabric/tree/main/installer/client">`/client`</a> directory in this repository.
 
 ### Setting up the fabric commands
 


### PR DESCRIPTION
Broken reference link. Replaced it with new:

https://github.com/danielmiessler/fabric/tree/main/installer/client

See issue: 
https://github.com/danielmiessler/fabric/issues/366 
