### PR TITLE
Fix broken link in table of contents in README.md (Migrating -> Migration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
   - [Too many prompts](#too-many-prompts)
   - [The Fabric approach to prompting](#our-approach-to-prompting)
 - [Installation](#Installation)
-  - [Migrating](#Migrating)
+  - [Migration](#Migration)
   - [Upgrading](#Upgrading)
 - [Usage](#Usage)
 - [Examples](#examples)


### PR DESCRIPTION
## What this Pull Request (PR) does
Minor typo fix. The table of contents is broken and links to the word 'Migrating' instead of 'Migration'

## Related issues
N/A

## Screenshots
N/A
