### PR TITLE
Add dry run

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,7 @@ Application Options:
   -u, --url=              Choose ollama url (default: http://127.0.0.1:11434)
   -o, --output=           Output to file
   -n, --latest=           Number of latest patterns to list (default: 0)
+      --dry-run           Show what would be sent to the model without actually sending it
 
 Help Options:
   -h, --help              Show this help message

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -142,6 +142,13 @@ func Cli() (message string, err error) {
 		}
 	}
 
+	if currentFlags.DryRun {
+		fmt.Println("Dry run: Would send the following request:")
+		fmt.Printf("Chat Request: %+v\n", currentFlags.BuildChatRequest())
+		fmt.Printf("Chat Options: %+v\n", currentFlags.BuildChatOptions())
+		return
+	}
+
 	var chatter *core.Chatter
 	if chatter, err = fabric.GetChatter(currentFlags.Model, currentFlags.Stream); err != nil {
 		return

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -143,10 +143,38 @@ func Cli() (message string, err error) {
 	}
 
 	if currentFlags.DryRun {
-		fmt.Println("Dry run: Would send the following request:")
-		fmt.Printf("Chat Request: %+v\n", currentFlags.BuildChatRequest())
-		fmt.Printf("Chat Options: %+v\n", currentFlags.BuildChatOptions())
-		return
+		var patternContent string
+		var contextContent string
+
+		if currentFlags.Pattern != "" {
+			pattern, patternErr := fabric.Db.Patterns.GetPattern(currentFlags.Pattern)
+			if patternErr != nil {
+				fmt.Printf("Error getting pattern content: %v\n", patternErr)
+				return "", patternErr
+			}
+			patternContent = pattern.Pattern // Assuming the content is stored in the 'Pattern' field
+		}
+
+		if currentFlags.Context != "" {
+			context, contextErr := fabric.Db.Contexts.GetContext(currentFlags.Context)
+			if contextErr != nil {
+				fmt.Printf("Error getting context content: %v\n", contextErr)
+				return "", contextErr
+			}
+			contextContent = context.Content
+		}
+
+		systemMessage := strings.TrimSpace(contextContent) + strings.TrimSpace(patternContent)
+		userMessage := strings.TrimSpace(currentFlags.Message)
+
+		fmt.Println("Dry run: Would send the following request:\n")
+		if systemMessage != "" {
+			fmt.Printf("System:\n%s\n\n", systemMessage)
+		}
+		if userMessage != "" {
+			fmt.Printf("User:\n%s\n", userMessage)
+		}
+		return "", nil
 	}
 
 	var chatter *core.Chatter

--- a/cli/cli.go
+++ b/cli/cli.go
@@ -142,43 +142,8 @@ func Cli() (message string, err error) {
 		}
 	}
 
-	if currentFlags.DryRun {
-		var patternContent string
-		var contextContent string
-
-		if currentFlags.Pattern != "" {
-			pattern, patternErr := fabric.Db.Patterns.GetPattern(currentFlags.Pattern)
-			if patternErr != nil {
-				fmt.Printf("Error getting pattern content: %v\n", patternErr)
-				return "", patternErr
-			}
-			patternContent = pattern.Pattern // Assuming the content is stored in the 'Pattern' field
-		}
-
-		if currentFlags.Context != "" {
-			context, contextErr := fabric.Db.Contexts.GetContext(currentFlags.Context)
-			if contextErr != nil {
-				fmt.Printf("Error getting context content: %v\n", contextErr)
-				return "", contextErr
-			}
-			contextContent = context.Content
-		}
-
-		systemMessage := strings.TrimSpace(contextContent) + strings.TrimSpace(patternContent)
-		userMessage := strings.TrimSpace(currentFlags.Message)
-
-		fmt.Println("Dry run: Would send the following request:\n")
-		if systemMessage != "" {
-			fmt.Printf("System:\n%s\n\n", systemMessage)
-		}
-		if userMessage != "" {
-			fmt.Printf("User:\n%s\n", userMessage)
-		}
-		return "", nil
-	}
-
 	var chatter *core.Chatter
