### PR TITLE
feat: add Cerebras AI plugin to plugin registry

### DIFF
--- a/core/plugin_registry.go
+++ b/core/plugin_registry.go
@@ -18,6 +18,7 @@ import (
 	"github.com/danielmiessler/fabric/plugins/ai"
 	"github.com/danielmiessler/fabric/plugins/ai/anthropic"
 	"github.com/danielmiessler/fabric/plugins/ai/azure"
+	"github.com/danielmiessler/fabric/plugins/ai/cerebras"
 	"github.com/danielmiessler/fabric/plugins/ai/deepseek"
 	"github.com/danielmiessler/fabric/plugins/ai/dryrun"
 	"github.com/danielmiessler/fabric/plugins/ai/gemini"
@@ -73,6 +74,7 @@ func NewPluginRegistry(db *fsdb.Db) (ret *PluginRegistry, err error) {
 		exolab.NewClient(),
 		litellm.NewClient(),
 		grokai.NewClient(),
+		cerebras.NewClient(),
 	)
 	_ = ret.Configure()
 

--- a/plugins/ai/cerebras/cerebras.go
+++ b/plugins/ai/cerebras/cerebras.go
@@ -1,0 +1,18 @@
+// File: plugins/ai/cerebras/cerebras.go
+package cerebras
+
+import (
+	"github.com/danielmiessler/fabric/plugins/ai/openai"
+)
+
+// NewClient initializes and returns a new Cerebras Client.
+func NewClient() (ret *Client) {
+	ret = &Client{}
+	ret.Client = openai.NewClientCompatible("Cerebras", "https://api.cerebras.ai/v1", nil)
+	return
+}
+
+// Client wraps the openai.Client to provide additional functionality specific to Cerebras.
+type Client struct {
+	*openai.Client
+}

--- a/plugins/ai/cerebras/cerebras_test.go
+++ b/plugins/ai/cerebras/cerebras_test.go
@@ -1,0 +1,27 @@
+// File: plugins/ai/cerebras/cerebras_test.go
+package cerebras
+
+import (
+	"testing"
+)
+
+// Test the client initialization
+func TestNewClient_EmbeddedClientNotNil(t *testing.T) {
+	client := NewClient()
+	if client.Client == nil {
+		t.Fatalf("Expected embedded openai.Client to be non-nil, got nil")
+	}
+}
+
+// Test the client name and URL configuration
+func TestNewClient_ConfiguredCorrectly(t *testing.T) {
+	client := NewClient()
+	if client.GetName() != "Cerebras" {
+		t.Errorf("Expected client name to be 'Cerebras', got '%s'", client.GetName())
+	}
+
+	// Check if the ApiBaseURL is set correctly
+	if client.ApiBaseURL.Value != "https://api.cerebras.ai/v1" {
+		t.Errorf("Expected base URL to be 'https://api.cerebras.ai/v1', got '%s'", client.ApiBaseURL.Value)
+	}
+}


### PR DESCRIPTION
### CHANGES

- Introduce Cerebras AI plugin import in plugin registry.
- Register Cerebras client in the NewPluginRegistry function.

## What this Pull Request (PR) does

This PR adds support for Cerebras AI to the Fabric CLI, enabling users to access models hosted on the Cerebras platform.

## Related issues

N/A - Rework of https://github.com/danielmiessler/fabric/pull/1424

## Screenshots

N/A

### Files Changed

- **core/plugin_registry.go**: Updated to include the Cerebras plugin in the list of AI plugins and instantiate its client in the plugin registry.
- **plugins/ai/cerebras/cerebras.go**: A new file was added to define the Cerebras client, leveraging the OpenAI-compatible client structure for seamless integration.
- **plugins/ai/cerebras/cerebras_test.go**: New file added with unit tests to validate the initialization and configuration of the Cerebras client.

### Code Changes
- In `core/plugin_registry.go`, the Cerebras package is imported, and its client is added to the registry initialization:
  ```go
  +     "github.com/danielmiessler/fabric/plugins/ai/cerebras"
  ...
  +     cerebras.NewClient(),
  ```
- In `plugins/ai/cerebras/cerebras.go`, a new `Client` struct is defined, embedding the OpenAI client for compatibility:
  ```go
  ret.Client = openai.NewClientCompatible("Cerebras", "https://api.cerebras.ai/v1", nil)
  ```
- In `plugins/ai/cerebras/cerebras_test.go`, tests are added to ensure the client is initialized correctly and configured with the expected name and base URL.

### Reason for Changes
The addition of the Cerebras AI plugin expands the range of AI service providers supported by the `fabric` project. This change allows users to interact with Cerebras AI models through the same interface used for other AI providers, promoting flexibility and extensibility in the application.

### Impact of Changes
- **Functionality**: Users can now select Cerebras as an AI backend, potentially benefiting from its unique capabilities or pricing models.
- **Performance**: As the Cerebras client uses the OpenAI-compatible structure, there should be no significant performance overhead compared to other similar plugins.
- **Compatibility**: This change maintains backward compatibility with existing plugins and does not alter the core functionality of the plugin registry.

### Test Plan
- Unit tests have been added in `cerebras_test.go` to verify that the Cerebras client initializes correctly and is configured with the right name and API base URL.
- Integration testing should be conducted to ensure the Cerebras client interacts correctly with the API endpoint under real-world conditions, including authentication and request handling.
- Reviewers are encouraged to test the plugin with a valid Cerebras API key to confirm functionality.
