### PR TITLE
Fix GOROOT path for Apple Silicon Macs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,9 +137,9 @@ export PATH=$GOPATH/bin:$GOROOT/bin:$HOME/.local/bin:$PATH
 for Apple Silicon based macs
 ```bash
 # Golang environment variables
-export GOROOT=/opt/homebrew/bin/go
+export GOROOT=$(brew --prefix go)/libexec
 export GOPATH=$HOME/go
-export PATH=$GOPATH/bin:$GOROOT/bin:$HOME/.local/bin:$PATH:
+export PATH=$GOPATH/bin:$GOROOT/bin:$HOME/.local/bin:$PATH
 ```
 
 ### Setup


### PR DESCRIPTION
This PR addresses an issue in the setup instructions for Apple Silicon Macs. The previous configuration for GOROOT pointed to '/opt/homebrew/bin/go', which resulted in an error: 'go: cannot find GOROOT directory'. 

By dynamically determining the correct GOROOT path using Homebrew's installation path, this fix ensures compatibility with M1/M2 Macs. These changes resolve the issue for users following the README on Apple Silicon Macs.