### PR TITLE
Add --input-has-vars flag to control variable substitution in input

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -55,6 +55,7 @@ type Flags struct {
 	PrintContext       string            `long:"printcontext" description:"Print context"`
 	PrintSession       string            `long:"printsession" description:"Print session"`
 	HtmlReadability    bool              `long:"readability" description:"Convert HTML input into a clean, readable view"`
+	InputHasVars 	 		 bool 			 		   `long:"input-has-vars" description:"Apply variables to user input"`
 	DryRun             bool              `long:"dry-run" description:"Show what would be sent to the model without actually sending it"`
 	Serve              bool              `long:"serve" description:"Serve the Fabric Rest API"`
 	ServeAddress       string            `long:"address" description:"The address to bind the REST API" default:":8080"`
@@ -126,6 +127,7 @@ func (o *Flags) BuildChatRequest(Meta string) (ret *common.ChatRequest, err erro
 		SessionName:      o.Session,
 		PatternName:      o.Pattern,
 		PatternVariables: o.PatternVariables,
+		InputHasVars:     o.InputHasVars,
 		Meta:             Meta,
 	}
 

--- a/common/domain.go
+++ b/common/domain.go
@@ -12,6 +12,7 @@ type ChatRequest struct {
 	Message          *goopenai.ChatCompletionMessage
 	Language         string
 	Meta             string
+	InputHasVars     bool
 }
 
 type ChatOptions struct {

--- a/core/chatter.go
+++ b/core/chatter.go
@@ -121,9 +121,11 @@ func (o *Chatter) BuildSession(request *common.ChatRequest, raw bool) (session *
 	}
 
 	// Now we know request.Message is not nil, process template variables
-	request.Message.Content, err = template.ApplyTemplate(request.Message.Content, request.PatternVariables, "")
-	if err != nil {
-		return nil, err
+	if request.InputHasVars {
+		request.Message.Content, err = template.ApplyTemplate(request.Message.Content, request.PatternVariables, "")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	var patternContent string


### PR DESCRIPTION
Make template variable substitution in input opt-in via --input-has-vars flag

## Problem
When users paste Ansible, Jekyll, or other content containing {{variable}} syntax into fabric, 
our template processor attempts to resolve these variables, leading to unwanted variable 
substitution and errors about missing variables.

## Solution
- Added new --input-has-vars flag
- Template variable substitution in user input only occurs when flag is set
- All other template processing (patterns, etc.) remains unchanged
- Preserves literal curly braces by default

## Testing
```bash
# Without flag - preserves template syntax
echo "Hello my name is {{name}}" | ./fabric -v=name:Matt
> Hello! It looks like there might have been a small error...

# With flag - performs substitution
echo "Hello my name is {{name}}" | ./fabric -v=name:Matt --input-has-vars
> Hello Matt! How can I assist you today?

Relates to : 
https://github.com/danielmiessler/fabric/issues/1184
https://github.com/danielmiessler/fabric/issues/1171