### PR TITLE
bug: Using patterns, fabric needlessly scans input for template vars

### DIFF
--- a/core/chatter.go
+++ b/core/chatter.go
@@ -130,8 +130,12 @@ func (o *Chatter) BuildSession(request *common.ChatRequest, raw bool) (session *
 
 	var patternContent string
 	if request.PatternName != "" {
-		pattern, err := o.db.Patterns.GetApplyVariables(request.PatternName, request.PatternVariables, request.Message.Content)
-		// pattrn will now contain user input, and all variables will be resolved, or errored
+		contentToPass := ""
+		if request.InputHasVars {
+			contentToPass = request.Message.Content
+		}
+		pattern, err := o.db.Patterns.GetApplyVariables(request.PatternName, request.PatternVariables, contentToPass)
+		// pattern will now contain user input, and all variables will be resolved, or errored
 
 		if err != nil {
 			return nil, fmt.Errorf("could not get pattern %s: %v", request.PatternName, err)

--- a/plugins/db/fsdb/patterns.go
+++ b/plugins/db/fsdb/patterns.go
@@ -68,7 +68,7 @@ func (o *PatternsEntity) applyVariables(
 	}
 
 	var result string
-	if result, err = template.ApplyTemplate(pattern.Pattern, variables, input); err != nil {
+	if result, err = template.ApplyTemplate(pattern.Pattern, variables, ""); err != nil {
 		return
 	}
 	pattern.Pattern = result

--- a/plugins/db/fsdb/patterns.go
+++ b/plugins/db/fsdb/patterns.go
@@ -68,7 +68,7 @@ func (o *PatternsEntity) applyVariables(
 	}
 
 	var result string
-	if result, err = template.ApplyTemplate(pattern.Pattern, variables, ""); err != nil {
+	if result, err = template.ApplyTemplate(pattern.Pattern, variables, input); err != nil {
 		return
 	}
 	pattern.Pattern = result


### PR DESCRIPTION
## What this Pull Request (PR) does

Fix a minor bug related to https://github.com/danielmiessler/fabric/pull/1189

## Related issues

#1171 
#1184 

## Result

Using the simplest pattern (`ai`):

```text
$ echo 'My name is {{ name }}' | fabric -p ai   
could not get pattern ai: missing required variable:  name
```

And after the fix:

```text
$ echo 'My name is {{ name }}' | fabric -p ai  
- Your name is a core part of your identity.
- It can influence personal and social interactions significantly.
- Names often carry cultural, familial, or historical significance.
- They can shape perceptions and first impressions in various contexts.
- Understanding your name's meaning can offer personal insights.
```

And variable substitution:

```text
$ echo 'My name is {{ name }}' -vname=Kayvan --input-has-vars | fabric -p ai   
- Hello, Kayvan! How can I assist you today?  
- Do you have any specific questions or topics in mind?  
- Feel free to share any details or context for assistance.  
- I'm here to help with insights or advice you need.  
- Let's explore solutions or ideas tailored to your interests.
```
