### PR TITLE
refactor: unify pattern loading and variable handling

### DIFF
--- a/core/chatter.go
+++ b/core/chatter.go
@@ -72,6 +72,7 @@ func (o *Chatter) Send(request *common.ChatRequest, opts *common.ChatOptions) (s
 	return
 }
 
+
 func (o *Chatter) BuildSession(request *common.ChatRequest, raw bool) (session *fsdb.Session, err error) {
 	if request.SessionName != "" {
 		var sess *fsdb.Session
@@ -99,32 +100,13 @@ func (o *Chatter) BuildSession(request *common.ChatRequest, raw bool) (session *
 	}
 
 
-
 	var patternContent string
-	var pattern *fsdb.Pattern
 	if request.PatternName != "" {
-			pathStr := request.PatternName
-			// First determine if this looks like a file path at all
-			isFilePath := strings.HasPrefix(pathStr, "\\") || 
-										strings.HasPrefix(pathStr, "/") ||
-										strings.HasPrefix(pathStr, "~") ||
-										strings.HasPrefix(pathStr, ".")
-			if isFilePath {
-				// Use the new file-based pattern method
-				if pattern, err = o.db.Patterns.GetFromFile(pathStr, request.PatternVariables); err != nil {
-						err = fmt.Errorf("could not read pattern file %s: %v", pathStr, err)
-						return
-				}
-			} else {
-					// Existing database lookup
-					if pattern, err = o.db.Patterns.GetApplyVariables(request.PatternName, request.PatternVariables); err != nil {
-							err = fmt.Errorf("could not find pattern %s: %v", request.PatternName, err)
-							return
-					}
+			pattern, err := o.db.Patterns.GetApplyVariables(request.PatternName, request.PatternVariables)
+			if err != nil {
+					return nil, fmt.Errorf("could not get pattern %s: %v", request.PatternName, err)
 			}
-			if pattern.Pattern != "" {
-					patternContent = pattern.Pattern
-			}
+			patternContent = pattern.Pattern
 	}
 
 	

--- a/plugins/db/fsdb/patterns.go
+++ b/plugins/db/fsdb/patterns.go
@@ -13,7 +13,49 @@ type PatternsEntity struct {
 	UniquePatternsFilePath string
 }
 
-func (o *PatternsEntity) Get(name string) (ret *Pattern, err error) {
+// Pattern represents a single pattern with its metadata
+type Pattern struct {
+	Name        string
+	Description string
+	Pattern     string
+}
+
+// main entry point for getting patterns from any source
+func (o *PatternsEntity) GetApplyVariables(source string, variables map[string]string) (*Pattern, error) {
+    var pattern *Pattern
+    var err error
+
+    // Determine if this is a file path
+    isFilePath := strings.HasPrefix(source, "\\") ||
+                  strings.HasPrefix(source, "/") ||
+                  strings.HasPrefix(source, "~") ||
+                  strings.HasPrefix(source, ".")
+    
+    if isFilePath {
+        pattern, err = o.getFromFile(source)
+    } else {
+        pattern, err = o.getFromDB(source)
+    }
+
+    if err != nil {
+        return nil, err
+    }
+
+    return o.applyVariables(pattern, variables), nil
+}
+
+// handles all variable substitution
+func (o *PatternsEntity) applyVariables(pattern *Pattern, variables map[string]string) *Pattern {
+	if variables != nil && len(variables) > 0 {
+			for variableName, value := range variables {
+					pattern.Pattern = strings.ReplaceAll(pattern.Pattern, variableName, value)
+			}
+	}
+	return pattern
+}
+
+// retrieves a pattern from the database by name
+func (o *PatternsEntity) getFromDB(name string) (ret *Pattern, err error) {
 	patternPath := filepath.Join(o.Dir, name, o.SystemPatternFile)
 
 	var pattern []byte
@@ -25,21 +67,6 @@ func (o *PatternsEntity) Get(name string) (ret *Pattern, err error) {
 	ret = &Pattern{
 		Name:    name,
 		Pattern: patternStr,
-	}
-	return
-}
-
-// GetApplyVariables finds a pattern by name and returns the pattern as an entry or an error
-func (o *PatternsEntity) GetApplyVariables(name string, variables map[string]string) (ret *Pattern, err error) {
-
-	if ret, err = o.Get(name); err != nil {
-		return
-	}
-
-	if variables != nil && len(variables) > 0 {
-		for variableName, value := range variables {
-			ret.Pattern = strings.ReplaceAll(ret.Pattern, variableName, value)
-		}
 	}
 	return
 }
@@ -61,39 +88,30 @@ func (o *PatternsEntity) PrintLatestPatterns(latestNumber int) (err error) {
 	return
 }
 
-type Pattern struct {
-	Name        string
-	Description string
-	Pattern     string
-}
-
-// GetFromFile reads a pattern from a file path and applies variables if provided
-// this provides an ad-hoc way to use a pattern
-func (o *PatternsEntity) GetFromFile(pathStr string, variables map[string]string) (ret *Pattern, err error) {
-  // Handle home directory expansion
-  if strings.HasPrefix(pathStr, "~/") {
-			var homedir string
-			if homedir, err = os.UserHomeDir(); err != nil {
+// reads a pattern from a file path and returns it
+func (o *PatternsEntity) getFromFile(pathStr string) (*Pattern, error) {
+	// Handle home directory expansion
+	if strings.HasPrefix(pathStr, "~/") {
+			homedir, err := os.UserHomeDir()
+			if err != nil {
 					return nil, fmt.Errorf("could not get home directory: %v", err)
 			}
 			pathStr = filepath.Join(homedir, pathStr[2:])
 	}
 
-
-	var content []byte
-	if content, err = os.ReadFile(pathStr); err != nil {
+	content, err := os.ReadFile(pathStr)
+	if err != nil {
 			return nil, fmt.Errorf("could not read pattern file %s: %v", pathStr, err)
 	}
 
-	ret = &Pattern{
+	return &Pattern{
 			Name:    pathStr,
 			Pattern: string(content),
-	}
+	}, nil
+}
 
-	if variables != nil && len(variables) > 0 {
-			for variableName, value := range variables {
-					ret.Pattern = strings.ReplaceAll(ret.Pattern, variableName, value)
-			}
-	}
-	return
+// Get required for Storage interface
+func (o *PatternsEntity) Get(name string) (*Pattern, error) {
+	// Use GetPattern with no variables
+	return o.GetApplyVariables(name, nil)
 }


### PR DESCRIPTION
- Stronger separation of concerns between chatter.go and patterns.go
- Consolidate pattern loading logic into GetPattern method
- Support both file and database patterns through single interface
- Maintain API compatibility with Storage interface
- Handle variable substitution in one place
- Keep backward compatibility for REST API through Get method

The changes enable cleaner pattern handling while maintaining existing interfaces and adding file-based pattern support.
