### PR TITLE
Fix cross-filesystem file move in to_pdf plugin (issue 1221)

### DIFF
--- a/plugins/tools/to_pdf/to_pdf.go
+++ b/plugins/tools/to_pdf/to_pdf.go
@@ -76,9 +76,16 @@ func main() {
 	}
 
 	// Move the output PDF to the current directory
-	err = os.Rename(pdfPath, outputFile)
+	err = copyFile(pdfPath, outputFile)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error moving output file: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Remove the original file after copying
+	err = os.Remove(pdfPath)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error cleaning up temporary file: %v\n", err)
 		os.Exit(1)
 	}
 
@@ -102,4 +109,26 @@ func cleanupTempFiles(dir string) {
 			}
 		}
 	}
+}
+
+// Copy a file from source src to destination dst
+func copyFile(src, dst string) error {
+	sourceFile, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer sourceFile.Close()
+
+	destFile, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer destFile.Close()
+
+	_, err = io.Copy(destFile, sourceFile)
+	if err != nil {
+		return err
+	}
+
+	return destFile.Sync()
 }


### PR DESCRIPTION
## What this Pull Request (PR) does
This PR resolves a bug in the `to_pdf` plugin where it fails to move files across different filesystems. The issue arises from the use of the `os.Rename` function, which does not support cross-device file moves. The fix replaces `os.Rename` with a combination of `io.Copy` and `os.Remove`, ensuring compatibility with environments where /tmp and the current working directory are on different filesystems.

## Related issues
closes #[1221]

## Screenshots
None