-	if chatter, err = fabric.GetChatter(currentFlags.Model, currentFlags.Stream); err != nil {
+	if chatter, err = fabric.GetChatter(currentFlags.Model, currentFlags.Stream, currentFlags.DryRun); err != nil {
 		return
 	}
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -37,6 +37,7 @@ type Flags struct {
 	YouTube                 string  `short:"y" long:"youtube" description:"YouTube video url to grab transcript, comments from it and send to chat"`
 	YouTubeTranscript       bool    `long:"transcript" description:"Grab transcript from YouTube video and send to chat"`
 	YouTubeComments         bool    `long:"comments" description:"Grab comments from YouTube video and send to chat"`
+	DryRun                  bool    `long:"dry-run" description:"Show what would be sent to the model without actually sending it"`
 }
 
 // Init Initialize flags. returns a Flags struct and an error

--- a/core/chatter.go
+++ b/core/chatter.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"fmt"
+
 	"github.com/danielmiessler/fabric/common"
 	"github.com/danielmiessler/fabric/db"
 	"github.com/danielmiessler/fabric/vendors"
@@ -11,6 +12,7 @@ type Chatter struct {
 	db *db.Db
 
 	Stream bool
+	DryRun bool
 
 	model  string
 	vendor vendors.Vendor

--- a/core/fabric.go
+++ b/core/fabric.go
@@ -59,7 +59,7 @@ func NewFabricBase(db *db.Db) (ret *Fabric) {
 		"Enter the index the name of your default model")
 
 	ret.VendorsAll.AddVendors(openai.NewClient(), azure.NewClient(), ollama.NewClient(), groc.NewClient(),
-		gemini.NewClient(), anthropic.NewClient(), dryrun.NewClient())
+		gemini.NewClient(), anthropic.NewClient())
 
 	return
 }

--- a/core/fabric.go
+++ b/core/fabric.go
@@ -3,20 +3,22 @@ package core
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
 	"github.com/atotto/clipboard"
 	"github.com/danielmiessler/fabric/common"
 	"github.com/danielmiessler/fabric/db"
 	"github.com/danielmiessler/fabric/vendors/anthropic"
 	"github.com/danielmiessler/fabric/vendors/azure"
+	"github.com/danielmiessler/fabric/vendors/dryrun"
 	"github.com/danielmiessler/fabric/vendors/gemini"
 	"github.com/danielmiessler/fabric/vendors/groc"
 	"github.com/danielmiessler/fabric/vendors/ollama"
 	"github.com/danielmiessler/fabric/vendors/openai"
 	"github.com/danielmiessler/fabric/youtube"
 	"github.com/pkg/errors"
-	"os"
-	"strconv"
-	"strings"
 )
 
 const DefaultPatternsGitRepoUrl = "https://github.com/danielmiessler/fabric.git"
@@ -57,7 +59,7 @@ func NewFabricBase(db *db.Db) (ret *Fabric) {
 		"Enter the index the name of your default model")
 
 	ret.VendorsAll.AddVendors(openai.NewClient(), azure.NewClient(), ollama.NewClient(), groc.NewClient(),
-		gemini.NewClient(), anthropic.NewClient())
+		gemini.NewClient(), anthropic.NewClient(), dryrun.NewClient())
 
 	return
 }
@@ -182,13 +184,20 @@ func (o *Fabric) configure() (err error) {
 	return
 }
 
