### PR TITLE
Add configurable date format for save helper app

### DIFF
--- a/installer/client/cli/save.py
+++ b/installer/client/cli/save.py
@@ -54,12 +54,12 @@ def main(tag, tags, silent, fabric):
     # Prevent a NoneType ending up in the tags
     frontmatter_tags = ""
     if fabric:
-        frontmatter_tags = os.getenv(FM_KEY)
+        frontmatter_tags = os.getenv(FM_KEY) or ""
 
     with open(target, "w") as fp:
         if frontmatter_tags or len(tags) != 0:
             fp.write("---\n")
-            now = datetime.now().strftime(f"{DATE_FORMAT} %H:%M")
+            now = datetime.now().strftime(f"%Y-%m-%d %H:%M")
             fp.write(f"generation_date: {now}\n")
             fp.write(f"tags: {frontmatter_tags} {tag} {' '.join(tags)}\n")
             fp.write("---\n")

--- a/installer/client/cli/save.py
+++ b/installer/client/cli/save.py
@@ -8,9 +8,8 @@ from dotenv import load_dotenv
 DEFAULT_CONFIG = "~/.config/fabric/.env"
 PATH_KEY = "FABRIC_OUTPUT_PATH"
 FM_KEY = "FABRIC_FRONTMATTER_TAGS"
-DATE_FORMAT = "%Y-%m-%d"
 load_dotenv(os.path.expanduser(DEFAULT_CONFIG))
-
+DATE_FORMAT = os.getenv("SAVE_DATE_FORMAT", "%Y-%m-%d")
 
 def main(tag, tags, silent, fabric):
     out = os.getenv(PATH_KEY)
@@ -31,15 +30,21 @@ def main(tag, tags, silent, fabric):
         print(f"'{sys.argv[0]}' takes a single argument to tag your summary")
         sys.exit(1)
 
-    yyyymmdd = datetime.now().strftime(DATE_FORMAT)
-    target = f"{out}{yyyymmdd}-{tag}.md"
+    if DATE_FORMAT:
+        yyyymmdd = datetime.now().strftime(DATE_FORMAT)
+        target = f"{out}{yyyymmdd}-{tag}.md"
+    else:
+        target = f"{out}{tag}.md"
 
     # don't clobber existing files- add an incremented number to the end instead
     would_clobber = True
     inc = 0
     while would_clobber:
         if inc > 0:
-            target = f"{out}{yyyymmdd}-{tag}-{inc}.md"
+            if DATE_FORMAT:
+                target = f"{out}{yyyymmdd}-{tag}-{inc}.md"
+            else:
+                target = f"{out}{tag}-{inc}.md"
         if os.path.exists(target):
             inc += 1
         else:


### PR DESCRIPTION
## What this Pull Request (PR) does

### Feature

This PR adds the ability to configure the date format of the target filename via setting the `SAVE_DATE_FORMAT` variable in `~/.config/fabric/.env`.

Previously, there was no way to get rid of the date being prepended to the target filename, but with this PR this is now possible by leaving `SAVE_DATE_FORMAT` empty like so:

```
SAVE_DATE_FORMAT=''
```

#### More Details:

- Update `DATE_FORMAT` to be configurable using the `SAVE_DATE_FORMAT` environment variable
- Modify target filename generation to handle cases where `SAVE_DATE_FORMAT` is left blank
- Default to date format "%Y-%m-%d" if `SAVE_DATE_FORMAT` is not set

### Bug Fix
Prevent NoneType from ending up in the tags. The previous fix did not work and "None" would still end up in the tags if `FABRIC_FRONTMATTER_TAGS` was not specified.

## Related issues
None

## Screenshots
N/A