### PR TITLE
docs: add contributors section to README with contrib.rocks image

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,14 @@ The Streamlit UI supports clipboard operations across different platforms:
 <a href="https://github.com/sbehrens"><img src="https://avatars.githubusercontent.com/u/688589?v=4" title="Scott Behrens" width="50" height="50"></a>
 <a href="https://github.com/agu3rra"><img src="https://avatars.githubusercontent.com/u/10410523?v=4" title="Andre Guerra" width="50" height="50"></a>
 
+### Contributors
+
+<a href="https://github.com/danielmiessler/fabric/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=danielmiessler/fabric" />
+</a>
+
+Made with [contrib.rocks](https://contrib.rocks).
+
 `fabric` was created by <a href="https://danielmiessler.com/subscribe" target="_blank">Daniel Miessler</a> in January of 2024.
 <br /><br />
 <a href="https://twitter.com/intent/user?screen_name=danielmiessler">![X (formerly Twitter) Follow](https://img.shields.io/twitter/follow/danielmiessler)</a>


### PR DESCRIPTION
## CHANGES

- Add contributors section with visual representation
- Include link to project contributors page
- Add attribution to contrib.rocks tool

## What this Pull Request (PR) does

This pull request adds a "Contributors" section to the `README.md` file, utilizing the `contrib.rocks` service to visually display project contributors.

## Related issues

N/A

## Screenshots

![image](https://github.com/user-attachments/assets/71cd9e47-46dc-4a5f-a542-e1ae8408caeb)

Clicking on the image leads to the project contributors page on GitHub: https://github.com/danielmiessler/fabric/graphs/contributors