### PR TITLE
feat: remove cli list label and indentation

### DIFF
--- a/db/storage.go
+++ b/db/storage.go
@@ -3,10 +3,11 @@ package db
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/samber/lo"
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/samber/lo"
 )
 
 type Storage struct {
@@ -69,9 +70,8 @@ func (o *Storage) ListNames() (err error) {
 		return
 	}
 
-	fmt.Printf("\n%v:\n", o.Label)
 	for _, item := range names {
-		fmt.Printf("\t%s\n", item)
+		fmt.Printf("%s\n", item)
 	}
 	return
 }


### PR DESCRIPTION
Trims the formatting on fabric -l, making it easier to combine with other CLI tools like fzf

## Before
<img width="450" alt="SCR-20240921-gpou" src="https://github.com/user-attachments/assets/e5f6fe4d-6d79-4472-8912-05acdf3247f4">

## After
<img width="286" alt="SCR-20240921-gpyb" src="https://github.com/user-attachments/assets/a1e3b98e-c296-4dd0-a582-45587fcc2f48">

## With gum (filtering CLI)
![SCR-20240921-gqoi](https://github.com/user-attachments/assets/1f01d9e9-ad67-4d89-9daa-6dbf2af2884c)

This is a breaking change from the previous functionality. I also think we could combine this with a "raw" flag (ex: `fabric -l --raw`).

Let me know what you think, thanks!