### PR TITLE
Add the ability to grab YouTube video transcript with timestamps

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -287,7 +287,7 @@ func Cli(version string) (err error) {
 func processYoutubeVideo(
 	flags *Flags, registry *core.PluginRegistry, videoId string) (message string, err error) {
 
-	if (!flags.YouTubeComments && !flags.YouTubeMetadata) || flags.YouTubeTranscript {
+	if (!flags.YouTubeComments && !flags.YouTubeMetadata) || flags.YouTubeTranscript || flags.YouTubeTranscriptWithTimestamps {
 		var transcript string
 		var language = "en"
 		if flags.Language != "" || registry.Language.DefaultLanguage.Value != "" {
@@ -297,8 +297,14 @@ func processYoutubeVideo(
 				language = registry.Language.DefaultLanguage.Value
 			}
 		}
-		if transcript, err = registry.YouTube.GrabTranscript(videoId, language); err != nil {
-			return
+		if flags.YouTubeTranscriptWithTimestamps {
+			if transcript, err = registry.YouTube.GrabTranscriptWithTimestamps(videoId, language); err != nil {
+				return
+			}
+		} else {
+			if transcript, err = registry.YouTube.GrabTranscript(videoId, language); err != nil {
+				return
+			}
 		}
 		message = AppendMessage(message, transcript)
 	}

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -48,6 +48,7 @@ type Flags struct {
 	YouTube            string            `short:"y" long:"youtube" description:"YouTube video or play list \"URL\" to grab transcript, comments from it and send to chat or print it put to the console and store it in the output file"`
 	YouTubePlaylist    bool              `long:"playlist" description:"Prefer playlist over video if both ids are present in the URL"`
 	YouTubeTranscript  bool              `long:"transcript" description:"Grab transcript from YouTube video and send to chat (it is used per default)."`
+	YouTubeTranscriptWithTimestamps bool `long:"transcript-with-timestamps" description:"Grab transcript from YouTube video with timestamps and send to chat"`
 	YouTubeComments    bool              `long:"comments" description:"Grab comments from YouTube video and send to chat"`
 	YouTubeMetadata    bool              `long:"metadata" description:"Output video metadata"`
 	Language           string            `short:"g" long:"language" description:"Specify the Language Code for the chat, e.g. -g=en -g=zh" default:""`


### PR DESCRIPTION
## What this Pull Request (PR) does

This PR adds the ability to grab the transcript of a YouTube video with timestamps. The timestamps are formatted as `HH:MM:SS` and are prepended to each line of the transcript. The feature is enabled by the new `--transcript-with-timestamps` flag, so it's similar to the existing `--transcript` flag.

### Example future use-case

Providing a summary of a video that includes timestamps for quick navigation to specific parts of the video.

## Related issues
Please reference any open issues this PR relates to in here - not applicable.

## Screenshots/examples
Provide any screenshots you may find relevant to facilitate us understanding your PR.

```
❯ ./fabric -y "https://www.youtube.com/watch?v=5DgHDANmP9M" --transcript-with-timestamps             
[00:00:07 - 00:00:10] hi uh hi everybody good afternoon thank
[00:00:09 - 00:00:13] you so much for coming to my talk I'm
[00:00:10 - 00:00:15] tram founder of Igan lay uh today I'm
[00:00:13 - 00:00:18] going to talk about the state of the aan
[00:00:15 - 00:00:19] universe so you may have seen some of my
[00:00:18 - 00:00:21] earlier talks where I mostly talk about
[00:00:19 - 00:00:23] the future today I'm going to talk about
[00:00:21 - 00:00:27] the present and what we've done till now
[00:00:23 - 00:00:29] okay so firstly what are we all about
...
..
```

The output can be easily used as input for patterns.

## Caveats

The output containing timestamps significantly increases the length of the prompt sent to a model. This can lead to rate limiting. We may mitigate that issue by changing the timestamps' format.
I'm wondering about skipping seconds and concatenating lines under the same timestamp `HH:MM`.
