### PR TITLE
Remove Generic Type Parameters from StorageHandler Initialization

### DIFF
--- a/restapi/contexts.go
+++ b/restapi/contexts.go
@@ -14,6 +14,6 @@ type ContextsHandler struct {
 // NewContextsHandler creates a new ContextsHandler
 func NewContextsHandler(r *gin.Engine, contexts *fsdb.ContextsEntity) (ret *ContextsHandler) {
 	ret = &ContextsHandler{
-		StorageHandler: NewStorageHandler[fsdb.Context](r, "contexts", contexts), contexts: contexts}
+		StorageHandler: NewStorageHandler(r, "contexts", contexts), contexts: contexts}
 	return
 }

--- a/restapi/patterns.go
+++ b/restapi/patterns.go
@@ -16,7 +16,7 @@ type PatternsHandler struct {
 // NewPatternsHandler creates a new PatternsHandler
 func NewPatternsHandler(r *gin.Engine, patterns *fsdb.PatternsEntity) (ret *PatternsHandler) {
 	ret = &PatternsHandler{
-		StorageHandler: NewStorageHandler[fsdb.Pattern](r, "patterns", patterns), patterns: patterns}
+		StorageHandler: NewStorageHandler(r, "patterns", patterns), patterns: patterns}
 
 	// TODO: Add custom, replacement routes here
 	//r.GET("/patterns/:name", ret.Get)

--- a/restapi/sessions.go
+++ b/restapi/sessions.go
@@ -14,6 +14,6 @@ type SessionsHandler struct {
 // NewSessionsHandler creates a new SessionsHandler
 func NewSessionsHandler(r *gin.Engine, sessions *fsdb.SessionsEntity) (ret *SessionsHandler) {
 	ret = &SessionsHandler{
-		StorageHandler: NewStorageHandler[fsdb.Session](r, "sessions", sessions), sessions: sessions}
+		StorageHandler: NewStorageHandler(r, "sessions", sessions), sessions: sessions}
 	return ret
 }


### PR DESCRIPTION
## CHANGES

- Remove explicit type parameters from StorageHandler initialization
- Update contexts handler constructor implementation
- Update patterns handler constructor implementation
- Update sessions handler constructor implementation
- Simplify API by relying on type inference

## What this Pull Request (PR) does

This PR removes explicit type parameters from `NewStorageHandler` function calls in three REST API handler implementations: contexts, patterns, and sessions. The change simplifies the code by relying on Go's type inference capabilities.

## Related issues

N/A

## Reason for Changes

This change leverages Go's type inference capabilities to simplify the code. Since the `NewStorageHandler` function can infer the type parameter from the provided arguments, explicitly specifying the type parameter is unnecessary. This makes the code cleaner and more maintainable while preserving the same functionality.

## Impact of Changes

The changes have no functional impact on the application. The code will behave exactly the same way, as the compiler will infer the correct types during compilation. This is a code quality improvement that makes the codebase more concise and easier to read.

While the change is minimal, it demonstrates good Go programming practices by leveraging language features like type inference.