### PR TITLE
:sparkles: Added unaliasing to pattern setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,6 +221,9 @@ for pattern_file in ~/.config/fabric/patterns/*; do
     # Get the base name of the file (i.e., remove the directory path)
     pattern_name=$(basename "$pattern_file")
 
+    # Unalias any existing alias with the same name
+    unalias "$pattern_name" 2>/dev/null
+
     # Define a function dynamically for each pattern
     eval "
     $pattern_name() {


### PR DESCRIPTION
In the process of setting up patterns, we've added a step to unalias any existing alias with the same name. This ensures that our dynamically defined functions won't conflict with any pre-existing aliases.

## What this Pull Request (PR) does
During the setup of fabric I added the obsidian vault bits and received this error after sourcing my `~/.zshrc`

 ```bash
 (eval):2: defining function based on alias `agility_story'
    (eval):2: parse error near `()'
    (eval):2: defining function based on alias `ai'
    (eval):2: parse error near `()'
    (eval):2: defining function based on alias `analyze_answers'
    (eval):2: parse error near `()'
    (eval):2: defining function based on alias `analyze_cfp_submission'
    (eval):2: parse error near `()'
    (eval):2: defining function based on alias `analyze_claims'
    (eval):2: parse error near `()'
    (eval):2: defining function based on alias `analyze_comments'
    (eval):2: parse error near `()'
    (eval):2: defining function based on alias `analyze_debate'
.... cut for brevity
```

The unalias "`$pattern_name" 2>/dev/null` command removes any existing alias with the same name as the function you're about to define. The `2>/dev/null` part suppresses any error messages if the alias doesn't exist, ensuring the script runs smoothly.


## Related issues
n/a

## Screenshots
After sourcing with initial command:
![--llan~projectsfabric 2024-11-08 at 11 25 54 AM](https://github.com/user-attachments/assets/68488f54-62b8-423e-a4df-5072b50193f9)

After corrected script:
![--llan~projectsfabric 2024-11-08 at 11 27 24 AM](https://github.com/user-attachments/assets/ab8148fb-be19-45b5-8d11-b392056b0505)