### PR TITLE
Fix yt transcript encoding errors

### DIFF
--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -407,7 +407,7 @@ class Standalone:
         fullOllamaList = []
         googleList = []
         if "CLAUDE_API_KEY" in os.environ:
-            claudeList = ['claude-3-5-sonnet-20240620','claude-3-opus-20240229', 'claude-3-sonnet-20240229',
+            claudeList = ['claude-3-5-sonnet-20240620', 'claude-3-5-sonnet-20240620','claude-3-opus-20240229', 'claude-3-sonnet-20240229',
                           'claude-3-haiku-20240307', 'claude-2.1']
         else:
             claudeList = []

--- a/installer/client/cli/yt.py
+++ b/installer/client/cli/yt.py
@@ -110,7 +110,7 @@ def main_function(url, options):
         if options.duration:
             print(duration_minutes)
         elif options.transcript:
-            print(transcript_text.encode('utf-8').decode('unicode-escape'))
+            print(transcript_text)
         elif options.comments:
             print(json.dumps(comments, indent=2))
         elif options.metadata:


### PR DESCRIPTION
## What this Pull Request (PR) does
Fix error in the encoded output when using the yt command with --transcript. 

Reproduce the error with the command 
`yt --transcript https://youtu.be/k8cdByDa3oA\?si\=__-Tlmvt7KoP7eR2`

Original Output: 
`In the early years of microelectronics,Â  there were many types of transistors. But one rose up to rule all the others. Based onÂ  an idea that physicists have chased for decades. And today, we have made more of it than anythingÂ`

Fixed Output:
`In the early years of microelectronics,  there were many types of transistors. But one rose up to rule all the others. Based on  an idea that physicists have chased for decades. And today, we have made more of it than anything `

Solution:
Edit `fabric/installer/client/cli/yt.py` line 113.
Original code: `print(transcript_text.encode('utf-8').decode('unicode-escape'))`
Fixed code: `print(transcript_text)`
Reinstall: `pipx install . --force`

Thanks to CaeChao here: https://github.com/danielmiessler/fabric/issues/468#issuecomment-2140722991
