### PR TITLE
Strategy flag enhancement - Web UI implementation 

### DIFF
--- a/restapi/serve.go
+++ b/restapi/serve.go
@@ -28,6 +28,7 @@ func Serve(registry *core.PluginRegistry, address string, apiKey string) (err er
 	NewChatHandler(r, registry, fabricDb)
 	NewConfigHandler(r, fabricDb)
 	NewModelsHandler(r, registry.VendorManager)
+	NewStrategiesHandler(r)
 
 	// Start server
 	err = r.Run(address)

--- a/restapi/strategies.go
+++ b/restapi/strategies.go
@@ -1,0 +1,59 @@
+package restapi
+
+import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"github.com/gin-gonic/gin"
+)
+
+// StrategyMeta represents the minimal info about a strategy
+type StrategyMeta struct {
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+// NewStrategiesHandler registers the /strategies GET endpoint
+func NewStrategiesHandler(r *gin.Engine) {
+	r.GET("/strategies", func(c *gin.Context) {
+		strategiesDir := filepath.Join(os.Getenv("HOME"), ".config", "fabric", "strategies")
+
+		files, err := ioutil.ReadDir(strategiesDir)
+		if err != nil {
+			c.JSON(http.StatusInternalServerError, gin.H{"error": "Failed to read strategies directory"})
+			return
+		}
+
+		var strategies []StrategyMeta
+
+		for _, file := range files {
+			if file.IsDir() || filepath.Ext(file.Name()) != ".json" {
+				continue
+			}
+
+			fullPath := filepath.Join(strategiesDir, file.Name())
+			data, err := ioutil.ReadFile(fullPath)
+			if err != nil {
+				continue
+			}
+
+			var s struct {
+				Name        string `json:"name"`
+				Description string `json:"description"`
+			}
+			if err := json.Unmarshal(data, &s); err != nil {
+				continue
+			}
+
+			strategies = append(strategies, StrategyMeta{
+				Name:        s.Name,
+				Description: s.Description,
+			})
+		}
+
+		c.JSON(http.StatusOK, strategies)
+	})
+}

--- a/web/Web Interface Update README Files/pr-1284-update.md
+++ b/web/Web Interface Update README Files/pr-1284-update.md
@@ -35,6 +35,11 @@ https://youtu.be/fcVitd4Kb98
 
 The tag filtering system has been deeply integrated into the Pattern Selection interface through several UI enhancements:
 
+### 5. Strategy flags
+- strategies are fetch from .config/fabric/strategies for server processing
+- for gui, they are fetched from static/strategies 
+
+
 1. **Dual-Position Tag Panel**
    - Sliding panel positioned to the right of pattern modal
    - Dynamic toggle button that adapts position and text based on panel state

--- a/web/src/lib/components/chat/DropdownGroup.svelte
+++ b/web/src/lib/components/chat/DropdownGroup.svelte
@@ -4,6 +4,8 @@
   import ModelConfig from "./ModelConfig.svelte";
   import { Select } from "$lib/components/ui/select";
   import { languageStore } from '$lib/store/language-store';
+  import { strategies, selectedStrategy, fetchStrategies } from '$lib/store/strategy-store';
+  import { onMount } from 'svelte';
 
   const languages = [
     { code: '', name: 'Default Language' },
@@ -15,6 +17,10 @@
     { code: 'ja', name: 'Japanese' },
     { code: 'it', name: 'Italian' }
   ];
+
+  onMount(() => {
+    fetchStrategies();
+  });
 </script>
 
 <div class="flex gap-4">
@@ -33,6 +39,17 @@
       >
         {#each languages as lang}
           <option value={lang.code}>{lang.name}</option>
+        {/each}
+      </Select>
+    </div>
+    <div>
+      <Select 
+        bind:value={$selectedStrategy}
+        class="bg-primary-800/30 border-none hover:bg-primary-800/40 transition-colors"
+      >
+        <option value="">None</option>
+        {#each $strategies as strategy}
+          <option value={strategy.name}>{strategy.name} - {strategy.description}</option>
         {/each}
       </Select>
     </div>

--- a/web/src/lib/interfaces/chat-interface.ts
+++ b/web/src/lib/interfaces/chat-interface.ts
@@ -6,7 +6,8 @@ export interface ChatPrompt {
   userInput: string;
   systemPrompt: string;
   model: string;
-  patternName: string;
+  patternName?: string;
+  strategyName?: string; // Optional strategy name to prepend strategy prompt
 }
 
 export interface ChatConfig {

--- a/web/src/lib/services/ChatService.ts
+++ b/web/src/lib/services/ChatService.ts
@@ -10,6 +10,7 @@ import { systemPrompt, selectedPatternName } from '$lib/store/pattern-store';
 import { chatConfig } from '$lib/store/chat-config';
 import { messageStore } from '$lib/store/chat-store';
 import { languageStore } from '$lib/store/language-store';
+import { selectedStrategy } from '$lib/store/strategy-store';
 
 class LanguageValidator {
   constructor(private targetLanguage: string) {}
@@ -179,7 +180,8 @@ export class ChatService {
         userInput: finalUserInput,
         systemPrompt: finalSystemPrompt,
         model: config.model,
-        patternName: get(selectedPatternName)
+        patternName: get(selectedPatternName),
+        strategyName: get(selectedStrategy) // Add selected strategy to prompt
     };
 }
 

--- a/web/src/lib/store/strategy-store.ts
+++ b/web/src/lib/store/strategy-store.ts
@@ -1,0 +1,32 @@
+import { writable } from 'svelte/store';
+
+/**
+ * List of available strategies fetched from backend.
+ * Each strategy has a name and description.
+ */
+export const strategies = writable<Array<{ name: string; description: string }>>([]);
+
+/**
+ * Currently selected strategy name.
+ * Default is empty string meaning "None".
+ */
+export const selectedStrategy = writable<string>("");
+
+/**
+ * Fetches available strategies from the backend `/strategies` endpoint.
+ * Populates the `strategies` store.
+ */
+export async function fetchStrategies() {
+  try {
+    const response = await fetch('/strategies/strategies.json');
+    if (!response.ok) {
+      console.error('Failed to fetch strategies:', response.statusText);
+      return;
+    }
+    const data = await response.json();
+    // Expecting an array of { name, description }
+    strategies.set(data);
+  } catch (error) {
+    console.error('Error fetching strategies:', error);
+  }
+}

--- a/web/static/strategies/strategies.json
+++ b/web/static/strategies/strategies.json
@@ -1,0 +1,11 @@
+[
+  { "name": "cod", "description": "Chain-of-Density (CoD)" },
+  { "name": "cot", "description": "Chain-of-Thought (CoT) Prompting" },
+  { "name": "ltm", "description": "Least-to-Most Prompting" },
+  { "name": "reflexion", "description": "Reflexion Prompting" },
+  { "name": "self-consistent", "description": "Self-Consistency Prompting" },
+  { "name": "self-refine", "description": "Self-Refinement" },
+  { "name": "standard", "description": "Standard Prompting" },
+  { "name": "test", "description": "Test strategy" },
+  { "name": "tot", "description": "Tree-of-Thoughts (ToT)" }
+]

--- a/web/static/strategies/strategies.json
+++ b/web/static/strategies/strategies.json
@@ -1,11 +1,10 @@
 [
-  { "name": "cod", "description": "Chain-of-Density (CoD)" },
+  { "name": "cod", "description": "Chain-of-Draft (CoD)" },
   { "name": "cot", "description": "Chain-of-Thought (CoT) Prompting" },
   { "name": "ltm", "description": "Least-to-Most Prompting" },
   { "name": "reflexion", "description": "Reflexion Prompting" },
   { "name": "self-consistent", "description": "Self-Consistency Prompting" },
   { "name": "self-refine", "description": "Self-Refinement" },
   { "name": "standard", "description": "Standard Prompting" },
-  { "name": "test", "description": "Test strategy" },
   { "name": "tot", "description": "Tree-of-Thoughts (ToT)" }
 ]


### PR DESCRIPTION
### Created API end points to integrate the strategy flags in the web ui. 

Strategies, when selected, prepend the pattern prompt as per the cli implementation. 

<img width="674" alt="Screenshot 2025-04-10 at 6 41 23 PM" src="https://github.com/user-attachments/assets/3b1754ce-6da2-418a-bd5e-1b739fc0b9e3" />

### Here is a summary of the files modified to implement the strategy support in the Fabric project, covering both the frontend (Svelte) and backend (Gin API):

**Frontend (Svelte Web UI)**
web/src/lib/store/strategy-store.ts

**Created a Svelte store to manage the list of strategies and the selected strategy.**
Fetches the list from the static file /strategies/strategies.json.
web/static/strategies/strategies.json

**Created a static manifest listing all available strategies (name + description).**
Used by the frontend dropdown to populate options.
web/src/lib/components/chat/DropdownGroup.svelte

**Added a new dropdown for "Prompt Strategy".**
Binds to the selected strategy store.
Fetches and displays strategies from the static manifest.
web/src/lib/services/ChatService.ts

**Modified to include the selected strategy name in chat POST requests.**
web/src/lib/interfaces/chat-interface.ts

Extended the ChatPrompt interface to include an optional strategyName field.

### Backend (Gin REST API)
restapi/strategies.go

**New file implementing the /strategies GET endpoint.**
Reads strategy JSON files from ~/.config/fabric/strategies/ and returns their metadata.
restapi/serve.go

**Registered the new /strategies endpoint by calling NewStrategiesHandler().**
restapi/chat.go

**Extended the PromptRequest struct to include strategyName.**
Modified the chat POST handler to:
Load the strategy prompt from ~/.config/fabric/strategies/<name>.json if strategyName is set.
Prepend the strategy prompt to the user input before sending to the LLM.


**Summary**
The frontend now allows users to select a strategy, which is included in chat requests.
The backend exposes /strategies and applies the selected strategy prompt dynamically.
The CLI behavior remains unchanged.


@ksylvan this one's for you!  
