### PR TITLE
Remember my remote Ollama server:port in .env

### DIFF
--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -178,31 +178,31 @@ def main():
         text = standalone.get_cli_input()
     if args.stream and not args.context:
         if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
-            standalone.streamMessage(text, host=os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer)
+            standalone.streamMessage(text, host=args.remoteOllamaServer or os.environ["REMOTE_OLLAMA_SERVER"])
         else:
             standalone.streamMessage(text)
         sys.exit()
     if args.stream and args.context:
         with open(config_context, "r") as f:
             context = f.read()
-            if args.remoteOllamaServer:
+            if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
                 standalone.streamMessage(
-                    text, context=context, host=args.remoteOllamaServer)
+                    text, context=context, host=args.remoteOllamaServer or os.environ["REMOTE_OLLAMA_SERVER"])
             else:
                 standalone.streamMessage(text, context=context)
         sys.exit()
     elif args.context:
         with open(config_context, "r") as f:
             context = f.read()
-            if args.remoteOllamaServer:
+            if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
                 standalone.sendMessage(
-                    text, context=context, host=args.remoteOllamaServer)
+                    text, context=context, host=args.remoteOllamaServer or os.environ["REMOTE_OLLAMA_SERVER"])
             else:
                 standalone.sendMessage(text, context=context)
         sys.exit()
     else:
-        if args.remoteOllamaServer:
-            standalone.sendMessage(text, host=args.remoteOllamaServer)
+        if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
+            standalone.sendMessage(text, host=args.remoteOllamaServer or os.environ["REMOTE_OLLAMA_SERVER"])
         else:
             standalone.sendMessage(text)
         sys.exit()

--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -177,8 +177,8 @@ def main():
     else:
         text = standalone.get_cli_input()
     if args.stream and not args.context:
-        if args.remoteOllamaServer:
-            standalone.streamMessage(text, host=args.remoteOllamaServer)
+        if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
+            standalone.streamMessage(text, host=os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer)
         else:
             standalone.streamMessage(text)
         sys.exit()

--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -177,32 +177,32 @@ def main():
     else:
         text = standalone.get_cli_input()
     if args.stream and not args.context:
-        if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
-            standalone.streamMessage(text, host=args.remoteOllamaServer or os.environ["REMOTE_OLLAMA_SERVER"])
+        if os.environ.get('REMOTE_OLLAMA_SERVER', None) or args.remoteOllamaServer:
+            standalone.streamMessage(text, host=os.environ.get('REMOTE_OLLAMA_SERVER', None) or args.remoteOllamaServer)
         else:
             standalone.streamMessage(text)
         sys.exit()
     if args.stream and args.context:
         with open(config_context, "r") as f:
             context = f.read()
-            if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
+            if os.environ.get('REMOTE_OLLAMA_SERVER', None) or args.remoteOllamaServer:
                 standalone.streamMessage(
-                    text, context=context, host=args.remoteOllamaServer or os.environ["REMOTE_OLLAMA_SERVER"])
+                    text, context=context, host=os.environ.get('REMOTE_OLLAMA_SERVER', None) or args.remoteOllamaServer)
             else:
                 standalone.streamMessage(text, context=context)
         sys.exit()
     elif args.context:
         with open(config_context, "r") as f:
             context = f.read()
-            if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
+            if os.environ.get('REMOTE_OLLAMA_SERVER', None) or args.remoteOllamaServer:
                 standalone.sendMessage(
-                    text, context=context, host=args.remoteOllamaServer or os.environ["REMOTE_OLLAMA_SERVER"])
+                    text, context=context, host=os.environ.get('REMOTE_OLLAMA_SERVER', None) or args.remoteOllamaServer)
             else:
                 standalone.sendMessage(text, context=context)
         sys.exit()
     else:
-        if os.environ["REMOTE_OLLAMA_SERVER"] or args.remoteOllamaServer:
-            standalone.sendMessage(text, host=args.remoteOllamaServer or os.environ["REMOTE_OLLAMA_SERVER"])
+        if os.environ.get('REMOTE_OLLAMA_SERVER', None) or args.remoteOllamaServer:
+            standalone.sendMessage(text, host=os.environ.get('REMOTE_OLLAMA_SERVER', None) or args.remoteOllamaServer)
         else:
             standalone.sendMessage(text)
         sys.exit()

--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -479,7 +479,7 @@ class Standalone:
         if model in self.sorted_gpt_models:
             os.environ["OPENAI_API_BASE"] = "https://api.openai.com/v1/"
         elif model in self.ollamaList:
-            os.environ["OPENAI_API_BASE"] = "http://localhost:11434/v1"
+            os.environ["OPENAI_API_BASE"] = f"http://{getattr(self.args, 'remoteOllamaServer', None) or os.environ.get('REMOTE_OLLAMA_SERVER', 'localhost')}/v1"  # if nothing about remote was passed - localhost it would be; also user flag takes precedence over the env variable.
             os.environ["OPENAI_API_KEY"] = "NA"
 
         elif model in self.claudeList:

--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -431,7 +431,7 @@ class Standalone:
 
         import ollama
         try:
-            remoteOllamaServer = os.environ["REMOTE_OLLAMA_SERVER"] or getattr(self.args, 'remoteOllamaServer', None)
+            remoteOllamaServer = getattr(self.args, 'remoteOllamaServer', None) or os.environ.get('REMOTE_OLLAMA_SERVER', None)
             if remoteOllamaServer:
                 client = ollama.Client(host=remoteOllamaServer)
                 default_modelollamaList = client.list()['models']

--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -431,9 +431,9 @@ class Standalone:
 
         import ollama
         try:
-            remoteOllamaServer = getattr(self.args, 'remoteOllamaServer', None)
+            remoteOllamaServer = os.environ["REMOTE_OLLAMA_SERVER"] or getattr(self.args, 'remoteOllamaServer', None)
             if remoteOllamaServer:
-                client = ollama.Client(host=self.args.remoteOllamaServer)
+                client = ollama.Client(host=remoteOllamaServer)
                 default_modelollamaList = client.list()['models']
             else:
                 default_modelollamaList = ollama.list()['models']


### PR DESCRIPTION
### RATIONALE
In order to streamline local LLM use on servers, here is a tiny update that simplifies calling remote Ollama models from the terminal machines. You can do so by setting the --remoteOllamaServer flag in each fabric call... every time you do a call. For me personally it's 40 extra characters that include the --remoteOllamaServer flag plus IP and port.
To further simplify this process, I propose adding support for the REMOTE_OLLAMA_SERVER environment variable, which enables users to configure their remote Ollama server settings globally. This enhancement fits well within the general quick setup paradigm and caters to a broader range of users who may not require this feature in every situation.

### CHANGES
- Added support for `REMOTE_OLLAMA_SERVER` environment variable.
- Updated `streamMessage` to use `REMOTE_OLLAMA_SERVER` if available.
- Refactored `Standalone` class to prioritize `REMOTE_OLLAMA_SERVER`.
- Simplified client initialization with `ollama.Client`.
- Ensured backward compatibility with existing `remoteOllamaServer` argument.