### PR TITLE
Removing the note about pattern updates changing the default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ options:
                         sets the frequency penalty for the model. Default is 0.1
   --presence_penalty PRESENCE_PENALTY
                         sets the presence penalty for the model. Default is 0.1
-  --update, -u          Update patterns. NOTE: This will revert the default model to gpt4-turbo. please run --changeDefaultModel to once again set the default model
+  --update, -u          Update patterns.
   --pattern PATTERN, -p PATTERN
                         The pattern (prompt) to use
   --setup               Set up your fabric instance

--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -55,7 +55,7 @@ def main():
     parser.add_argument(
         '--presence_penalty', help="set the presence penalty for the model. Default is 0.1", default=0.1, type=float)
     parser.add_argument(
-        "--update", "-u", help="Update patterns. NOTE: This will revert the default model to gpt4-turbo. please run --changeDefaultModel to once again set default model", action="store_true")
+        "--update", "-u", help="Update patterns", action="store_true")
     parser.add_argument("--pattern", "-p", help="The pattern (prompt) to use")
     parser.add_argument(
         "--setup", help="Set up your fabric instance", action="store_true"


### PR DESCRIPTION
## What this Pull Request (PR) does
This removes the "NOTE: This will revert the default model to gpt4-turbo. please run --changeDefaultModel to once again set the default model" that appears (1) in the readme file, and (2) in the --help text. The note appears to reflect behavior that is no longer happening, at least, I've not observed this reversion.

## Note
If this behavior still happens, given some specific conditions, then the note should be changed (instead of removed) to call that out.