### PR TITLE
feat: enhance StrategyMeta with Prompt field and dynamic naming

### DIFF
--- a/restapi/strategies.go
+++ b/restapi/strategies.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/gin-gonic/gin"
 )
@@ -14,6 +15,7 @@ import (
 type StrategyMeta struct {
 	Name        string `json:"name"`
 	Description string `json:"description"`
+	Prompt      string `json:"prompt"`
 }
 
 // NewStrategiesHandler registers the /strategies GET endpoint
@@ -41,16 +43,17 @@ func NewStrategiesHandler(r *gin.Engine) {
 			}
 
 			var s struct {
-				Name        string `json:"name"`
 				Description string `json:"description"`
+				Prompt      string `json:"prompt"`
 			}
 			if err := json.Unmarshal(data, &s); err != nil {
 				continue
 			}
 
 			strategies = append(strategies, StrategyMeta{
-				Name:        s.Name,
+				Name:        strings.TrimSuffix(file.Name(), ".json"),
 				Description: s.Description,
+				Prompt:      s.Prompt,
 			})
 		}
 


### PR DESCRIPTION
### CHANGES

- Add `Prompt` field to `StrategyMeta` struct.
- Include `strings` package for filename processing.
- Derive strategy name from filename using `strings.TrimSuffix`.
- Store `Prompt` value from JSON data in `StrategyMeta`

## What this Pull Request (PR) does

This pull request updates the `/strategies` endpoint implementation to include a `prompt` field in the strategy metadata returned by the API. It also derives the `name` of each strategy from the filename rather than relying on a `name` field in the JSON files.

## Related issues

closes #1423 

## Files Changed

### `restapi/strategies.go`

- **Added**: Import of the `strings` package.
- **Changed**: The `StrategyMeta` struct now includes a `Prompt` field.
- **Changed**: The anonymous struct used for unmarshaling strategy metadata in the file reader loop now includes a `Prompt` field and omits the `Name` field.
- **Changed**: The `Name` for each strategy is now derived by trimming the `.json` suffix from the filename, rather than using a `name` property from the JSON.
- **Changed**: The `Prompt` property is now included when constructing `StrategyMeta` for the response.

---

## Code Changes

**StrategyMeta struct now includes prompt:**
```go
type StrategyMeta struct {
	Name        string `json:"name"`
	Description string `json:"description"`
	Prompt      string `json:"prompt"`
}
```

**Anonymous struct for unmarshaling:**
```go
var s struct {
	Description string `json:"description"`
	Prompt      string `json:"prompt"`
}
```

**Strategy name is derived from filename:**
```go
Name: strings.TrimSuffix(file.Name(), ".json"),
```

**Prompt field is added to response:**
```go
Prompt: s.Prompt,
```

---

## Reason for Changes

- **Inclusion of Prompt:** The changes allow the API to provide the `prompt` for each strategy, which may be required by clients for display or processing.
- **File-based Naming:** By deriving the strategy name from the filename, this removes the need for a redundant `name` field within each strategy JSON file and eliminates the risk of inconsistency between filename and metadata.

---

## Impact of Changes

- **API Contract:** The `/strategies` endpoint now includes a `prompt` field in each strategy object, which may be a breaking or additive change for clients consuming this endpoint.

---

## Test Plan

- **Functional Test:** Call the `/strategies` endpoint and verify that each returned object includes the correct `name` (matching the filename), `description`, and `prompt` fields.

---

## Additional Notes

- Clients consuming the `/strategies` endpoint should be informed of the new `prompt` field and the change in how the `name` is derived.
- No changes were made to the structure or location of the strategy JSON files themselves.

## Screenshots

### Before fix:

![image](https://github.com/user-attachments/assets/e05f39d7-23fd-4bd3-ab92-5cf81f99c9c7)

### After fix:

![image](https://github.com/user-attachments/assets/a461aef2-bfb4-47c5-b8bf-befada20a9ca)
