### PR TITLE
Fix: Issue with the custom message and added example config file.

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,68 @@
+# YAML Configuration Support
+
+## Overview
+Fabric now supports YAML configuration files for commonly used options. This allows users to persist settings and share configurations across multiple runs.
+
+## Usage
+Use the `--config` flag to specify a YAML configuration file:
+```bash
+fabric --config ~/.config/fabric/config.yaml "Tell me about APIs"
+```
+
+## Configuration Precedence
+1. CLI flags (highest priority)
+2. YAML config values
+3. Default values (lowest priority)
+
+## Supported Configuration Options
+```yaml
+# Model selection
+model: gpt-4
+modelContextLength: 4096
+
+# Model parameters
+temperature: 0.7
+topp: 0.9
+presencepenalty: 0.0
+frequencypenalty: 0.0
+seed: 42
+
+# Pattern selection
+pattern: analyze  # Use pattern name or filename
+
+# Feature flags
+stream: true
+raw: false
+```
+
+## Rules and Behavior
+- Only long flag names are supported in YAML (e.g., `temperature` not `-t`)
+- CLI flags always override YAML values
+- Unknown YAML declarations are ignored
+- If a declaration appears multiple times in YAML, the last one wins
+- The order of YAML declarations doesn't matter
+
+## Type Conversions
+The following string-to-type conversions are supported:
+- String to number: `"42"` → `42`
+- String to float: `"42.5"` → `42.5`
+- String to boolean: `"true"` → `true`
+
+## Example Config
+```yaml
+# ~/.config/fabric/config.yaml
+model: gpt-4
+temperature: 0.8
+pattern: analyze
+stream: true
+topp: 0.95
+presencepenalty: 0.1
+frequencypenalty: 0.2
+```
+
+## CLI Override Example
+```bash
+# Override temperature from config
+fabric --config ~/.config/fabric/config.yaml --temperature 0.9 "Query"
+```
+

--- a/cli/example.yaml
+++ b/cli/example.yaml
@@ -1,0 +1,21 @@
+#this is an example yaml config file for fabric
+
+# use fabric pattern names
+pattern: ai
+
+# or use a filename
+# pattern: ~/testpattern.md
+
+model: phi3:latest
+
+# for models that support context length
+modelContextLength: 2048
+
+frequencypenalty: 0.5
+presencepenalty: 0.5
+topp: 0.67
+temperature: 0.88
+seed: 42
+
+stream: true
+raw: false

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"reflect"
+	"strconv"
 	"strings"
 
 	"github.com/jessevdk/go-flags"
