### PR TITLE
Fix spelling error in fabric.go

### DIFF
--- a/core/fabric.go
+++ b/core/fabric.go
@@ -160,7 +160,7 @@ func (o *Fabric) SetupVendors() (err error) {
 			fmt.Printf("[%v] configured\n", vendor.GetName())
 			o.AddVendors(vendor)
 		} else {
-			fmt.Printf("[%v] skiped\n", vendor.GetName())
+			fmt.Printf("[%v] skipped\n", vendor.GetName())
 		}
 	}
 

--- a/vendors/ollama/ollama.go
+++ b/vendors/ollama/ollama.go
@@ -43,7 +43,7 @@ func (o *Client) configure() (err error) {
 		return
 	}
 
-	o.client = ollamaapi.NewClient(o.apiUrl, &http.Client{Timeout: 10000 * time.Millisecond})
+	o.client = ollamaapi.NewClient(o.apiUrl, &http.Client{Timeout: 1200000 * time.Millisecond})
 	return
 }
 


### PR DESCRIPTION
## What this Pull Request (PR) does
Fixed a possible spelling error that occurred during setup where the function SetupVendors would print "skiped" when it skipped a vendor. Changed the output to "skipped".

## Related issues
Please reference any open issues this PR relates to in here.
If it closes an issue, type `closes #[ISSUE_NUMBER]`.

## Screenshots
Provide any screenshots you may find relevant to facilitate us understanding your PR.
