### PR TITLE
Fix Default Model Change Functionality

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -73,7 +73,10 @@ func Cli(version string) (err error) {
 	}
 
 	if currentFlags.ChangeDefaultModel {
-		err = registry.Defaults.Setup()
+		if err = registry.Defaults.Setup(); err != nil {
+			return
+		}
+		err = registry.SaveEnvFile()
 		return
 	}
 


### PR DESCRIPTION
## What this Pull Request (PR) does
This PR fixes an issue where changes to the default model were not being persisted to the environment file. Now, after setting up the default model, we explicitly save the environment file to ensure changes are preserved.

## Related issues
closes #1353 

## Screenshots

### Before fix:

```plaintext
$ grep DEFAULT ~/.config/fabric/.env 
DEFAULT_VENDOR=OpenAI
DEFAULT_MODEL=gpt-4o
kayvan@thor ~ $ fabric -d

Available models:
[...]
        [136]   tts-1
        [137]   computer-use-preview
        [138]   o1

[Default]

Enter the index the name of your default model (leave empty for 'gpt-4o' or type 'reset' to remove the value):
o1

Enter model context length (leave empty to skip):


DEFAULT_VENDOR: OpenAI
DEFAULT_MODEL: o1
```

However, looking at `.env` we still see:

```plaintext
$ grep DEFAULT ~/.config/fabric/.env
DEFAULT_VENDOR=OpenAI
DEFAULT_MODEL=gpt-4o
```

### After fix:

Running the same flow:

```plaintext
[...]
        [142]   computer-use-preview
        [143]   o1

[Default]

Enter the index the name of your default model (leave empty for 'gpt-4o' or type 'reset' to remove the value):
o1

Enter model context length (leave empty to skip):


DEFAULT_VENDOR: OpenAI
DEFAULT_MODEL: o1
```

And the `.env` file is changed as expected:

```plaintext
$ grep DEFAULT ~/.config/fabric/.env 
DEFAULT_VENDOR=OpenAI
DEFAULT_MODEL=o1
```
