### PR TITLE
Adding deepseek support

### DIFF
--- a/core/plugin_registry.go
+++ b/core/plugin_registry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/danielmiessler/fabric/plugins/ai/openai"
 	"github.com/danielmiessler/fabric/plugins/ai/openrouter"
 	"github.com/danielmiessler/fabric/plugins/ai/siliconcloud"
+	"github.com/danielmiessler/fabric/plugins/ai/deepseek"
 	"github.com/danielmiessler/fabric/plugins/db/fsdb"
 	"github.com/danielmiessler/fabric/plugins/template"
 	"github.com/danielmiessler/fabric/plugins/tools"
@@ -53,7 +54,7 @@ func NewPluginRegistry(db *fsdb.Db) (ret *PluginRegistry, err error) {
 		gemini.NewClient(),
 		//gemini_openai.NewClient(),
 		anthropic.NewClient(), siliconcloud.NewClient(),
-		openrouter.NewClient(), mistral.NewClient())
+		openrouter.NewClient(), mistral.NewClient(), deepseek.NewClient())
 	_ = ret.Configure()
 
 	return

--- a/plugins/ai/deepseek/deepseek.go
+++ b/plugins/ai/deepseek/deepseek.go
@@ -1,0 +1,15 @@
+package deepseek
+
+import (
+	"github.com/danielmiessler/fabric/plugins/ai/openai"
+)
+
+func NewClient() (ret *Client) {
+	ret = &Client{}
+	ret.Client = openai.NewClientCompatible("DeepSeek", "https://api.deepseek.com", nil)
+	return
+}
+
+type Client struct {
+	*openai.Client
+}

--- a/restapi/configuration.go
+++ b/restapi/configuration.go
@@ -44,6 +44,7 @@ func (h *ConfigHandler) GetConfig(c *gin.Context) {
 			"ollama":     "",
 			"openrouter": "",
 			"silicon":    "",
+			"deepseek":   "",
 		})
 		return
 	}
@@ -63,6 +64,7 @@ func (h *ConfigHandler) GetConfig(c *gin.Context) {
 		"ollama":     os.Getenv("OLLAMA_URL"),
 		"openrouter": os.Getenv("OPENROUTER_API_KEY"),
 		"silicon":    os.Getenv("SILICON_API_KEY"),
+		"deepseek":   os.Getenv("DEEPSEEK_API_KEY"),
 	}
 
 	c.JSON(http.StatusOK, config)
@@ -83,6 +85,7 @@ func (h *ConfigHandler) UpdateConfig(c *gin.Context) {
 		OllamaURL        string `json:"ollama_url"`
 		OpenRouterApiKey string `json:"openrouter_api_key"`
 		SiliconApiKey    string `json:"silicon_api_key"`
+		DeepSeekApiKey   string `json:"deepseek_api_key"`
 	}
 
 	if err := c.BindJSON(&config); err != nil {
@@ -99,6 +102,7 @@ func (h *ConfigHandler) UpdateConfig(c *gin.Context) {
 		"OLLAMA_URL":         config.OllamaURL,
 		"OPENROUTER_API_KEY": config.OpenRouterApiKey,
 		"SILICON_API_KEY":    config.SiliconApiKey,
+		"DEEPSEEK_API_KEY":   config.DeepSeekApiKey,
 	}
 
 	var envContent strings.Builder


### PR DESCRIPTION
## What this Pull Request (PR) does
Adding Deepseek AI Vendor support
Deepseek is fully compatible with OpenAI. Both models are available: deepseek-chat and deepseek-reasoner

## Related issues
None

## Screenshots
![image](https://github.com/user-attachments/assets/91c055c8-8238-442a-95ce-8ab9d92700d4)

