### PR TITLE
modified regex in get_video_id() to include youtube.com/live/* urls.

### DIFF
--- a/installer/client/cli/yt.py
+++ b/installer/client/cli/yt.py
@@ -13,7 +13,7 @@ import sys
 
 def get_video_id(url):
     # Extract video ID from URL
-    pattern = r"(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=)|youtu\.be\/)([a-zA-Z0-9_-]{11})"
+    pattern = r"(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})"
     match = re.search(pattern, url)
     return match.group(1) if match else None
 


### PR DESCRIPTION
### Title: Enhance Regex Pattern to Include YouTube Live URLs

### Description:
This pull request introduces an enhancement to the existing regex pattern in the CLI application [to support extracting YouTube video IDs](https://github.com/danielmiessler/fabric/discussions/760) from URLs that contain the `/live/` segment. The following changes have been made:

1. **Updated Regex Pattern:**
   - The regex pattern now includes support for URLs of the format `https://www.youtube.com/live/VIDEO_ID`.
   - The updated regex pattern is:
     ```python
     pattern = r"(?:https?:\/\/)?(?:www\.)?(?:youtube\.com\/(?:[^\/\n\s]+\/\S+\/|(?:v|e(?:mbed)?)\/|\S*?[?&]v=|live\/)|youtu\.be\/)([a-zA-Z0-9_-]{11})"
     ```
### Motivation and Context:
The enhancement is necessary to accommodate the increasing usage of YouTube live URLs. Previously, the regex pattern did not capture video IDs from URLs with the `/live/` segment, limiting the functionality of the `get_video_id` function and returning a `Invalid YouTube URL` error.

### How Has This Been Tested?
The changes have been tested locally with various YouTube URL formats to ensure the function extracts the correct video IDs. 

### Types of Changes:
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Additional Notes:
Please review the changes and let me know if there are any further adjustments needed. I am open to feedback and willing to make necessary modifications.

Thank you for considering my [first ever] pull request.