### PR TITLE
fix: provide default message content to avoid nil pointer dereference

### DIFF
--- a/core/chatter.go
+++ b/core/chatter.go
@@ -101,6 +101,7 @@ func (o *Chatter) BuildSession(request *common.ChatRequest, raw bool) (session *
 		contextContent = ctx.Content
 	}
 
+	var messageContent string
 	// Process any template variables in the message content (user input)
 	// Double curly braces {{variable}} indicate template substitution
 	// should occur, whether in patterns or direct input
@@ -109,13 +110,13 @@ func (o *Chatter) BuildSession(request *common.ChatRequest, raw bool) (session *
 		if err != nil {
 			return nil, err
 		}
+		messageContent = request.Message.Content
 	}
 
 	var patternContent string
 	if request.PatternName != "" {
-		pattern, err := o.db.Patterns.GetApplyVariables(request.PatternName, request.PatternVariables, request.Message.Content)
+		pattern, err := o.db.Patterns.GetApplyVariables(request.PatternName, request.PatternVariables, messageContent)
 		// pattrn will now contain user input, and all variables will be resolved, or errored
-
 		if err != nil {
 			return nil, fmt.Errorf("could not get pattern %s: %v", request.PatternName, err)
 		}


### PR DESCRIPTION
In the current version, if user is executing pattern without input, eg `fabric --pattern summarize_git_diff`, the program will panic with this error:
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x10 pc=0xe22330]

goroutine 1 [running]:
github.com/danielmiessler/fabric/core.(*Chatter).BuildSession(0xc0004e43c0, 0xc00051e060, 0x0)
        /home/gs/go/pkg/mod/github.com/danielmiessler/fabric@v1.4.111/core/chatter.go:116 +0x3b0
github.com/danielmiessler/fabric/core.(*Chatter).Send(0xc0004e43c0, 0xc00051e060, 0xc0003f00a0)
        /home/gs/go/pkg/mod/github.com/danielmiessler/fabric@v1.4.111/core/chatter.go:30 +0x69
github.com/danielmiessler/fabric/cli.Cli({0x129b59d, 0x8})
        /home/gs/go/pkg/mod/github.com/danielmiessler/fabric@v1.4.111/cli/cli.go:230 +0x7fc
main.main()
        /home/gs/go/pkg/mod/github.com/danielmiessler/fabric@v1.4.111/main.go:12 +0x25

```
This PR address that issue by giving an empty input, or `messageContent` if `request.Message` is nil.