### PR TITLE
fix: set percentEncoded to false

### DIFF
--- a/patterns/raycast/yt
+++ b/patterns/raycast/yt
@@ -7,7 +7,7 @@
 
 # Optional parameters:
 # @raycast.icon 🧠
-# @raycast.argument1 { "type": "text", "placeholder": "Input text", "optional": false, "percentEncoded": true}
+# @raycast.argument1 { "type": "text", "placeholder": "Input text", "optional": false, "percentEncoded": false}
 
 # Documentation:
 # @raycast.description Run fabric -y on the input text of a YouTube video to get the transcript from.


### PR DESCRIPTION
If you use a youtube link like `https://youtu.be/sHIlFKKaq0A` percentEndcoding encodes the link to `https%3A%2F%2Fyoutu.be%2FsHIlFKKaq0A`, which throws an error in fabric.

With percentEndcoding false, the script receives the link without encoding and works.

## Related issues
https://github.com/danielmiessler/fabric/issues/1075

