### PR TITLE
Update docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use official golang image as builder
-FROM golang:1.22.5-alpine AS builder
+FROM golang:1.23.3-alpine AS builder
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## What this Pull Request (PR) does

Updates the docker image to `golang:1.23.3-alpine`. 

This change fixes an issue when trying to use fabric via docker. Prior to this change if you'd run `docker-compose up` it would fail with the following error: 

```
> [fabric-api builder 4/6] RUN go mod download:
0.131 go: go.mod requires go >= 1.22.8 (running go 1.22.5; GOTOOLCHAIN=local)

failed to solve: process "/bin/sh -c go mod download" did not complete successfully: exit code: 1
```
## Related issues
None

## Screenshots
None