### PR TITLE
feat: add Grok AI provider support

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Fabric is graciously supported by…
 ## Updates
 
 > [!NOTE]
-> February 24, 2025
+> April 16, 2025
 >
-> - Fabric now supports Sonnet 3.7! Update and use `-S` to select it as your default if you want, or just use the shortcut `-m claude-3-7-sonnet-latest`. Enjoy!
+> - Fabric now supports Grok (from XAI)! Update and use `-S` to select it as your default if you want, or just use the shortcut `-m grok-3-beta`. Enjoy!
 
 ## What and why
 

--- a/core/plugin_registry.go
+++ b/core/plugin_registry.go
@@ -8,6 +8,7 @@ import (
 	"strconv"
 
 	"github.com/danielmiessler/fabric/plugins/ai/exolab"
+	"github.com/danielmiessler/fabric/plugins/ai/grokai"
 	"github.com/danielmiessler/fabric/plugins/strategy"
 
 	"github.com/samber/lo"
@@ -71,6 +72,7 @@ func NewPluginRegistry(db *fsdb.Db) (ret *PluginRegistry, err error) {
 		deepseek.NewClient(),
 		exolab.NewClient(),
 		litellm.NewClient(),
+		grokai.NewClient(),
 	)
 	_ = ret.Configure()
 

--- a/plugins/ai/grokai/grokai.go
+++ b/plugins/ai/grokai/grokai.go
@@ -1,0 +1,15 @@
+package grokai
+
+import (
+	"github.com/danielmiessler/fabric/plugins/ai/openai"
+)
+
+func NewClient() (ret *Client) {
+	ret = &Client{}
+	ret.Client = openai.NewClientCompatible("GrokAI", "https://api.x.ai/v1", nil)
+	return
+}
+
+type Client struct {
+	*openai.Client
+}

--- a/plugins/ai/grokai/grokai_test.go
+++ b/plugins/ai/grokai/grokai_test.go
@@ -1,0 +1,13 @@
+package grokai
+
+// Test generated using Keploy
+import (
+	"testing"
+)
+
+func TestNewClient_EmbeddedClientNotNil(t *testing.T) {
+	client := NewClient()
+	if client.Client == nil {
+		t.Fatalf("Expected embedded openai.Client to be non-nil, got nil")
+	}
+}

--- a/restapi/configuration.go
+++ b/restapi/configuration.go
@@ -45,6 +45,7 @@ func (h *ConfigHandler) GetConfig(c *gin.Context) {
 			"openrouter": "",
 			"silicon":    "",
 			"deepseek":   "",
+			"grokai":     "",
 		})
 		return
 	}
@@ -65,6 +66,7 @@ func (h *ConfigHandler) GetConfig(c *gin.Context) {
 		"openrouter": os.Getenv("OPENROUTER_API_KEY"),
 		"silicon":    os.Getenv("SILICON_API_KEY"),
 		"deepseek":   os.Getenv("DEEPSEEK_API_KEY"),
+		"grokai":     os.Getenv("GROKAI_API_KEY"),
 		"lmstudio":   os.Getenv("LM_STUDIO_API_BASE_URL"),
 	}
 
@@ -87,6 +89,7 @@ func (h *ConfigHandler) UpdateConfig(c *gin.Context) {
 		OpenRouterApiKey string `json:"openrouter_api_key"`
 		SiliconApiKey    string `json:"silicon_api_key"`
 		DeepSeekApiKey   string `json:"deepseek_api_key"`
+		GrokaiApiKey     string `json:"grokai_api_key"`
 		LMStudioURL      string `json:"lm_studio_base_url"`
 	}
 
@@ -105,6 +108,7 @@ func (h *ConfigHandler) UpdateConfig(c *gin.Context) {
 		"OPENROUTER_API_KEY":     config.OpenRouterApiKey,
 		"SILICON_API_KEY":        config.SiliconApiKey,
 		"DEEPSEEK_API_KEY":       config.DeepSeekApiKey,
+		"GROKAI_API_KEY":         config.GrokaiApiKey,
 		"LM_STUDIO_API_BASE_URL": config.LMStudioURL,
 	}
 


### PR DESCRIPTION
Integrate the Grok AI provider into the Fabric system for AI model interactions.

### CHANGES

* Add Grok AI client to the plugin registry.
* Include Grok AI API key in REST API configuration endpoints.
* Updated README note.

## What this Pull Request (PR) does

This pull request adds support for GrokAI as a new AI plugin in the fabric project. The changes include the addition of a new plugin client for GrokAI, integration into the plugin registry, and updates to the configuration handler to manage GrokAI API keys.

## Related issues

closes #1412

## Screenshots

`fabric -L` now shows this:

![image](https://github.com/user-attachments/assets/eedfd40b-7496-4160-9ee6-795fbcf24813)

Also, tested by having it write most of this PR:

![image](https://github.com/user-attachments/assets/49d5a45f-0e96-4733-8a9f-027b80c971b6)

## Files Changed

- **core/plugin_registry.go**: Updated to include the GrokAI plugin in the registry.
- **plugins/ai/grokai/grokai.go**: New file added to define the GrokAI client, leveraging compatibility with the OpenAI client.
- **plugins/ai/grokai/grokai_test.go**: New test file added to verify the initialization of the GrokAI client.
- **restapi/configuration.go**: Updated to include GrokAI API key management in the configuration endpoints.

## Code Changes

- In **core/plugin_registry.go**, the GrokAI client is imported and instantiated in the `NewPluginRegistry` function:
  ```go
  grokai.NewClient(),
  ```

- In **plugins/ai/grokai/grokai.go**, a new `Client` struct is defined embedding the OpenAI client for compatibility, with the API endpoint set to GrokAI's URL:
  ```go
  ret.Client = openai.NewClientCompatible("GrokAI", "https://api.x.ai/v1", nil)
  ```

- In **plugins/ai/grokai/grokai_test.go**, a basic test ensures the embedded OpenAI client is not nil:
  ```go
  if client.Client == nil {
      t.Fatalf("Expected embedded openai.Client to be non-nil, got nil")
  }
  ```

- In **restapi/configuration.go**, the configuration handler is updated to include GrokAI API key retrieval and updates, ensuring it can be configured via the REST API:
  ```go
  "grokai": os.Getenv("GROKAI_API_KEY"),
  ```

## Reason for Changes

The purpose of these changes is to integrate GrokAI as a supported AI service within the fabric project. This allows users to utilize GrokAI's capabilities alongside other AI providers already supported by the platform, enhancing flexibility and choice for AI-driven functionalities.

## Impact of Changes

These changes introduce a new AI provider option without disrupting existing functionality. Users can now configure and use GrokAI through the same interfaces and configuration mechanisms as other AI plugins. This should have no negative impact on performance and broadens the project's compatibility with AI services.

## Test Plan

The changes include a basic unit test to ensure the GrokAI client initializes correctly. Further testing should include:
- Integration tests to verify GrokAI API interactions through the fabric platform. [✅ ]
- Manual testing of the configuration endpoints to ensure GrokAI API keys are properly handled. [✅ ]
- Validation that existing AI plugins remain unaffected by this addition. [✅ ]

