### PR TITLE
fix: correct os.Exit code from -1 to 1 in main.go

### DIFF
--- a/main.go
+++ b/main.go
@@ -11,6 +11,6 @@ func main() {
 	_, err := cli.Cli()
 	if err != nil {
 		fmt.Printf("%s\n", err)
-		os.Exit(-1)
+		os.Exit(1)
 	}
 }


### PR DESCRIPTION
## What this Pull Request (PR) does
Changes the exit code from -1 to 1. 1 means the program terminated due to a generic error

## Related issues
N/A

## Screenshots
N/A
