### PR TITLE
Bug Fix: splitting string only if find_most_recent_file() returns something

### DIFF
--- a/installer/client/cli/helper.py
+++ b/installer/client/cli/helper.py
@@ -60,7 +60,12 @@ class Session:
 
     def list_sessions(self):
         sessionlist = os.listdir(self.sessions_folder)
-        most_recent = self.find_most_recent_file().split("/")[-1]
+        most_recent = self.find_most_recent_file()
+        if most_recent:
+            most_recent = most_recent.split("/")[-1]
+        else:
+            print("no recent sessions found")
+            return
         for session in sessionlist:
             with open(os.path.join(self.sessions_folder, session), "r") as f:
                 firstline = f.readline().strip()


### PR DESCRIPTION
## What this Pull Request (PR) does
Fixes  error that occurs when NoneType is returned from `find_most_recent_file()` and split is called hastily

## Related issues
[issue 450](https://github.com/danielmiessler/fabric/issues/450)
## Screenshots
Not a screenshot per-se, but should help with context
```
fabric --listsessions
Traceback (most recent call last):
  File "/path/to/fabric", line 8, in <module>
    sys.exit(cli())
             ^^^^^
  File "/path/to/fabric/site-packages/installer/client/cli/fabric.py", line 148, in main
    session.list_sessions()
  File "/path/to/fabric/site-packages/installer/client/cli/helper.py", line 63, in list_sessions
    most_recent = self.find_most_recent_file().split("/")[-1]
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'split'
```