### PR TITLE
Improved handling of non-ASCII characters in transcript printing and JSON output from `yt` command 

### DIFF
--- a/installer/client/cli/yt.py
+++ b/installer/client/cli/yt.py
@@ -110,11 +110,20 @@ def main_function(url, options):
         if options.duration:
             print(duration_minutes)
         elif options.transcript:
-            print(transcript_text.encode('utf-8').decode('unicode-escape'))
+            try:
+                 print(transcript_text)
+            except UnicodeEncodeError:
+                print(transcript_text.encode('utf-8').decode('unicode-escape'))
         elif options.comments:
-            print(json.dumps(comments, indent=2))
+            try:
+                print(json.dumps(comments, indent=2, ensure_ascii=False))
+            except UnicodeEncodeError:
+                print(json.dumps(comments, indent=2))
         elif options.metadata:
-            print(json.dumps(metadata, indent=2))
+            try:
+                print(json.dumps(metadata, indent=2, ensure_ascii=False))
+            except UnicodeEncodeError:
+                print(json.dumps(metadata, indent=2))
         else:
             # Create JSON object with all data
             output = {
@@ -124,7 +133,10 @@ def main_function(url, options):
                 "metadata": metadata
             }
             # Print JSON object
-            print(json.dumps(output, indent=2))
+            try:
+                print(json.dumps(output, indent=2, ensure_ascii=False))
+            except UnicodeEncodeError:
+                print(json.dumps(output, indent=2))
     except HttpError as e:
         print(f"Error: Failed to access YouTube API. Please check your YOUTUBE_API_KEY and ensure it is valid: {e}")
 


### PR DESCRIPTION
## What this PR does
Improved handling of non-ASCII characters in transcript printing and JSON output from `yt` command 

- Updated print(transcript) to handle non-ASCII characters correctly.
- Modified print statements to use ensure_ascii=False in json.dumps for correct display of non-ASCII characters.
- Implemented exception handling to manage potential UnicodeEncodeErrors, ensuring fallback encoding to avoid garbled text.

This change enhances the readability of outputs containing non-ASCII characters and addresses potential encoding issues across different environments.

## Related issues and Screenshots
See this issue: https://github.com/JFK/fabric/issues/1
