### PR TITLE
Readme: move fabric setup after environment setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,16 +114,13 @@ To install Fabric, [make sure Go is installed](https://go.dev/doc/install), and 
 ```bash
 # Install Fabric directly from the repo
 go install github.com/danielmiessler/fabric@latest
-
-# Run the setup to set up your directories and keys
-fabric --setup
 ```
 
 ### Environment Variables
 
-If everything works you are good to go, but you may need to set some environment variables in your `~/.bashrc` or `~/.zshrc` file. Here is an example of what you can add:
+You may need to set some environment variables in your `~/.bashrc` on linux or `~/.zshrc` file on mac to be able to run the `fabric` command. Here is an example of what you can add:
 
-For Intel based macs
+For Intel based macs or linux
 ```bash
 # Golang environment variables
 export GOROOT=/usr/local/go
@@ -140,6 +137,15 @@ export GOROOT=/opt/homebrew/bin/go
 export GOPATH=$HOME/go
 export PATH=$GOPATH/bin:$GOROOT/bin:$HOME/.local/bin:$PATH:
 ```
+
+### Setup
+Now run the following command
+```bash
+# Run the setup to set up your directories and keys
+fabric --setup
+```
+If everything works you are good to go.
+
 
 ### Migration
 


### PR DESCRIPTION
## What this Pull Request (PR) does
Proposal to update Readme file for a smoother setup experience, especially for users who use Golang for the first time.

Why: According to current Readme users might attempt to call `fabric --setup` before they have added the Golang environment variables.

## Related issues
https://github.com/danielmiessler/fabric/issues/942

## Screenshots

