### PR TITLE
feat: add file-based pattern support

### DIFF
--- a/plugins/db/fsdb/patterns.go
+++ b/plugins/db/fsdb/patterns.go
@@ -66,3 +66,34 @@ type Pattern struct {
 	Description string
 	Pattern     string
 }
+
+// GetFromFile reads a pattern from a file path and applies variables if provided
+// this provides an ad-hoc way to use a pattern
+func (o *PatternsEntity) GetFromFile(pathStr string, variables map[string]string) (ret *Pattern, err error) {
+  // Handle home directory expansion
+  if strings.HasPrefix(pathStr, "~/") {
+			var homedir string
+			if homedir, err = os.UserHomeDir(); err != nil {
+					return nil, fmt.Errorf("could not get home directory: %v", err)
+			}
+			pathStr = filepath.Join(homedir, pathStr[2:])
+	}
+
+
+	var content []byte
+	if content, err = os.ReadFile(pathStr); err != nil {
+			return nil, fmt.Errorf("could not read pattern file %s: %v", pathStr, err)
+	}
+
+	ret = &Pattern{
+			Name:    pathStr,
+			Pattern: string(content),
+	}
+
+	if variables != nil && len(variables) > 0 {
+			for variableName, value := range variables {
+					ret.Pattern = strings.ReplaceAll(ret.Pattern, variableName, value)
+			}
+	}
+	return
+}


### PR DESCRIPTION
## What this Pull Request (PR) does
# Add file-based pattern support

This PR adds the ability to load patterns directly from files using explicit path prefixes, making it easier to test and iterate on patterns without requiring installation into the fabric config structure.

## Why
Currently, to test a pattern it needs to be instantiated in the fabric config file structure. This change allows for quicker testing and iteration of patterns directly from files.

## What
- Adds support for loading patterns from files using explicit path prefixes
- Maintains full backwards compatibility with named patterns
- Handles common path formats:
  - Relative paths (`./pattern.txt`, `../pattern.txt`)
  - Home directory (`~/patterns/test.txt`)
  - Absolute paths (`/path/to/pattern.txt`)

## How
Use explicit path prefixes to distinguish file paths from pattern names:
```bash
# From files
fabric --pattern ./draft-pattern.txt
fabric --pattern ~/patterns/my-pattern.txt
fabric --pattern ../../shared-patterns/test.txt

# Existing pattern behavior remains unchanged
fabric --pattern patternname


