### PR TITLE
Typos, spelling, grammar and other minor updates

### DIFF
--- a/NOTES.md
+++ b/NOTES.md
@@ -2,7 +2,7 @@
 
 - The goal is to bring more encapsulation of the models management and simplified configuration management to bring increased flexibility, transparency on the overall flow, and simplicity in adding new model.
 - We need to differentiate:
-  - Vendors: the producer of models (like OpenAI, Azure, Anthropric, Ollama, ..etc) and their associated APIs
+  - Vendors: the producer of models (like OpenAI, Azure, Anthropic, Ollama, ..etc) and their associated APIs
   - Models: the LLM models these vendors are making public
 - Each vendor and operations allowed by the vendor needs to be encapsulated. This includes:
   - The questions needed to setup the model (like the API key, or the URL)

--- a/Pattern_Descriptions/README_Pattern_Descriptions_and_Tags_MGT.md
+++ b/Pattern_Descriptions/README_Pattern_Descriptions_and_Tags_MGT.md
@@ -53,7 +53,7 @@ Pattern descriptions and tags are managed in pattern_descriptions.json:
 
 3. How to update Pattern short descriptions (one sentence). 
 
-You can update your descriptions in pattern_descriptions.json manually or using LLM assistance (prefered approach). 
+You can update your descriptions in pattern_descriptions.json manually or using LLM assistance (preferred approach). 
 
 Tell AI to look for "Description pending" entries in this file and write a short description based on the extract info in the pattern_extracts.json file. You can also ask your LLM to add tags for those newly added patterns, using other patterns tag assignments as example.    
 

--- a/Web Interface MOD Readme Files/pr-1284-update.md
+++ b/Web Interface MOD Readme Files/pr-1284-update.md
@@ -1,4 +1,4 @@
-This Cummulative PR adds several Web UI and functionality improvements to make pattern selection more intuitive with the addition of pattern descriptions, ability to save favorite patterns, a Pattern TAG system, powerful multilingual capabilities, PDF-to-markdown functionnalities, a help reference section, more robust Youtube processing and a variety of other ui improvements. 
+This Cumulative PR adds several Web UI and functionality improvements to make pattern selection more intuitive with the addition of pattern descriptions, ability to save favorite patterns, a Pattern TAG system, powerful multilingual capabilities, PDF-to-markdown functionalities, a help reference section, more robust Youtube processing and a variety of other ui improvements.
 
 ## 🎥 Demo Video
 https://youtu.be/XMzjgqvdltM

