### PR TITLE
Add completion to the build output for Nix

### DIFF
--- a/nix/pkgs/fabric/default.nix
+++ b/nix/pkgs/fabric/default.nix
@@ -2,6 +2,7 @@
   lib,
   buildGoApplication,
   go,
+  installShellFiles,
 }:
 
 buildGoApplication {
@@ -19,6 +20,13 @@ buildGoApplication {
   ];
 
   inherit go;
+
+  nativeBuildInputs = [ installShellFiles ];
+  postInstall = ''
+    installShellCompletion --zsh ./completions/_fabric
+    installShellCompletion --bash ./completions/fabric.bash
+    installShellCompletion --fish ./completions/fabric.fish
+  '';
 
   meta = with lib; {
     description = "Fabric is an open-source framework for augmenting humans using AI. It provides a modular framework for solving specific problems using a crowdsourced set of AI prompts that can be used anywhere";


### PR DESCRIPTION
## What this Pull Request (PR) does
Add the completion scripts to the nix package build output so that completion works on supported shells.

## Related issues
None

## Screenshots
Build output puts the completion files in the output where nix expects them.
```
$ tree result/
result/
├── bin
│   ├── code_helper
│   ├── fabric
│   └── to_pdf
└── share
    ├── bash-completion
    │   └── completions
    │       └── fabric.bash
    ├── fish
    │   └── vendor_completions.d
    │       └── fabric.fish
    └── zsh
        └── site-functions
            └── _fabric
```
Screenshot shows tab completion working with Zsh after installing the package from my fork.
![Screenshot 2025-05-07 at 5 22 50 PM](https://github.com/user-attachments/assets/7bc8cea8-776c-4348-ada9-2af22d136690)
