### PR TITLE
chore: Fix user input handling when using raw mode and `--strategy` flag

### DIFF
--- a/plugins/template/extension_executor.go
+++ b/plugins/template/extension_executor.go
@@ -117,8 +117,12 @@ func (e *ExtensionExecutor) executeWithFile(cmd *exec.Cmd, ext *ExtensionDefinit
 	// Create context with timeout
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
+	// Store the original environment
+	originalEnv := cmd.Env
+	// Create a new command with context. This might reset Env, depending on the Go version.
 	cmd = exec.CommandContext(ctx, cmd.Path, cmd.Args[1:]...)
-	cmd.Env = cmd.Env
+	// Restore the environment variables explicitly
+	cmd.Env = originalEnv
 
 	fileConfig := ext.GetFileConfig()
 	if fileConfig == nil {


### PR DESCRIPTION
## CHANGES

- refactor BuildSession raw mode to prepend system to user content
- ensure raw mode messages always have User role
- keep existing user message when no `systemMessage` provided
- append systemMessage separately in non-raw mode sessions
- Store original `cmd.Env` before context-based exec command creation
- recreate exec command with context then restore `originalEnv`
- add comments clarifying raw vs non-raw handling behavior

This PR introduces two primary changes:

1. Updates the logic in `core/chatter.go` for handling system and user messages in "raw" mode, ensuring the system message is prepended to the user input and always marked as a user message.
2. Fixes environment variable propagation in `plugins/template/extension_executor.go` when executing commands with context, ensuring the intended environment is preserved after wrapping the command with a timeout.

## Related issues

closes #1434 

---

### Files Changed

#### 1. `core/chatter.go`

- **What changed:**  
  Modified how system and user messages are combined in raw mode in the `BuildSession` method.
- **Why:**  
  To ensure that the system message is always included as part of the user's message (not as a separate system message) and that the user's role is properly set, improving raw-mode consistency for downstream consumers.

#### 2. `plugins/template/extension_executor.go`

- **What changed:**  
  Adjusted command construction in `executeWithFile` to preserve environment variables when creating a new command with context (to enforce timeouts).
- **Why:**  
  `exec.CommandContext` can reset the environment; the update explicitly restores the intended environment, preventing loss of configuration or credentials in child processes.

---

### Code Changes

#### `core/chatter.go` (Raw Mode Message Handling)

**Old Logic:**
```go
if raw {
    if request.Message != nil {
        if systemMessage != "" {
            request.Message.Content = systemMessage
            // system contains pattern which contains user input
        }
    } else {
        if systemMessage != "" {
            request.Message = &goopenai.ChatCompletionMessage{Role: goopenai.ChatMessageRoleSystem, Content: systemMessage}
        }
    }
}
```

**New Logic:**
```go
if raw {
    // In raw mode, combine system message (potentially with strategy) and user message into a single user message
    if systemMessage != "" {
        if request.Message != nil {
            // Prepend system message to user content, ensuring user input is preserved
            request.Message.Content = fmt.Sprintf("%s\n\n%s", systemMessage, request.Message.Content)
            request.Message.Role = goopenai.ChatMessageRoleUser // Ensure role is User in raw mode
        } else {
            // If no user message, create one with the system content, marked as User role
            request.Message = &goopenai.ChatCompletionMessage{Role: goopenai.ChatMessageRoleUser, Content: systemMessage}
        }
    }
    // else: no system message, user message (if any) remains unchanged
}
```

#### `plugins/template/extension_executor.go` (Environment Variable Fix)

**Old Logic:**
```go
cmd = exec.CommandContext(ctx, cmd.Path, cmd.Args[1:]...)
cmd.Env = cmd.Env
```

**New Logic:**
```go
originalEnv := cmd.Env
cmd = exec.CommandContext(ctx, cmd.Path, cmd.Args[1:]...)
// Restore the environment variables explicitly
cmd.Env = originalEnv
```

---

### Reason for Changes

- **Raw Mode Consistency:**  
  Previously, the system message could overwrite the user's input or be set with the system role, which was inconsistent with expectations for "raw" mode where a single user message is expected. This update makes the system message part of the user's content, preserving both intent and input.

- **Environment Propagation Fix:**  
  Wrapping a command with a new context can inadvertently reset its environment variables, which can cause subtle bugs if the plugin relies on those variables. The fix ensures all environment settings are retained after the context is applied.

---

### Impact of Changes

- **For Users:**  
  - In raw mode, messages sent to the LLM (or other consumers) will now always include both the system and user content as a single user message, preserving user input and prompt structure.
  - Any plugins or extensions using environment variables will now work reliably with execution timeouts.

- **For Developers:**  
  - The change clarifies and simplifies raw mode logic, making future maintenance easier.
  - The environment handling fix eliminates a class of hard-to-debug issues when integrating with external tools via plugins.

- **Potential Bugs:**  
  - If downstream consumers assume the system message is always a separate message, this could cause confusion; review all such consumers.
  - Ensure that `cmd.Env` is always set prior to this function or the original environment may be nil.

---

### Test Plan

- All tests pass. 🆗 
- Manual testing of `-r` with `--strategy` flag. 🆗 

---

### Additional Notes

- Both changes are bug fixes.
- No new dependencies or breaking API changes are introduced.

## Screenshots

### Before fix:

![image](https://github.com/user-attachments/assets/0ae355d9-7aa1-4bfb-943b-e7f87612a51f)

### After fix:

![image](https://github.com/user-attachments/assets/f28c3c1c-6878-4fdd-ad6d-224aa99f9eb8)

