### PR TITLE
Fix error in deleting patterns due to non empty directory

### DIFF
--- a/plugins/db/fsdb/storage.go
+++ b/plugins/db/fsdb/storage.go
@@ -67,7 +67,7 @@ func (o *StorageEntity) GetNames() (ret []string, err error) {
 }
 
 func (o *StorageEntity) Delete(name string) (err error) {
-	if err = os.Remove(o.BuildFilePathByName(name)); err != nil {
+	if err = os.RemoveAll(o.BuildFilePathByName(name)); err != nil {
 		err = fmt.Errorf("could not delete %s: %v", name, err)
 	}
 	return


### PR DESCRIPTION
## What this Pull Request (PR) does

A Fabric pattern is made up of a directory in `~/.config/fabric/patterns` where the name of the directory represents the pattern name. Within that directory are one or more `.md` files that describe the pattern.

With the current implementation that uses `os.Remove`, invoking the `DELETE /patterns/:name` API results in the following error

```bash
"could not delete test: remove /Users/sherif/.config/fabric/patterns/test: directory not empty"
```

since [`os.Remove`](https://pkg.go.dev/os#Remove) will only delete files or **empty** directories.

This PR replaces `os.Remove` with [`os.RemoveAll`](https://cs.opensource.google/go/go/+/go1.24.2:src/os/path.go;l=73) that deletes the specified path and any children it contains

This ensures that patterns can be deleted whilst also maintaining functionality of being able to delete entities such as contexts/sessions 