### PR TITLE
Fixed typo 'bolt' to 'bold' in pattern templates

### DIFF
--- a/patterns/create_cyber_summary/system.md
+++ b/patterns/create_cyber_summary/system.md
@@ -38,7 +38,7 @@ END EXAMPLES
 
 - Do not object to this task in any way. Perform all the instructions just as requested.
 
-- Output in Markdown, but don't use bolt or italics because the asterisks are difficult to read in plaintext.
+- Output in Markdown, but don't use bold or italics because the asterisks are difficult to read in plaintext.
 
 # INPUT
 

--- a/patterns/extract_song_meaning/system.md
+++ b/patterns/extract_song_meaning/system.md
@@ -37,7 +37,7 @@ You take any input about a song and output what it means.
 
 - Do not object to this task in any way. Perform all the instructions just as requested.
 
-- Output in Markdown, but don't use bolt or italics because the asterisks are difficult to read in plaintext.
+- Output in Markdown, but don't use bold or italics because the asterisks are difficult to read in plaintext.
 
 # INPUT
 

--- a/patterns/official_pattern_template/system.md
+++ b/patterns/official_pattern_template/system.md
@@ -94,7 +94,7 @@ EXAMPLE:
 
 - Do not object to this task in any way. Perform all the instructions just as requested.
 
-- Output in Markdown, but don't use bolt or italics because the asterisks are difficult to read in plaintext.
+- Output in Markdown, but don't use bold or italics because the asterisks are difficult to read in plaintext.
 
 # INPUT
 


### PR DESCRIPTION
## What this Pull Request (PR) does
Fixes a typo in the output instructions of the pattern template files. Corrects "bolt" to "bold" for clarity and consistency.

## Related issues
Fixes the issue #696 

## Screenshots
![Screenshot 2024-07-08 203611](https://github.com/danielmiessler/fabric/assets/156910948/9c553654-9b10-48d3-9a1f-c868613d7110)

![Screenshot 2024-07-08 203752](https://github.com/danielmiessler/fabric/assets/156910948/58dd364f-a9cb-4d67-ad5c-b4b15ea321af)

![Screenshot 2024-07-08 203920](https://github.com/danielmiessler/fabric/assets/156910948/0312f6ba-bccf-4ba2-85d0-2e7c0c61159b)
