### PR TITLE
fix: continue fetching models even if some vendors fail

### DIFF
--- a/plugins/ai/vendors.go
+++ b/plugins/ai/vendors.go
@@ -94,7 +94,6 @@ func (o *VendorsManager) readModels() (err error) {
 	for result := range resultsChan {
 		if result.err != nil {
 			fmt.Println(result.vendorName, result.err)
-			cancel() // Cancel remaining goroutines if needed
 		} else {
 			o.Models.AddGroupItems(result.vendorName, result.models...)
 		}


### PR DESCRIPTION
## What this Pull Request (PR) does

Remove the cancellation of remaining goroutines when a vendor collection fails. This ensures that other vendor collections continue even if one fails.

Fixes listing models via `fabric -L` and using non-default models via `fabric -m custom_model`, when localhost models (e.g. Ollama, LM Studio) are not listening on a given port (basically shut down).

---

After https://github.com/danielmiessler/fabric/pull/1302, commands like `fabric -L` and `fabric -m` hang indefinitely if LM Studio is not setup. With this change, it will only print error and proceed further with the other configured vendors:
```shell
❯ fabric -L
LM Studio failed to send request: Get "http://localhost:1234/v1/models": dial tcp 127.0.0.1:1234: connect: connection refused
Ollama Get "http://localhost:11434/api/tags": dial tcp 127.0.0.1:11434: connect: connection refused

Available models:

Gemini

        [1]     chat-bison-001
        [2]     text-bison-001
        [3]     embedding-gecko-001
...
```