### PR TITLE
update: add  env variable info for Apple Silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,9 +115,18 @@ fabric --setup
 
 If everything works you are good to go, but you may need to set some environment variables in your `~/.bashrc` or `~/.zshrc` file. Here is an example of what you can add:
 
+For Intel based macs
 ```bash
 # Golang environment variables
 export GOROOT=/usr/local/go
+export GOPATH=$HOME/go
+export PATH=$GOPATH/bin:$GOROOT/bin:$HOME/.local/bin:$PATH:
+```
+
+for Apple Silicon based macs
+```bash
+# Golang environment variables
+export GOROOT=/opt/homebrew/bin/go
 export GOPATH=$HOME/go
 export PATH=$GOPATH/bin:$GOROOT/bin:$HOME/.local/bin:$PATH:
 ```


### PR DESCRIPTION
## What this Pull Request (PR) does
-Updated the readme with env variables for Apple Silicon based mac as the path for Brew installed apps is different there.

The path on Apple Silicon based macs for brew installed go is:
`opt/homebrew/bin/go`
On Intel based macs it will be:
`/usr/local/go`

This is just a small proposal that clears it up.
