### PR TITLE
fix: genai.list_models() precedes model names by models/ => just take the part after /

### DIFF
--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -446,7 +446,7 @@ class Standalone:
             genai.configure(api_key=os.environ["GOOGLE_API_KEY"])
             for m in genai.list_models():
                 if 'generateContent' in m.supported_generation_methods:
-                    googleList.append(m.name)
+                    googleList.append(m.name.split("/")[-1])
         except:
             googleList = []
 


### PR DESCRIPTION
## What this Pull Request (PR) does
fetch_available_models in utils.py populates googleList with model names preceded by models/ - e.g. models/gemini-1.5-flash instead of just gemini-1.5-flash. This PR fixes this.

closes #[674]
