### PR TITLE
chore: update Anthropic SDK to v0.2.0-beta.3 and migrate to V2 API

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.23.4
 
 require (
 	github.com/anaskhan96/soup v1.2.5
-	github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.11
+	github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3
 	github.com/atotto/clipboard v0.1.4
 	github.com/gabriel-vasile/mimetype v1.4.8
 	github.com/gin-gonic/gin v1.10.0

--- a/go.sum
+++ b/go.sum
@@ -25,6 +25,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.11 h1:O3/AMObKntZyu1KH6Xks6E0gbE8w6HVaKHE+/vXARzM=
 github.com/anthropics/anthropic-sdk-go v0.2.0-alpha.11/go.mod h1:GJxtdOs9K4neo8Gg65CjJ7jNautmldGli5/OFNabOoo=
+github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3 h1:b5t1ZJMvV/l99y4jbz7kRFdUp3BSDkI8EhSlHczivtw=
+github.com/anthropics/anthropic-sdk-go v0.2.0-beta.3/go.mod h1:AapDW22irxK2PSumZiQXYUFvsdQgkwIWlpESweWZI/c=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=


### PR DESCRIPTION
## CHANGES

- Upgrade Anthropic SDK from alpha.11 to beta.3
- Update API endpoint from v1 to v2
- Replace anthropic.F() with direct assignment
- Replace anthropic.F() with anthropic.Opt() for optional params
- Simplify event delta handling in streaming
- Change client type from pointer to value type
- Update comment with SDK changelog reference

## What this Pull Request (PR) does

This PR updates the Anthropic Go SDK from v0.2.0-alpha.11 to v0.2.0-beta.3 and adapts our code to the breaking changes introduced in the new SDK version. The main changes include switching from v1 to v2 API endpoints and updating the client method signatures to match the new SDK requirements.

## Files Changed

### go.mod and go.sum
- Updated the Anthropic SDK dependency from v0.2.0-alpha.11 to v0.2.0-beta.3
- Added the corresponding checksum entry in go.sum

### plugins/ai/anthropic/anthropic.go
- Changed the client type from pointer to value type (`*anthropic.Client` → `anthropic.Client`)
- Updated API endpoint handling to use v2 instead of v1
- Modified parameter passing in API calls to match new SDK requirements:
  - Replaced `anthropic.F()` wrapper with direct value passing or `anthropic.Opt()` for optional parameters
  - Simplified the stream event handling logic to directly access the delta text

## Screenshots

After change, fabric with anthropic models is still working.

![image](https://github.com/user-attachments/assets/90207615-bd15-44d5-9b42-bb62b73a4704)

Verified that streaming chat works as expected.

## Code Changes

The most significant changes are in the API endpoint handling and parameter passing:

```go
// Old API endpoint handling
if strings.Contains(baseURL, "-") && !strings.HasSuffix(baseURL, "/v1") {
    if strings.HasSuffix(baseURL, "/") {
        baseURL = strings.TrimSuffix(baseURL, "/")
    }
    baseURL = baseURL + "/v1"
}

// New API endpoint handling
// As of 2.0beta1, using v2 API endpoint.
// https://github.com/anthropics/anthropic-sdk-go/blob/main/CHANGELOG.md#020-beta1-2025-03-25
if strings.Contains(baseURL, "-") && !strings.HasSuffix(baseURL, "/v2") {
    baseURL = strings.TrimSuffix(baseURL, "/")
    baseURL = baseURL + "/v2"
}
```

Parameter passing has been simplified:

```go
// Old parameter passing
Model:       anthropic.F(opts.Model),
MaxTokens:   anthropic.F(int64(an.maxTokens)),
TopP:        anthropic.F(opts.TopP),
Temperature: anthropic.F(opts.Temperature),
Messages:    anthropic.F(messages),

// New parameter passing
Model:       opts.Model,
MaxTokens:   int64(an.maxTokens),
TopP:        anthropic.Opt(opts.TopP),
Temperature: anthropic.Opt(opts.Temperature),
Messages:    messages,
```

Stream handling has been simplified:

```go
// Old stream handling
switch delta := event.Delta.(type) {
case anthropic.ContentBlockDeltaEventDelta:
    if delta.Text != "" {
        channel <- delta.Text
    }
}

// New stream handling
// directly send any non-empty delta text
if event.Delta.Text != "" {
    channel <- event.Delta.Text
}
```

## Reason for Changes

The Anthropic SDK has undergone significant changes in the beta version, including

1. Migration from v1 to v2 API endpoints
2. Simplified parameter passing without requiring the `F()` wrapper function
3. Streamlined event handling in streaming responses

These changes required us to update our integration code to maintain compatibility with the latest SDK version.

## Impact of Changes

This update ensures our application remains compatible with the latest Anthropic API. The v2 API is more stable and provides improved performance and reliability. The code is now more concise and easier to maintain with the simplified parameter passing and event handling.

## Test Plan

The changes have been tested with
- Basic message sending 🆗 
- Streaming responses 🆗 
- Various parameter combinations (temperature, top_p) 🆗 
