### PR TITLE
feat: Alphabetical case-insensitive sorting for groups and items

### DIFF
--- a/common/groups_items.go
+++ b/common/groups_items.go
@@ -2,6 +2,8 @@ package common
 
 import (
 	"fmt"
+	"sort"
+	"strings"
 
 	"github.com/samber/lo"
 )
@@ -71,15 +73,31 @@ func (o *GroupsItemsSelector[I]) Print() {
 	fmt.Printf("\n%v:\n", o.SelectionLabel)
 
 	var currentItemIndex int
-	for _, groupItems := range o.GroupsItems {
+	// Create a copy of groups to sort
+	sortedGroupsItems := make([]*GroupItems[I], len(o.GroupsItems))
+	copy(sortedGroupsItems, o.GroupsItems)
+
+	// Sort groups alphabetically case-insensitive
+	sort.SliceStable(sortedGroupsItems, func(i, j int) bool {
+		return strings.ToLower(sortedGroupsItems[i].Group) < strings.ToLower(sortedGroupsItems[j].Group)
+	})
+
+	for _, groupItems := range sortedGroupsItems {
 		fmt.Println()
 		fmt.Printf("%s\n", groupItems.Group)
 		fmt.Println()
 
-		for _, item := range groupItems.Items {
+		// Create a copy of items to sort
+		sortedItems := make([]I, len(groupItems.Items))
+		copy(sortedItems, groupItems.Items)
+		// Sort items alphabetically case-insensitive
+		sort.SliceStable(sortedItems, func(i, j int) bool {
+			return strings.ToLower(o.GetItemKey(sortedItems[i])) < strings.ToLower(o.GetItemKey(sortedItems[j]))
+		})
+
+		for _, item := range sortedItems {
 			currentItemIndex++
 			fmt.Printf("\t[%d]\t%s\n", currentItemIndex, o.GetItemKey(item))
-
 		}
 	}
 }


### PR DESCRIPTION
Enhances the GroupsItemsSelector Print method by adding case-insensitive alphabetical sorting for both groups and items, improving user navigation and experience.

Changes include:
- Add case-insensitive alphabetical sorting for groups
- Add case-insensitive alphabetical sorting for items within each group
- Preserve original ordering stability using sort.SliceStable
- Improve code organization with separate sorting steps for groups and items

### Summary
This pull request introduces alphabetical sorting (case-insensitive) for both groups and items within the `GroupsItemsSelector` struct's `Print` method in the `common` package. The changes ensure a more organized and user-friendly output when displaying grouped items.

### Files Changed
- **common/groups_items.go**: Modified to include sorting functionality for groups and items in the `Print` method.

### Code Changes
The significant updates are in the `Print` method of the `GroupsItemsSelector` struct:
- Added imports for the `sort` and `strings` packages to support sorting and case-insensitive comparison.
- Implemented sorting for groups:
  ```go
  // Create a copy of groups to sort
  sortedGroupsItems := make([]*GroupItems[I], len(o.GroupsItems))
  copy(sortedGroupsItems, o.GroupsItems)
  
  // Sort groups alphabetically case-insensitive
  sort.SliceStable(sortedGroupsItems, func(i, j int) bool {
      return strings.ToLower(sortedGroupsItems[i].Group) < strings.ToLower(sortedGroupsItems[j].Group)
  })
  ```
- Implemented sorting for items within each group:
  ```go
  // Create a copy of items to sort
  sortedItems := make([]I, len(groupItems.Items))
  copy(sortedItems, groupItems.Items)
  // Sort items alphabetically case-insensitive
  sort.SliceStable(sortedItems, func(i, j int) bool {
      return strings.ToLower(o.GetItemKey(sortedItems[i])) < strings.ToLower(o.GetItemKey(sortedItems[j]))
  })
  ```

### Reason for Changes
The changes were made to improve the readability and usability of the output generated by the `Print` method. Previously, groups and items were displayed in an arbitrary order, which could be confusing for users. Sorting them alphabetically ensures a consistent and intuitive presentation, making it easier to locate specific groups or items.

### Impact of Changes
- **Usability**: The sorted output will enhance user experience by providing a predictable and organized display of data.
- **Performance**: There is a minor performance overhead due to the sorting operations. However, since `sort.SliceStable` is used, the impact should be negligible for typical use cases with reasonably sized datasets.
- **Functionality**: No existing functionality is altered beyond the visual representation of the data in the `Print` method.

### Test Plan
- **Unit Tests**: Existing unit tests for the `GroupsItemsSelector` struct should be run to ensure that the sorting logic does not interfere with the core functionality.
- **Manual Testing**: Manually invoke the `Print` method with various datasets to visually confirm that groups and items are sorted alphabetically in a case-insensitive manner.

### Additional Notes
- The use of `sort.SliceStable` ensures that the relative order of equal elements is preserved, maintaining stability in the sorting process.

## Screenshots

### Before change:

![image](https://github.com/user-attachments/assets/384b30ac-76bf-46f3-b7d5-cbcd4822270f)

### After change:

![image](https://github.com/user-attachments/assets/3c2fb9b5-a0dc-48da-879d-fbce74d00557)
