### PR TITLE
fix(ci): upload built binaries to GitHub Releases on tag creation

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,14 +2,18 @@ name: Go Build and Release
 
 on:
   push:
-    branches: [ "main" ]
+    branches: ["main"]
+    tags:
+      - "v*"
   pull_request:
-    branches: [ "main" ]
+    branches: ["main"]
 
 jobs:
   build:
     name: Build binaries for Windows, macOS, and Linux
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -20,12 +24,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.22.1'
+          go-version-file: ./go.mod
 
       - name: Build binary on Linux and macOS
         if: matrix.os != 'windows-latest'
@@ -56,3 +60,12 @@ jobs:
           path: |
             fabric-${{ matrix.os }}-${{ matrix.arch }}-${{ github.ref_name }}
             fabric-macos-${{ matrix.arch }}-${{ github.ref_name }}.dmg
+
+      - name: Upload release artifact
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+        run: |
+          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
+            gh release upload ${{ github.ref_name }} fabric-macos-${{ matrix.arch }}-${{ github.ref_name }}.dmg
+          else
+            gh release upload ${{ github.ref_name }} fabric-${{ matrix.os }}-${{ matrix.arch }}-${{ github.ref_name }}*
+          fi

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -33,17 +33,21 @@ jobs:
 
       - name: Build binary on Linux and macOS
         if: matrix.os != 'windows-latest'
+        env:
+          OS: ${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}
+          GOOS: ${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}
+          GOARCH: ${{ matrix.arch }}
         run: |
-          GOOS=${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }} \
-          GOARCH=${{ matrix.arch }} \
-          go build -o fabric-${{ matrix.os }}-${{ matrix.arch }}-${{ github.ref_name }} .
+          go build -o fabric-${OS}-${{ matrix.arch }}-${{ github.ref_name }} .
 
       - name: Build binary on Windows
         if: matrix.os == 'windows-latest'
+        env:
+          OS: windows
+          GOOS: windows
+          GOARCH: ${{ matrix.arch }}
         run: |
-          $env:GOOS = 'windows'
-          $env:GOARCH = '${{ matrix.arch }}'
-          go build -o fabric-${{ matrix.os }}-${{ matrix.arch }}-${{ github.ref_name }} .
+          go build -o fabric-${OS}-${{ matrix.arch }}-${{ github.ref_name }} .
 
       - name: Create DMG for macOS
         if: matrix.os == 'macos-latest'
@@ -64,8 +68,4 @@ jobs:
       - name: Upload release artifact
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
         run: |
-          if [[ "${{ matrix.os }}" == "macos-latest" ]]; then
-            gh release upload ${{ github.ref_name }} fabric-macos-${{ matrix.arch }}-${{ github.ref_name }}.dmg
-          else
-            gh release upload ${{ github.ref_name }} fabric-${{ matrix.os }}-${{ matrix.arch }}-${{ github.ref_name }}*
-          fi
+          gh release upload ${{ github.ref_name }} fabric-*-${{ matrix.arch }}-${{ github.ref_name }}*

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,7 +53,7 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: |
           mkdir dist
-          mv fabric-macos-latest-${{ matrix.arch }}-${{ github.ref_name }} dist/fabric
+          cp fabric-macos-latest-${{ matrix.arch }}-${{ github.ref_name }} dist/fabric
           hdiutil create dist/fabric-${{ matrix.arch }}.dmg -volname "fabric" -srcfolder dist/fabric
           mv dist/fabric-${{ matrix.arch }}.dmg fabric-macos-${{ matrix.arch }}-${{ github.ref_name }}.dmg
 


### PR DESCRIPTION
## What this Pull Request (PR) does
Updates the GitHub Actions workflow to be triggered on tag creation.
On tag creation, it runs the regular builds, but the only difference is a final step to upload the artifacts to GitHub Releases so they are discoverable.

Also manages the Go version in a single go.mod file, rather than across two different files, where the workflow version is easily forgotten. 

Finally updates the binary names to not include the distribution.  ubuntu-latest binaries work on Fedora, so therefore it makes more sense to me to call them `linux` and `darwin`.

## Related issues
Closes #808 

