### PR TITLE
Update Dockerfile so that Go image version matches go.mod version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use official golang image as builder
-FROM golang:1.23.3-alpine AS builder
+FROM golang:1.23.4-alpine AS builder
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## What this Pull Request (PR) does
Updates the base Go image from 1.23.3 to 1.23.4 to match the minimum required Go version specified in the `go.mod` file

Without this PR the Docker image fails to build with the error

```bash
=> ERROR [builder 4/6] RUN go mod download                                                                                                                                                                                                                                                            0.1s
------
 > [builder 4/6] RUN go mod download:
0.101 go: go.mod requires go >= 1.23.4 (running go 1.23.3; GOTOOLCHAIN=local)
```