### PR TITLE
Ensure env file created in setup when no API keys provided

### DIFF
--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -531,6 +531,21 @@ class Setup:
         except:
             pass
 
+    def __ensure_env_file_created(self):
+        """        Ensure that the environment file is created.
+
+        Returns:
+            None
+
+        Raises:
+            OSError: If the environment file cannot be created.
+        """
+        print("Creating empty environment file...")
+        if not os.path.exists(self.env_file):
+            with open(self.env_file, "w") as f:
+                f.write("#No API key set\n")
+        print("Environment file created.")
+
     def update_shconfigs(self):
         bootstrap_file = os.path.join(
             self.config_directory, "fabric-bootstrap.inc")
@@ -697,6 +712,7 @@ class Setup:
         self.youtube_key(youtubekey)
         self.patterns()
         self.update_shconfigs()
+        self.__ensure_env_file_created()
 
 
 class Transcribe:


### PR DESCRIPTION
Hi there,

thank you for providing fabric to the community. This PR is a little contribution to solve the following loop : setup -> no API key provided --> need to setup. The use case is to only use local models with ollama.
Feel free to do whatever you want with this btw ;)

## What this Pull Request (PR) does
This PR add a private function at the end of setup step to ensure .env file is created even if no API key provided. This lets user with only local models use fabric without creating useless openAPI key for example.

## Related issues
closes #285 


