### PR TITLE
Add feat: use Rich to enhance Markdown output

### DIFF
--- a/installer/client/cli/fabric.py
+++ b/installer/client/cli/fabric.py
@@ -73,7 +73,9 @@ def main():
                         help='The URL of the remote ollamaserver to use. ONLY USE THIS if you are using a local ollama server in an non-default location or port')
     parser.add_argument('--context', '-c',
                         help="Use Context file (context.md) to add context to your pattern", action="store_true")
-
+    parser.add_argument("--rich", "-r",
+                        help="Use Python Library Rich for beautiful formatting of markdown in the terminal.", action="store_true")
+    
     args = parser.parse_args()
     home_holder = os.path.expanduser("~")
     config = os.path.join(home_holder, ".config", "fabric")

--- a/installer/client/cli/utils.py
+++ b/installer/client/cli/utils.py
@@ -11,6 +11,8 @@ import tempfile
 import subprocess
 import shutil
 from youtube_transcript_api import YouTubeTranscriptApi
+from rich.console import Console
+from rich.markdown import Markdown
 
 current_directory = os.path.dirname(os.path.realpath(__file__))
 config_directory = os.path.expanduser("~/.config/fabric")
@@ -69,7 +71,7 @@ class Standalone:
             response = await AsyncClient(host=host).chat(model=self.model, messages=messages)
         else:
             response = await AsyncClient().chat(model=self.model, messages=messages)
-        print(response['message']['content'])
+        rich_print(self.args.rich, response['message']['content'])
         copy = self.args.copy
         if copy:
             pyperclip.copy(response['message']['content'])
@@ -133,7 +135,7 @@ class Standalone:
             model=self.model,
             temperature=self.args.temp, top_p=self.args.top_p
         )
-        print(message.content[0].text)
+        rich_print(self.args.rich, message.content[0].text)
         copy = self.args.copy
         if copy:
             pyperclip.copy(message.content[0].text)
@@ -153,7 +155,7 @@ class Standalone:
         model = genai.GenerativeModel(
             model_name=self.model, system_instruction=system)
         response = model.generate_content(user)
-        print(response.text)
+        rich_print(self.args.rich, response.text)
         if copy:
             pyperclip.copy(response.text)
         if self.args.output:
@@ -375,7 +377,7 @@ class Standalone:
                     frequency_penalty=self.args.frequency_penalty,
                     presence_penalty=self.args.presence_penalty,
                 )
-                print(response.choices[0].message.content)
+                rich_print(self.args.rich, response.choices[0].message.content)
                 if self.args.copy:
                     pyperclip.copy(response.choices[0].message.content)
                 if self.args.output:
@@ -895,3 +897,20 @@ def run_electron_app():
         subprocess.run(['npm', 'start'], check=True)
     except subprocess.CalledProcessError as e:
         print(f"An error occurred while executing NPM commands: {e}")
+
+
+def rich_print(rich_enabled, text):
+    """ 
+    This method prints text using [Rich](https://github.com/Textualize/rich) library if rich_enabled is True.
+    It is suitable for printing Markdown text when the output is not a stream.
+
+    Input:
+        rich_enabled: a boolean indicating whether to use Rich or not
+        text: the text to be printed
+    """
+    if rich_enabled:
+        markdown = Markdown(text)
+        console = Console()
+        console.print(markdown)
+    else:
+        print(text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,7 @@ gunicorn = "^22.0.0"
 gevent = "^23.9.1"
 httpx = ">=0.25.2,<0.26.0"
 tqdm = "^4.66.3"
+rich = "^13.7.1"
 
 [tool.poetry.group.server.dependencies]
 requests = "^2.32.0"


### PR DESCRIPTION
## What this Pull Request (PR) does
Markdown output is a suitable format, but it can sometimes be difficult to read in the terminal. 
Why not utilize [Rich](https://github.com/Textualize/rich) to enhance the markdown output and make it more readable and beautiful?

### changes:
- Add the Rich dependency in `pyproject.toml`
- Add an argument `--rich -r` in `fabric.py` to use rich in the normal output mode
- Add a function`rich_print()` to replace `print()` in `utils.py`

### Usage:
- Add `--rich` or `-r` to the commands.
- Not suitable for the stream output

## Related issues

## Screenshots
### Demo 1: compare_and_contrast
![demo1](https://github.com/danielmiessler/fabric/assets/23497428/3fa2b772-7b4c-4293-9006-a8bf6c343961)
### Demo 2: summarize
![demo2](https://github.com/danielmiessler/fabric/assets/23497428/da7b7f53-01e2-4ad9-b655-a2416209ca70)
### Demo 3: create_coding_project
![demo3](https://github.com/danielmiessler/fabric/assets/23497428/5d9c69e6-d3d9-4700-ab0a-ba2732e7f1ed)