### PR TITLE
Added current model indicator with an * when --listmodels is called

### DIFF
--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -159,32 +159,22 @@ def main():
             print("No patterns found")
             sys.exit()
     if args.listmodels:
+        def print_models(model_type, curr_model):
+            for model in model_type:
+                if curr_model == model:
+                    print(model + " (current)")
+                else:
+                    print(model)
         gptmodels, localmodels, claudemodels, googlemodels = standalone.fetch_available_models()
         curr_model = os.environ.get('DEFAULT_MODEL', None)
         print("GPT Models:")
-        for model in gptmodels:
-            if curr_model == model:
-                print(model + "*")
-            else:
-                print(model)
+        print_models(gptmodels, curr_model)
         print("\nLocal Models:")
-        for model in localmodels:
-            if curr_model == model:
-                print(model + "*")
-            else:
-                print(model)
+        print_models(localmodels, curr_model)
         print("\nClaude Models:")
-        for model in claudemodels:
-            if curr_model == model:
-                print(model + "*")
-            else:
-                print(model)
+        print_models(claudemodels, curr_model)
         print("\nGoogle Models:")
-        for model in googlemodels:
-            if curr_model == model:
-                print(model + "*")
-            else:
-                print(model)
+        print_models(googlemodels, curr_model)
         sys.exit()
     if args.text is not None:
         text = args.text

--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -1,6 +1,7 @@
 from .utils import Standalone, Update, Setup, Alias, run_electron_app
 import argparse
 import sys
+from dotenv import load_dotenv
 import os
 
 
@@ -159,18 +160,31 @@ def main():
             sys.exit()
     if args.listmodels:
         gptmodels, localmodels, claudemodels, googlemodels = standalone.fetch_available_models()
+        curr_model = os.environ.get('DEFAULT_MODEL', None)
         print("GPT Models:")
         for model in gptmodels:
-            print(model)
+            if curr_model == model:
+                print(model + "*")
+            else:
+                print(model)
         print("\nLocal Models:")
         for model in localmodels:
-            print(model)
+            if curr_model == model:
+                print(model + "*")
+            else:
+                print(model)
         print("\nClaude Models:")
         for model in claudemodels:
-            print(model)
+            if curr_model == model:
+                print(model + "*")
+            else:
+                print(model)
         print("\nGoogle Models:")
         for model in googlemodels:
-            print(model)
+            if curr_model == model:
+                print(model + "*")
+            else:
+                print(model)
         sys.exit()
     if args.text is not None:
         text = args.text


### PR DESCRIPTION
## What this Pull Request (PR) does
Trying to add a small and simple feature for my first contribution. Whenever 'fabric --listmodels' is called, the output will denote the currently used model with an asterisk after it. Hopefully this will give users a better idea of the current model they've set Fabric to utilize.

## Related issues
closes #446 

## Screenshots
![image](https://github.com/danielmiessler/fabric/assets/67214216/d1c64b97-a625-42f0-8dab-f3ceba07b16f)


