### PR TITLE
fix: fix default gin

### DIFF
--- a/restapi/serve.go
+++ b/restapi/serve.go
@@ -6,7 +6,7 @@ import (
 )
 
 func Serve(registry *core.PluginRegistry, address string) (err error) {
-	r := gin.Default()
+	r := gin.New()
 
 	// Middleware
 	r.Use(gin.Logger())


### PR DESCRIPTION
## What this Pull Request (PR) does
Please briefly describe what this PR does.
gin.Default() to gin.New() because `gin.Default()` already includes the Logger and Recover middleware. 
```
r.Use(gin.Logger())
r.Use(gin.Recovery())
```
## Related issues
Please reference any open issues this PR relates to in here.
If it closes an issue, type `closes #[ISSUE_NUMBER]`.

## Screenshots
Provide any screenshots you may find relevant to facilitate us understanding your PR.
