### PR TITLE
chore: fix fabric setup mess-up introduced by sorting lists (tools and models)

### DIFF
--- a/core/plugin_registry.go
+++ b/core/plugin_registry.go
@@ -149,7 +149,7 @@ func (o *PluginRegistry) Setup() (err error) {
 			return vendor
 		})...)
 
-	groupsPlugins.AddGroupItems("Tools", o.Defaults, o.PatternsLoader, o.YouTube, o.Language, o.Jina, o.Strategies)
+	groupsPlugins.AddGroupItems("Tools", o.Defaults, o.Jina, o.Language, o.PatternsLoader, o.Strategies, o.YouTube)
 
 	for {
 		groupsPlugins.Print()

--- a/plugins/ai/vendors.go
+++ b/plugins/ai/vendors.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
+	"strings"
 	"sync"
 
 	"github.com/danielmiessler/fabric/plugins"
@@ -95,6 +97,9 @@ func (o *VendorsManager) readModels() (err error) {
 		if result.err != nil {
 			fmt.Println(result.vendorName, result.err)
 		} else {
+			sort.Slice(result.models, func(i, j int) bool {
+				return strings.ToLower(result.models[i]) < strings.ToLower(result.models[j])
+			})
 			o.Models.AddGroupItems(result.vendorName, result.models...)
 		}
 	}


### PR DESCRIPTION
## What this Pull Request (PR) does

This pull request introduces two primary changes:
1. Reorders the plugins listed under the "Tools" group within the plugin registry.
2. Ensures that AI model names from each vendor are sorted alphabetically (case-insensitive) before being grouped and added to the model list.

## Related issues

Closes #1430 


## Files Changed

### 1. `core/plugin_registry.go`
- **Change:** Modified the order in which plugins are added to the "Tools" group.
- **Before:** 
  ```go
  groupsPlugins.AddGroupItems("Tools", o.Defaults, o.PatternsLoader, o.YouTube, o.Language, o.Jina, o.Strategies)
  ```
- **After:** 
  ```go
  groupsPlugins.AddGroupItems("Tools", o.Defaults, o.Jina, o.Language, o.PatternsLoader, o.Strategies, o.YouTube)
  ```
- **Reason:** This matches the list that is printed (whose indexes are then used to access the plugins in `fabric -S` interactions).

### 2. `plugins/ai/vendors.go`
- **Change:** Introduced sorting for model names returned by each AI vendor.
- **Added:**
  ```go
  sort.Slice(result.models, func(i, j int) bool {
      return strings.ToLower(result.models[i]) < strings.ToLower(result.models[j])
  })
  ```
- **Location:** Before adding the models to the group via `o.Models.AddGroupItems(result.vendorName, result.models...)`.

---

## Code Changes

**Alphabetical Sorting of Models:**
```go
sort.Slice(result.models, func(i, j int) bool {
    return strings.ToLower(result.models[i]) < strings.ToLower(result.models[j])
})
```
This code ensures that the list of models for each vendor is sorted alphabetically in a case-insensitive manner, which improves readability and consistency in the UI or any outputs.

**Plugin Group Reordering:**
```go
groupsPlugins.AddGroupItems("Tools", o.Defaults, o.Jina, o.Language, o.PatternsLoader, o.Strategies, o.YouTube)
```
The sequence of plugins in the "Tools" group has been changed, possibly to improve the logical grouping or user experience.

---

## Reason for Changes

1. **Model Sorting:**  
   - To provide a consistent and predictable order of AI models, especially beneficial for user interfaces or CLI outputs where users expect alphabetical listings.
   - Reduces confusion and facilitates easier searching or scanning for specific models.
   - The model numbers now match what `fabric -S` expects, so it all works as designed.

2. **Plugin Order Adjustment:**  
   - To improve the logical or functional grouping of tools, making it more intuitive for end users or developers interacting with the plugin system.

---

## Impact of Changes

- **User Experience:**  
  - The sorted list of models will make it easier for users to locate specific models under each vendor, especially as the number of models grows.
  - The new ordering of plugins in the "Tools" group could enhance navigation and usability.

- **Code Maintainability:**  
  - Sorting logic is straightforward and leverages Go's standard library, adding negligible overhead and improving clarity.

- **No Breaking Changes:**  
  - These changes are non-breaking and only affect ordering/presentation, not core functionality.

---

## Test Plan

- **Manual Verification:**  
  - Run the application and confirm that, for each vendor, the models are displayed in alphabetical order.
  - Check the "Tools" group in the UI or CLI and verify that the plugin numbers launch the expected plugin setup.
  - Verified that changing the default model using the model number now works as expected:

![image](https://github.com/user-attachments/assets/fe67d21f-c4c5-46a8-b526-87825b9dd79c)
![image](https://github.com/user-attachments/assets/c8bf7979-5fc7-40d1-b1f1-d160b7db5b6a)


---

## Additional Notes

- The changes are minor but improve polish and user experience.
- No additional dependencies were introduced.
- No configuration or documentation changes are necessary.


## Screenshots

### Before fix

Tool numbers do not correspond to the plugin.

![image](https://github.com/user-attachments/assets/fbcc4092-c89b-4e4c-88b7-0953f6ed9574)

### After fix

![image](https://github.com/user-attachments/assets/6e85d85f-4284-4e2a-8ad4-2095eadb5649)