-func (o *Fabric) GetChatter(model string, stream bool) (ret *Chatter, err error) {
+func (o *Fabric) GetChatter(model string, stream bool, dryRun bool) (ret *Chatter, err error) {
 	ret = &Chatter{
 		db:     o.Db,
 		Stream: stream,
+		DryRun: dryRun,
 	}
 
-	if model == "" {
+	if dryRun {
+		ret.vendor = dryrun.NewClient()
+		ret.model = model
+		if ret.model == "" {
+			ret.model = o.DefaultModel.Value
+		}
+	} else if model == "" {
 		ret.vendor = o.FindByName(o.DefaultVendor.Value)
 		ret.model = o.DefaultModel.Value
 	} else {

--- a/core/models.go
+++ b/core/models.go
@@ -16,10 +16,8 @@ type VendorsModels struct {
 }
 
 func (o *VendorsModels) AddVendorModels(vendor string, models []string) {
-	if vendor != "DryRun" {
-		o.Vendors = append(o.Vendors, vendor)
-		o.VendorsModels[vendor] = models
-	}
+	o.Vendors = append(o.Vendors, vendor)
+	o.VendorsModels[vendor] = models
 }
 
 func (o *VendorsModels) GetVendorAndModelByModelIndex(modelIndex int) (vendor string, model string) {

--- a/core/models.go
+++ b/core/models.go
@@ -16,8 +16,10 @@ type VendorsModels struct {
 }
 
 func (o *VendorsModels) AddVendorModels(vendor string, models []string) {
-	o.Vendors = append(o.Vendors, vendor)
-	o.VendorsModels[vendor] = models
+	if vendor != "DryRun" {
+		o.Vendors = append(o.Vendors, vendor)
+		o.VendorsModels[vendor] = models
+	}
 }
 
 func (o *VendorsModels) GetVendorAndModelByModelIndex(modelIndex int) (vendor string, model string) {

--- a/vendors/dryrun/dryrun.go
+++ b/vendors/dryrun/dryrun.go
@@ -2,6 +2,7 @@ package dryrun
 
 import (
 	"bytes"
+	"context"
 	"fmt"
 
 	"github.com/danielmiessler/fabric/common"
@@ -29,10 +30,10 @@ func (c *Client) ListModels() ([]string, error) {
 	return []string{"dry-run-model"}, nil
 }
 
-func (c *Client) SendStream(messages []*common.Message, options *common.ChatOptions, channel chan string) error {
+func (c *Client) SendStream(msgs []*common.Message, opts *common.ChatOptions, channel chan string) error {
 	output := "Dry run: Would send the following request:\n\n"
 
-	for _, msg := range messages {
+	for _, msg := range msgs {
 		switch msg.Role {
 		case "system":
 			output += fmt.Sprintf("System:\n%s\n\n", msg.Content)
@@ -44,21 +45,21 @@ func (c *Client) SendStream(messages []*common.Message, options *common.ChatOpti
 	}
 
 	output += "Options:\n"
-	output += fmt.Sprintf("Model: %s\n", options.Model)
-	output += fmt.Sprintf("Temperature: %f\n", options.Temperature)
-	output += fmt.Sprintf("TopP: %f\n", options.TopP)
-	output += fmt.Sprintf("PresencePenalty: %f\n", options.PresencePenalty)
-	output += fmt.Sprintf("FrequencyPenalty: %f\n", options.FrequencyPenalty)
+	output += fmt.Sprintf("Model: %s\n", opts.Model)
+	output += fmt.Sprintf("Temperature: %f\n", opts.Temperature)
+	output += fmt.Sprintf("TopP: %f\n", opts.TopP)
+	output += fmt.Sprintf("PresencePenalty: %f\n", opts.PresencePenalty)
+	output += fmt.Sprintf("FrequencyPenalty: %f\n", opts.FrequencyPenalty)
 
 	channel <- output
 	close(channel)
 	return nil
 }
 
-func (c *Client) Send(messages []*common.Message, options *common.ChatOptions) (string, error) {
+func (c *Client) Send(ctx context.Context, msgs []*common.Message, opts *common.ChatOptions) (string, error) {
 	fmt.Println("Dry run: Would send the following request:")
 
-	for _, msg := range messages {
+	for _, msg := range msgs {
 		switch msg.Role {
 		case "system":
 			fmt.Printf("System:\n%s\n\n", msg.Content)
@@ -70,11 +71,11 @@ func (c *Client) Send(messages []*common.Message, options *common.ChatOptions) (
 	}
 
 	fmt.Println("Options:")
-	fmt.Printf("Model: %s\n", options.Model)
-	fmt.Printf("Temperature: %f\n", options.Temperature)
-	fmt.Printf("TopP: %f\n", options.TopP)
-	fmt.Printf("PresencePenalty: %f\n", options.PresencePenalty)
-	fmt.Printf("FrequencyPenalty: %f\n", options.FrequencyPenalty)
+	fmt.Printf("Model: %s\n", opts.Model)
+	fmt.Printf("Temperature: %f\n", opts.Temperature)
+	fmt.Printf("TopP: %f\n", opts.TopP)
+	fmt.Printf("PresencePenalty: %f\n", opts.PresencePenalty)
+	fmt.Printf("FrequencyPenalty: %f\n", opts.FrequencyPenalty)
 
 	return "", nil
 }

--- a/vendors/dryrun/dryrun.go
+++ b/vendors/dryrun/dryrun.go
@@ -1,0 +1,88 @@
+package dryrun
+
+import (
+	"bytes"
+	"fmt"
+
+	"github.com/danielmiessler/fabric/common"
+)
+
+type Client struct{}
+
+func NewClient() *Client {
+	return &Client{}
+}
+
+func (c *Client) GetName() string {
+	return "DryRun"
+}
+
+func (c *Client) IsConfigured() bool {
+	return true
+}
+
+func (c *Client) Configure() error {
+	return nil
+}
+
+func (c *Client) ListModels() ([]string, error) {
+	return []string{"dry-run-model"}, nil
+}
+
+func (c *Client) SendStream(messages []*common.Message, options *common.ChatOptions, channel chan string) error {
+	output := "Dry run: Would send the following request:\n\n"
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case "system":
+			output += fmt.Sprintf("System:\n%s\n\n", msg.Content)
+		case "user":
+			output += fmt.Sprintf("User:\n%s\n\n", msg.Content)
+		default:
+			output += fmt.Sprintf("%s:\n%s\n\n", msg.Role, msg.Content)
+		}
+	}
+
+	output += "Options:\n"
+	output += fmt.Sprintf("Model: %s\n", options.Model)
+	output += fmt.Sprintf("Temperature: %f\n", options.Temperature)
+	output += fmt.Sprintf("TopP: %f\n", options.TopP)
+	output += fmt.Sprintf("PresencePenalty: %f\n", options.PresencePenalty)
+	output += fmt.Sprintf("FrequencyPenalty: %f\n", options.FrequencyPenalty)
+
+	channel <- output
+	close(channel)
+	return nil
+}
+
+func (c *Client) Send(messages []*common.Message, options *common.ChatOptions) (string, error) {
+	fmt.Println("Dry run: Would send the following request:")
+
+	for _, msg := range messages {
+		switch msg.Role {
+		case "system":
+			fmt.Printf("System:\n%s\n\n", msg.Content)
+		case "user":
+			fmt.Printf("User:\n%s\n\n", msg.Content)
+		default:
+			fmt.Printf("%s:\n%s\n\n", msg.Role, msg.Content)
+		}
+	}
+
+	fmt.Println("Options:")
+	fmt.Printf("Model: %s\n", options.Model)
+	fmt.Printf("Temperature: %f\n", options.Temperature)
+	fmt.Printf("TopP: %f\n", options.TopP)
+	fmt.Printf("PresencePenalty: %f\n", options.PresencePenalty)
+	fmt.Printf("FrequencyPenalty: %f\n", options.FrequencyPenalty)
+
+	return "", nil
+}
+
+func (c *Client) Setup() error {
+	return nil
+}
+
+func (c *Client) SetupFillEnvFileContent(buffer *bytes.Buffer) {
+	// No environment variables needed for dry run
+}


### PR DESCRIPTION
# Pull Request Description

## Summary
This pull request introduces a new `--dry-run` flag to the CLI application. This flag allows users to see what would be sent to the model without actually sending the request. The changes include updates to the `README.md` for documentation purposes and modifications to the CLI code to implement the dry-run functionality.

## Files Changed
1. **README.md**
   - Added a description for the new `--dry-run` flag under the Application Options section.

2. **cli/cli.go**
   - Implemented the logic for handling the `--dry-run` flag. This includes fetching the pattern and context content (if provided) and displaying the formatted request that would be sent to the model.

3. **cli/flags.go**
   - Added the `DryRun` field to the `Flags` struct to accommodate the new command-line option.

## Code Changes

### README.md
```diff
 Application Options:
   -u, --url=              Choose ollama url (default: http://127.0.0.1:11434)
   -o, --output=           Output to file
   -n, --latest=           Number of latest patterns to list (default: 0)
+      --dry-run           Show what would be sent to the model without actually sending it
```

### cli/cli.go
```diff
 func Cli() (message string, err error) {
 		}
 	}

+	if currentFlags.DryRun {
+		var patternContent string
+		var contextContent string
+
+		if currentFlags.Pattern != "" {
+			pattern, patternErr := fabric.Db.Patterns.GetPattern(currentFlags.Pattern)
+			if patternErr != nil {
+				fmt.Printf("Error getting pattern content: %v\n", patternErr)
+				return "", patternErr
+			}
+			patternContent = pattern.Pattern // Assuming the content is stored in the 'Pattern' field
+		}
+
+		if currentFlags.Context != "" {
+			context, contextErr := fabric.Db.Contexts.GetContext(currentFlags.Context)
+			if contextErr != nil {
+				fmt.Printf("Error getting context content: %v\n", contextErr)
+				return "", contextErr
+			}
+			contextContent = context.Content
+		}
+
+		systemMessage := strings.TrimSpace(contextContent) + strings.TrimSpace(patternContent)
+		userMessage := strings.TrimSpace(currentFlags.Message)
+
+		fmt.Println("Dry run: Would send the following request:\n")
+		if systemMessage != "" {
+			fmt.Printf("System:\n%s\n\n", systemMessage)
+		}
+		if userMessage != "" {
+			fmt.Printf("User:\n%s\n", userMessage)
+		}
+		return "", nil
+	}
```

### cli/flags.go
```diff
 type Flags struct {
 	YouTube                 string  `short:"y" long:"youtube" description:"YouTube video url to grab transcript, comments from it and send to chat"`
 	YouTubeTranscript       bool    `long:"transcript" description:"Grab transcript from YouTube video and send to chat"`
 	YouTubeComments         bool    `long:"comments" description:"Grab comments from YouTube video and send to chat"`
+	DryRun                  bool    `long:"dry-run" description:"Show what would be sent to the model without actually sending it"`
 }
```

## Reason for Changes
The `--dry-run` flag is introduced to provide users with a way to preview the request that would be sent to the model. This can be useful for debugging and ensuring that the correct data is being sent without making an actual request.

## Impact of Changes
- **Functionality**: Adds a new feature allowing users to perform a dry run of their request.
- **Usability**: Improves the user experience by providing a way to verify requests before sending them.
- **Codebase**: Introduces additional conditional logic to handle the `--dry-run` flag.

## Test Plan
- Manually test the `--dry-run` flag with various combinations of patterns, contexts, and messages to ensure the correct output is displayed.
- Verify that the application behaves as expected when the `--dry-run` flag is not used.

## Additional Notes
- Ensure that any existing automated tests that may interact with the CLI are updated to account for the new `--dry-run` functionality.
- Consider adding automated tests specifically for the `--dry-run` feature in future updates.