### PR TITLE
Fix: v1.4.153 does not compile because of extra version declaration

### DIFF
--- a/main.go
+++ b/main.go
@@ -9,8 +9,6 @@ import (
 	"github.com/danielmiessler/fabric/cli"
 )
 
-var version string
-
 func main() {
 	err := cli.Cli(version)
 	if err != nil && !flags.WroteHelp(err) {

--- a/plugins/ai/azure/azure_test.go
+++ b/plugins/ai/azure/azure_test.go
@@ -48,8 +48,8 @@ func TestClientConfigure(t *testing.T) {
 		t.Errorf("Expected ApiClient to be initialized, got nil")
 	}
 
-	if client.ApiClient.Config.APIVersion != "2021-01-01" {
-		t.Errorf("Expected API version to be '2021-01-01', got %s", client.ApiClient.Config.APIVersion)
+	if client.ApiVersion.Value != "2021-01-01" {
+		t.Errorf("Expected API version to be '2021-01-01', got %s", client.ApiVersion.Value)
 	}
 }
 


### PR DESCRIPTION
## What this Pull Request (PR) does


## Related issues
N/A

## Screenshots

### Before fix

Fabric fails to compile:

```plain
$ go install .
# github.com/danielmiessler/fabric
./version.go:3:5: version redeclared in this block
        ./main.go:12:5: other declaration of version
```

The `version` string is set up in `version.go` and does not need to be declared again

```go
package main

var version = "v1.4.153"
```

### After fix

```plain
kayvan@dharma src/fabric [03-08-extra-version-declaration-removed] $ go install .
kayvan@dharma src/fabric [03-08-extra-version-declaration-removed] $ fabric --version
v1.4.153
```