--- a/patterns/write_nuclei_template_rule/system.md
+++ b/patterns/write_nuclei_template_rule/system.md
@@ -19,10 +19,10 @@ Take a deep breath and work on this problem step-by-step.
 You must output only a working YAML file.
 
 """
-As Nuclei AI, your primary function is to assist users in creating Nuclei templates.Your responses should focus on generating Nuclei templates based on user requirements, incorporating elements like HTTP requests, matchers, extractors, and conditions. You are now required to always use extractors when needed to extract a value from a request and use it in a subsequent request. This includes handling cases involving dynamic data extraction and response pattern matching. Provide templates for common security vulnerabilities like SSTI, XSS, Open Redirect, SSRF, and others, utilizing complex matchers and extractors. Additionally, handle cases involving raw HTTP requests, HTTP fuzzing, unsafe HTTP, and HTTP payloads, and use correct regexes in RE2 syntax. Avoid including hostnames directly in the template paths, instead, use placeholders like {{BaseURL}}. Your expertise includes understanding and implementing matchers and extractors in Nuclei templates, especially for dynamic data extraction and response pattern matching. Your responses are focused solely on Nuclei template generation and related guidance, tailored to cybersecurity applications.
+As Nuclei AI, your primary function is to assist users in creating Nuclei templates. Your responses should focus on generating Nuclei templates based on user requirements, incorporating elements like HTTP requests, matchers, extractors, and conditions. You are now required to always use extractors when needed to extract a value from a request and use it in a subsequent request. This includes handling cases involving dynamic data extraction and response pattern matching. Provide templates for common security vulnerabilities like SSTI, XSS, Open Redirect, SSRF, and others, utilizing complex matchers and extractors. Additionally, handle cases involving raw HTTP requests, HTTP fuzzing, unsafe HTTP, and HTTP payloads, and use correct regexes in RE2 syntax. Avoid including hostnames directly in the template paths, instead, use placeholders like {{BaseURL}}. Your expertise includes understanding and implementing matchers and extractors in Nuclei templates, especially for dynamic data extraction and response pattern matching. Your responses are focused solely on Nuclei template generation and related guidance, tailored to cybersecurity applications.
 
 Notes:
-When using a json extractor, use jq like syntax to extract json keys, E.g to extract the json key \"token\" you will need to use \'.token\'
+When using a json extractor, use jq like syntax to extract json keys, E.g., to extract the json key \"token\" you will need to use \'.token\'
 While creating headless templates remember to not mix it up with http protocol
 
 Always read the helper functions from the documentation first before answering a query.
@@ -30,7 +30,7 @@ Remember, the most important thing is to:
 Only respond with a nuclei template, nothing else, just the generated yaml nuclei template
 When creating a multi step template and extracting something from a request's response, use internal: true in that extractor unless asked otherwise.
 
-When using dsl you dont need to re-use {{}} if you are already inside a {{
+When using dsl you don’t need to re-use {{}} if you are already inside a {{
 
 ### What are Nuclei Templates?
 Nuclei templates are the cornerstone of the Nuclei scanning engine. Nuclei templates enable precise and rapid scanning across various protocols like TCP, DNS, HTTP, and more. They are designed to send targeted requests based on specific vulnerability checks, ensuring low-to-zero false positives and efficient scanning over large networks.

--- a/web/README.md
+++ b/web/README.md
@@ -3,7 +3,7 @@
 
 This is a web app for Fabric. It was built using [Svelte](https://svelte.dev/), [SkeletonUI](https://skeleton.dev/), and [Mdsvex](https://mdsvex.pngwn.io/). 
 
-The goal of this app is to not only provide a user interface for Fabric, but also a out-of-the-box website for those who want to get started with web development, blogging, or to just have a web interface for fabric. You can use this app as a GUI interface for Fabric, a ready to go blog-site, or a website template for your own projects. 
+The goal of this app is to not only provide a user interface for Fabric, but also an out-of-the-box website for those who want to get started with web development, blogging, or to just have a web interface for fabric. You can use this app as a GUI interface for Fabric, a ready to go blog-site, or a website template for your own projects.
 
 ![Preview](/fabric-png.png)
 
@@ -17,7 +17,7 @@ When creating new posts make sure to include a date, description, tags, and alia
 
 You can include images, tags to other articles, code blocks, and more all within your markdown files. 
 
-### If you choose to use Obsidian along side ths app
+### If you choose to use Obsidian alongside this app
 
 You can design and order your vault however you like, though a `posts` folder should be kept in your vault to house any articles you'd like to post. 
 

--- a/web/Web Interface Update README Files/pr-1284-update.md
+++ b/web/Web Interface Update README Files/pr-1284-update.md
@@ -1,4 +1,4 @@
-This Cummulative PR adds several Web UI and functionality improvements to make pattern selection more intuitive with the addition of pattern descriptions, ability to save favorite patterns, a Pattern TAG system, powerful multilingual capabilities, PDF-to-markdown functionnalities, a help reference section, more robust Youtube processing and a variety of other ui improvements. 
+This Cumulative PR adds several Web UI and functionality improvements to make pattern selection more intuitive with the addition of pattern descriptions, ability to save favorite patterns, a Pattern TAG system, powerful multilingual capabilities, PDF-to-markdown functionalities, a help reference section, more robust Youtube processing and a variety of other ui improvements.
 
 ## 🎥 Demo Video
 https://youtu.be/bhwtWXoMASA


### PR DESCRIPTION
This pull request primarily addresses minor spelling and grammar corrections across multiple documentation files to improve clarity and professionalism. Below is a summary of the most important changes, grouped by theme.

### Spelling Corrections:
* Corrected "Anthropric" to "Anthropic" in `NOTES.md` to fix a vendor name typo.
* Fixed "prefered" to "preferred" in `Pattern_Descriptions/README_Pattern_Descriptions_and_Tags_MGT.md` to ensure proper spelling.
* Corrected "Cummulative" to "Cumulative" and "functionnalities" to "functionalities" in `Web Interface MOD Readme Files/pr-1284-update.md` and `web/Web Interface Update README Files/pr-1284-update.md`. [[1]](diffhunk://#diff-7e3e4ed53eca1945bf427479a8fa23c9ee53824d7b20845d910c656ff340fb7aL1-R1) [[2]](diffhunk://#diff-d3811c7360c4cd7a554a22f8283b3397111b43aac9a0b06a664cef09a363dab0L1-R1)

### Grammar Improvements:
* Improved phrasing by adding "an" in "an out-of-the-box website" in `web/README.md`.
* Fixed "dont" to "don’t" and added a comma in "E.g., to extract" for better readability in `patterns/write_nuclei_template_rule/system.md`.

### Consistency Enhancements:
* Updated "ths" to "this" in a section heading in `web/README.md` for consistency and correctness.## What this Pull Request (PR) does
Please briefly describe what this PR does.

#
This pull request includes a series of minor corrections to spelling, grammar, and phrasing across multiple documentation files to improve clarity and professionalism. Below is a summary of the most important changes, grouped by theme:

### Spelling and Grammar Fixes:
* Corrected "Anthropric" to "Anthropic" in `NOTES.md` to fix a misspelling of a vendor name.
* Fixed "prefered" to "preferred" in `Pattern_Descriptions/README_Pattern_Descriptions_and_Tags_MGT.md` to address a typo.
* Updated "Cummulative" to "Cumulative" and "functionnalities" to "functionalities" in `Web Interface MOD Readme Files/pr-1284-update.md` and `web/Web Interface Update README Files/pr-1284-update.md`. [[1]](diffhunk://#diff-7e3e4ed53eca1945bf427479a8fa23c9ee53824d7b20845d910c656ff340fb7aL1-R1) [[2]](diffhunk://#diff-d3811c7360c4cd7a554a22f8283b3397111b43aac9a0b06a664cef09a363dab0L1-R1)
* Replaced "dont" with "don’t" and clarified phrasing around DSL usage in `patterns/write_nuclei_template_rule/system.md`.

### Improved Phrasing:
* Changed "a out-of-the-box website" to "an out-of-the-box website" in `web/README.md` for grammatical correctness.
* Refined the phrasing of a subsection title from "along side ths app" to "alongside this app" in `web/README.md`.# Related issues
