### PR TITLE
Fix: Mask input token to prevent var substitution in patterns

### DIFF
--- a/plugins/db/fsdb/patterns.go
+++ b/plugins/db/fsdb/patterns.go
@@ -10,6 +10,8 @@ import (
 	"github.com/danielmiessler/fabric/plugins/template"
 )
 
+const inputSentinel = "__FABRIC_INPUT_SENTINEL_TOKEN__"
+
 type PatternsEntity struct {
 	*StorageEntity
 	SystemPatternFile      string
@@ -59,19 +61,29 @@ func (o *PatternsEntity) GetApplyVariables(
 func (o *PatternsEntity) applyVariables(
 	pattern *Pattern, variables map[string]string, input string) (err error) {
 
-	// If {{input}} isn't in pattern, append it on new line
+	// Ensure pattern has an {{input}} placeholder
+	// If not present, append it on a new line
 	if !strings.Contains(pattern.Pattern, "{{input}}") {
-		if !strings.HasSuffix(pattern.Pattern, "\n") {
-			pattern.Pattern += "\n"
-		}
-		pattern.Pattern += "{{input}}"
+			if !strings.HasSuffix(pattern.Pattern, "\n") {
+					pattern.Pattern += "\n"
+			}
+			pattern.Pattern += "{{input}}"
 	}
 
-	var result string
-	if result, err = template.ApplyTemplate(pattern.Pattern, variables, input); err != nil {
-		return
+	// Temporarily replace {{input}} with a sentinel token to protect it
+	// from recursive variable resolution
+	withSentinel := strings.ReplaceAll(pattern.Pattern, "{{input}}", inputSentinel)
+
+	// Process all other template variables in the pattern
+	// At this point, our sentinel ensures {{input}} won't be affected
+	var processed string
+	if processed, err = template.ApplyTemplate(withSentinel, variables, ""); err != nil {
+			return
 	}
-	pattern.Pattern = result
+
+	// Finally, replace our sentinel with the actual user input
+	// The input has already been processed for variables if InputHasVars was true
+	pattern.Pattern = strings.ReplaceAll(processed, inputSentinel, input)
 	return
 }
 


### PR DESCRIPTION
Fix recursive variable resolution of {{input}} in patterns

This PR fixes an issue where the recursive template variable resolution system would process {{input}} placeholders prematurely during pattern processing.

The fix:
- Introduces a sentinel token approach to protect {{input}} during variable resolution
- Temporarily replaces all {{input}} occurrences with a unique sentinel string
- Processes all other template variables normally
- Restores the user input in place of each sentinel at the end

This ensures that:
1. Pattern variables are fully resolved
2. All {{input}} placements are preserved
3. User input is inserted at each {{input}} location
4. No unintended recursive processing occurs

The change is contained to the pattern processing logic and maintains compatibility with the `--input-has-vars` flag behavior introduced in #1157.
