### PR TITLE
Add rudimentary support for perplexity.ai API

### DIFF
--- a/core/plugin_registry.go
+++ b/core/plugin_registry.go
@@ -19,6 +19,7 @@ import (
 	"github.com/danielmiessler/fabric/plugins/ai/ollama"
 	"github.com/danielmiessler/fabric/plugins/ai/openai"
 	"github.com/danielmiessler/fabric/plugins/ai/openrouter"
+	"github.com/danielmiessler/fabric/plugins/ai/perplexity"
 	"github.com/danielmiessler/fabric/plugins/ai/siliconcloud"
 	"github.com/danielmiessler/fabric/plugins/db/fsdb"
 	"github.com/danielmiessler/fabric/plugins/tools/jina"
@@ -40,7 +41,7 @@ func NewPluginRegistry(db *fsdb.Db) (ret *PluginRegistry) {
 	ret.Defaults = tools.NeeDefaults(ret.VendorManager.GetModels)
 
 	ret.VendorsAll.AddVendors(openai.NewClient(), ollama.NewClient(), azure.NewClient(), groq.NewClient(),
-		gemini.NewClient(), anthropic.NewClient(), siliconcloud.NewClient(), openrouter.NewClient(), mistral.NewClient())
+		gemini.NewClient(), anthropic.NewClient(), siliconcloud.NewClient(), openrouter.NewClient(), mistral.NewClient(), perplexity.NewClient())
 	_ = ret.Configure()
 
 	return

--- a/plugins/ai/perplexity/perplexity.go
+++ b/plugins/ai/perplexity/perplexity.go
@@ -7,7 +7,6 @@ import (
 func NewClient() (ret *Client) {
 	ret = &Client{}
 	ret.Client = openai.NewClientCompatible("Perplexity", "https://api.perplexity.ai", nil)
-	ret.Client.ApiBaseURL.Value = "https://api.perplexity.ai"
 	
 	return
 }
@@ -18,6 +17,7 @@ type Client struct {
 
 // The endpoint needed to list model from perplexity doesn't exist, so we 
 // will return a list of models that were available at the time of writing.
+// TODO use models config like it is done in Azure Vendor
 func (o *Client) ListModels() (ret []string, err error) {
 	ret = []string{"llama-3.1-sonar-small-128k-online", "llama-3.1-sonar-large-128k-online", "llama-3.1-sonar-huge-128k-online", "llama-3.1-sonar-small-128k-chat", "llama-3.1-sonar-large-128k-chat", "llama-3.1-8b-instruct", "llama-3.1-70b-instruct"}
 	return

--- a/plugins/ai/perplexity/perplexity.go
+++ b/plugins/ai/perplexity/perplexity.go
@@ -1,0 +1,25 @@
+package perplexity
+
+import (
+	"github.com/danielmiessler/fabric/plugins/ai/openai"
+)
+
+func NewClient() (ret *Client) {
+	ret = &Client{}
+	ret.Client = openai.NewClientCompatible("Perplexity", "https://api.perplexity.ai", nil)
+	ret.Client.ApiBaseURL.Value = "https://api.perplexity.ai"
+	
+	return
+}
+
+type Client struct {
+	*openai.Client
+}
+
+// The endpoint needed to list model from perplexity doesn't exist, so we 
+// will return a list of models that were available at the time of writing.
+func (o *Client) ListModels() (ret []string, err error) {
+	ret = []string{"llama-3.1-sonar-small-128k-online", "llama-3.1-sonar-large-128k-online", "llama-3.1-sonar-huge-128k-online", "llama-3.1-sonar-small-128k-chat", "llama-3.1-sonar-large-128k-chat", "llama-3.1-8b-instruct", "llama-3.1-70b-instruct"}
+	return
+}
+


### PR DESCRIPTION
## What this Pull Request (PR) does
Adds rudimentary support for perplexity.ai API.

Since perplexity doesn't support the endpoint to list the available models, the list had to be hard-coded for now.

To enable perplexity support, add the following to your Fabric config file:
`PERPLEXITY_API_KEY=pplx-xxxxx`

## Related issues
#1078 

## Screenshots
N/A