### PR TITLE
feat: add it lang to the chat drop down menu lang in web gui

### DIFF
--- a/web/src/lib/components/chat/DropdownGroup.svelte
+++ b/web/src/lib/components/chat/DropdownGroup.svelte
@@ -12,7 +12,8 @@
     { code: 'es', name: 'Spanish' },
     { code: 'de', name: 'German' },
     { code: 'zh', name: 'Chinese' },
-    { code: 'ja', name: 'Japanese' }
+    { code: 'ja', name: 'Japanese' },
+    { code: 'it', name: 'Italian' }
   ];
 </script>
 


### PR DESCRIPTION
## What this Pull Request (PR) does
Hi!
This PR adds support for the Italian language in the language selection dropdown for the Web GUI.
As an Italian, I thought this could be useful for others as well.

I modified the array of supported languages by adding the last one (Italian):

```typescript
const languages = [
    { code: '', name: 'Default Language' },
    { code: 'en', name: 'English' },
    { code: 'fr', name: 'French' },
    { code: 'es', name: 'Spanish' },
    { code: 'de', name: 'German' },
    { code: 'zh', name: 'Chinese' },
    { code: 'ja', name: 'Japanese' },
    { code: 'it', name: 'Italian' }
  ];
```

I tested this locally, and it seems to work without any issues.
Additionally, the Fabric CLI correctly recognizes Italian as a valid option.

However, since this project uses Svelte and TypeScript, which I'm not deeply familiar with, I’d really appreciate any feedback from more experienced contributors.
Please let me know if any changes are needed!

Looking forward to your review and constructive feedback.

Thanks!

