### PR TITLE
Feature/add azure api version

### DIFF
--- a/plugins/ai/azure/azure.go
+++ b/plugins/ai/azure/azure.go
@@ -13,6 +13,8 @@ func NewClient() (ret *Client) {
 	ret.Client = openai.NewClientCompatible("Azure", "", ret.configure)
 	ret.ApiDeployments = ret.AddSetupQuestionCustom("deployments", true,
 		"Enter your Azure deployments (comma separated)")
+	ret.ApiVersion = ret.AddSetupQuestionCustom("API Version", false,
+		"Enter the Azure API version (optional, default is latest)")
 
 	return
 }
@@ -20,13 +22,18 @@ func NewClient() (ret *Client) {
 type Client struct {
 	*openai.Client
 	ApiDeployments *plugins.SetupQuestion
+	ApiVersion     *plugins.SetupQuestion
 
 	apiDeployments []string
 }
 
 func (oi *Client) configure() (err error) {
 	oi.apiDeployments = strings.Split(oi.ApiDeployments.Value, ",")
-	oi.ApiClient = goopenai.NewClientWithConfig(goopenai.DefaultAzureConfig(oi.ApiKey.Value, oi.ApiBaseURL.Value))
+	config := goopenai.DefaultAzureConfig(oi.ApiKey.Value, oi.ApiBaseURL.Value)
+	if oi.ApiVersion.Value != "" {
+		config.APIVersion = oi.ApiVersion.Value
+	}
+	oi.ApiClient = goopenai.NewClientWithConfig(config)
 	return
 }
 

--- a/plugins/ai/azure/azure.go
+++ b/plugins/ai/azure/azure.go
@@ -14,7 +14,7 @@ func NewClient() (ret *Client) {
 	ret.ApiDeployments = ret.AddSetupQuestionCustom("deployments", true,
 		"Enter your Azure deployments (comma separated)")
 	ret.ApiVersion = ret.AddSetupQuestionCustom("API Version", false,
-		"Enter the Azure API version (optional, default is latest)")
+		"Enter the Azure API version (optional)")
 
 	return
 }

--- a/plugins/ai/azure/azure_test.go
+++ b/plugins/ai/azure/azure_test.go
@@ -13,6 +13,9 @@ func TestNewClientInitialization(t *testing.T) {
 	if client.ApiDeployments == nil {
 		t.Errorf("Expected ApiDeployments to be initialized, got nil")
 	}
+	if client.ApiVersion == nil {
+		t.Errorf("Expected ApiVersion to be initialized, got nil")
+	}
 	if client.Client == nil {
 		t.Errorf("Expected Client to be initialized, got nil")
 	}
@@ -24,6 +27,7 @@ func TestClientConfigure(t *testing.T) {
 	client.ApiDeployments.Value = "deployment1,deployment2"
 	client.ApiKey.Value = "test-api-key"
 	client.ApiBaseURL.Value = "https://example.com"
+	client.ApiVersion.Value = "2021-01-01"
 
 	err := client.configure()
 	if err != nil {
@@ -42,6 +46,10 @@ func TestClientConfigure(t *testing.T) {
 
 	if client.ApiClient == nil {
 		t.Errorf("Expected ApiClient to be initialized, got nil")
+	}
+
+	if client.ApiClient.Config.APIVersion != "2021-01-01" {
+		t.Errorf("Expected API version to be '2021-01-01', got %s", client.ApiClient.Config.APIVersion)
 	}
 }
 


### PR DESCRIPTION
## What this Pull Request (PR) does
The go open ai client uses "2023-05-15" as hardcoded api version.
See here: https://github.com/sashabaranov/go-openai/blob/74d6449f22dd8bf668ebaeb181263b675b9a668b/config.go#L71C16-L71C26

The latest azure deployments require more recent api version.
This PR makes the api version therefore configurable.

## Hint

Changes are mainly done by an AI, since I'm not used to Go.
Please let me know, if I missed something.