@@ -77,7 +78,7 @@ func Debugf(format string, a ...interface{}) {
 func Init() (ret *Flags, err error) {
 	// Track which yaml-configured flags were set on CLI
 	usedFlags := make(map[string]bool)
-	args := os.Args[1:]
+	yamlArgsScan := os.Args[1:]
 
 	// Get list of fields that have yaml tags, could be in yaml config
 	yamlFields := make(map[string]bool)
@@ -90,7 +91,7 @@ func Init() (ret *Flags, err error) {
 	}
 
 	// Scan args for that are provided by cli and might be in yaml
-	for _, arg := range args {
+	for _, arg := range yamlArgsScan {
 		if strings.HasPrefix(arg, "--") {
 			flag := strings.TrimPrefix(arg, "--")
 			if i := strings.Index(flag, "="); i > 0 {
@@ -106,7 +107,8 @@ func Init() (ret *Flags, err error) {
 	// Parse CLI flags first
 	ret = &Flags{}
 	parser := flags.NewParser(ret, flags.Default)
-	if _, err = parser.Parse(); err != nil {
+	var args []string
+	if args, err = parser.Parse(); err != nil {
 		return nil, err
 	}
 
@@ -126,21 +128,21 @@ func Init() (ret *Flags, err error) {
 			field := flagsType.Field(i)
 			if yamlTag := field.Tag.Get("yaml"); yamlTag != "" {
 				if !usedFlags[yamlTag] {
-					flagField := flagsVal.Field(i)
-					yamlField := yamlVal.Field(i)
-					if flagField.CanSet() {
-						if yamlField.Type() != flagField.Type() {
-							if err := assignWithConversion(flagField, yamlField); err != nil {
-								Debugf("Type conversion failed for %s: %v\n", yamlTag, err)
-								continue
-							}
-						} else {
-							flagField.Set(yamlField)
+						flagField := flagsVal.Field(i)
+						yamlField := yamlVal.Field(i)
+						if flagField.CanSet() {
+								if yamlField.Type() != flagField.Type() {
+										if err := assignWithConversion(flagField, yamlField); err != nil {
+												Debugf("Type conversion failed for %s: %v\n", yamlTag, err)
+												continue
+										}
+								} else {
+										flagField.Set(yamlField)
+								}
+								Debugf("Applied YAML value for %s: %v\n", yamlTag, yamlField.Interface())
 						}
-						Debugf("Applied YAML value for %s: %v\n", yamlTag, yamlField.Interface())
-					}
 				}
-			}
+		}
 		}
 	}
 
@@ -148,9 +150,11 @@ func Init() (ret *Flags, err error) {
 	info, _ := os.Stdin.Stat()
 	pipedToStdin := (info.Mode() & os.ModeCharDevice) == 0
 
+
+	// Append positional arguments to the message (custom message)
 	if len(args) > 0 {
-		ret.Message = AppendMessage(ret.Message, args[len(args)-1])
-	}
+    ret.Message = AppendMessage(ret.Message, args[len(args)-1])
+  }
 
 	if pipedToStdin {
 		var pipedMessage string
@@ -164,38 +168,36 @@ func Init() (ret *Flags, err error) {
 }
 
 func assignWithConversion(targetField, sourceField reflect.Value) error {
-	switch targetField.Kind() {
-	case reflect.Float64:
-		if sourceField.Kind() == reflect.Int || sourceField.Kind() == reflect.Float32 {
-			targetField.SetFloat(float64(sourceField.Convert(reflect.TypeOf(float64(0))).Float()))
-			Debugf("Converted field %s : %v\n", targetField.Type(), targetField.Interface())
-			return nil
-		}
-	case reflect.Int:
-		if sourceField.Kind() == reflect.Float64 || sourceField.Kind() == reflect.Float32 {
-			targetField.SetInt(int64(sourceField.Convert(reflect.TypeOf(int64(0))).Int()))
-			Debugf("Converted field %s : %v\n", targetField.Type(), targetField.Interface())
-			return nil
-		}
-	case reflect.String:
-		if sourceField.Kind() == reflect.Interface {
-			if str, ok := sourceField.Interface().(string); ok {
-				targetField.SetString(str)
-				Debugf("Converted field %s : %v\n", targetField.Type(), targetField.Interface())
-				return nil
+	// Handle string source values
+	if sourceField.Kind() == reflect.String {
+			str := sourceField.String()
+			switch targetField.Kind() {
+			case reflect.Int:
+					// Try parsing as float first to handle "42.9" -> 42
+					if val, err := strconv.ParseFloat(str, 64); err == nil {
+							targetField.SetInt(int64(val))
+							return nil
+					}
+					// Try direct int parse
+					if val, err := strconv.ParseInt(str, 10, 64); err == nil {
+							targetField.SetInt(val)
+							return nil
+					}
+			case reflect.Float64:
+					if val, err := strconv.ParseFloat(str, 64); err == nil {
+							targetField.SetFloat(val)
+							return nil
+					}
+			case reflect.Bool:
+					if val, err := strconv.ParseBool(str); err == nil {
+							targetField.SetBool(val)
+							return nil
+					}
 			}
-		}
-	case reflect.Bool:
-		if sourceField.Kind() == reflect.Interface {
-			if b, ok := sourceField.Interface().(bool); ok {
-				targetField.SetBool(b)
-				Debugf("Converted field %s : %v\n", targetField.Type(), targetField.Interface())
-				return nil
-			}
-		}
+			return fmt.Errorf("cannot convert string %q to %v", str, targetField.Kind())
 	}
 
-	return fmt.Errorf("unsupported conversion: %s to %s", sourceField.Type(), targetField.Type())
+	return fmt.Errorf("unsupported conversion from %v to %v", sourceField.Kind(), targetField.Kind())
 }
 
 func loadYAMLConfig(configPath string) (*Flags, error) {


### PR DESCRIPTION
This fixes an issue introduced in the last feature, where the custom message was incorrectly handled.
In this usage 
echo "foo" | ./fabric --pattern ai "custom message" --dry-run

it would erroneously append --dry-run to the user input.



Added example.yaml and readme