### PR TITLE
0522 auto raw mode for some models

### DIFF
--- a/core/chatter.go
+++ b/core/chatter.go
@@ -32,6 +32,13 @@ type Chatter struct {
 
 // Send processes a chat request and applies any file changes if using the create_coding_feature pattern
 func (o *Chatter) Send(request *common.ChatRequest, opts *common.ChatOptions) (session *fsdb.Session, err error) {
+	modelToUse := opts.Model
+	if modelToUse == "" {
+		modelToUse = o.model // Default to the model set in the Chatter struct
+	}
+	if o.vendor.NeedsRawMode(modelToUse) {
+		opts.Raw = true
+	}
 	if session, err = o.BuildSession(request, opts.Raw); err != nil {
 		return
 	}

--- a/plugins/ai/anthropic/anthropic.go
+++ b/plugins/ai/anthropic/anthropic.go
@@ -205,3 +205,7 @@ func (an *Client) toMessages(msgs []*goopenai.ChatCompletionMessage) (ret []anth
 
 	return anthropicMessages
 }
+
+func (an *Client) NeedsRawMode(modelName string) bool {
+	return false
+}

--- a/plugins/ai/azure/azure.go
+++ b/plugins/ai/azure/azure.go
@@ -41,3 +41,7 @@ func (oi *Client) ListModels() (ret []string, err error) {
 	ret = oi.apiDeployments
 	return
 }
+
+func (oi *Client) NeedsRawMode(modelName string) bool {
+	return false
+}

--- a/plugins/ai/dryrun/dryrun.go
+++ b/plugins/ai/dryrun/dryrun.go
@@ -90,3 +90,7 @@ func (c *Client) Setup() error {
 func (c *Client) SetupFillEnvFileContent(_ *bytes.Buffer) {
 	// No environment variables needed for dry run
 }
+
+func (c *Client) NeedsRawMode(modelName string) bool {
+	return false
+}

--- a/plugins/ai/exolab/exolab.go
+++ b/plugins/ai/exolab/exolab.go
@@ -43,3 +43,7 @@ func (oi *Client) ListModels() (ret []string, err error) {
 	ret = oi.apiModels
 	return
 }
+
+func (oi *Client) NeedsRawMode(modelName string) bool {
+	return false
+}

--- a/plugins/ai/gemini/gemini.go
+++ b/plugins/ai/gemini/gemini.go
@@ -143,6 +143,10 @@ func (o *Client) extractText(response *genai.GenerateContentResponse) (ret strin
 	return
 }
 
+func (o *Client) NeedsRawMode(modelName string) bool {
+	return false
+}
+
 func toMessages(msgs []*goopenai.ChatCompletionMessage) (systemInstruction *genai.Content, messages []genai.Part) {
 	if len(msgs) >= 2 {
 		systemInstruction = &genai.Content{

--- a/plugins/ai/lmstudio/lmstudio.go
+++ b/plugins/ai/lmstudio/lmstudio.go
@@ -345,3 +345,7 @@ func (c *Client) GetEmbeddings(ctx context.Context, input string, opts *common.C
 	embeddings = result.Data[0].Embedding
 	return
 }
+
+func (c *Client) NeedsRawMode(modelName string) bool {
+	return false
+}

--- a/plugins/ai/ollama/ollama.go
+++ b/plugins/ai/ollama/ollama.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 
 	ollamaapi "github.com/ollama/ollama/api"
@@ -140,5 +141,14 @@ func (o *Client) createChatRequest(msgs []*goopenai.ChatCompletionMessage, opts 
 }
 
 func (o *Client) NeedsRawMode(modelName string) bool {
+	ollamaPrefixes := []string{
+		"llama3",
+		"llama2",
+	}
+	for _, prefix := range ollamaPrefixes {
+		if strings.HasPrefix(modelName, prefix) {
+			return true
+		}
+	}
 	return false
 }

--- a/plugins/ai/ollama/ollama.go
+++ b/plugins/ai/ollama/ollama.go
@@ -138,3 +138,7 @@ func (o *Client) createChatRequest(msgs []*goopenai.ChatCompletionMessage, opts 
 	}
 	return
 }
+
+func (o *Client) NeedsRawMode(modelName string) bool {
+	return false
+}

--- a/plugins/ai/openai/openai.go
+++ b/plugins/ai/openai/openai.go
@@ -123,6 +123,10 @@ func (o *Client) Send(ctx context.Context, msgs []*goopenai.ChatCompletionMessag
 	return
 }
 
+func (o *Client) NeedsRawMode(modelName string) bool {
+	return false
+}
+
 func (o *Client) buildChatCompletionRequest(
 	inputMsgs []*goopenai.ChatCompletionMessage, opts *common.ChatOptions,
 ) (ret goopenai.ChatCompletionRequest) {

--- a/plugins/ai/openai/openai.go
+++ b/plugins/ai/openai/openai.go
@@ -124,6 +124,16 @@ func (o *Client) Send(ctx context.Context, msgs []*goopenai.ChatCompletionMessag
 }
 
 func (o *Client) NeedsRawMode(modelName string) bool {
+	openaiModelsPrefixes := []string{
+		"o1",
+		"o3",
+		"o4",
+	}
+	for _, prefix := range openaiModelsPrefixes {
+		if strings.HasPrefix(modelName, prefix) {
+			return true
+		}
+	}
 	return false
 }
 

--- a/plugins/ai/vendor.go
+++ b/plugins/ai/vendor.go
@@ -14,4 +14,5 @@ type Vendor interface {
 	ListModels() ([]string, error)
 	SendStream([]*goopenai.ChatCompletionMessage, *common.ChatOptions, chan string) error
 	Send(context.Context, []*goopenai.ChatCompletionMessage, *common.ChatOptions) (string, error)
+	NeedsRawMode(modelName string) bool
 }


### PR DESCRIPTION
## What this Pull Request (PR) does

This PR introduces automatic raw mode detection for AI models that require it. The system now automatically enables raw mode for specific model families (OpenAI's o1/o3/o4 series and Ollama's llama2/llama3) without requiring manual configuration.

## Related issues

closes #1477 and #1068 

## Files Changed

- **core/chatter.go**: Modified the `Send` method to check if the selected model requires raw mode and automatically enable it
- **plugins/ai/vendor.go**: Added `NeedsRawMode` interface method to the Vendor interface
- **plugins/ai/\*/\*.go**: Implemented `NeedsRawMode` method across all AI vendor implementations (anthropic, azure, dryrun, exolab, gemini, lmstudio, ollama, openai)

## Code Changes

### core/chatter.go
```go
+       modelToUse := opts.Model
+       if modelToUse == "" {
+               modelToUse = o.model // Default to the model set in the Chatter struct
+       }
+       if o.vendor.NeedsRawMode(modelToUse) {
+               opts.Raw = true
+       }
```
Added logic to determine the model being used and automatically enable raw mode if the vendor indicates it's required for that model.

### plugins/ai/vendor.go
```go
+       NeedsRawMode(modelName string) bool
```
Extended the Vendor interface with a new method to query whether a specific model requires raw mode.

### plugins/ai/openai/openai.go
```go
+func (o *Client) NeedsRawMode(modelName string) bool {
+       openaiModelsPrefixes := []string{
+               "o1",
+               "o3",
+               "o4",
+       }
+       for _, prefix := range openaiModelsPrefixes {
+               if strings.HasPrefix(modelName, prefix) {
+                       return true
+               }
+       }
+       return false
+}
```
Implemented raw mode detection for OpenAI models, specifically targeting the o1, o3, and o4 model families.

### plugins/ai/ollama/ollama.go
```go
+func (o *Client) NeedsRawMode(modelName string) bool {
+       ollamaPrefixes := []string{
+               "llama3",
+               "llama2",
+       }
+       for _, prefix := range ollamaPrefixes {
+               if strings.HasPrefix(modelName, prefix) {
+                       return true
+               }
+       }
+       return false
+}
```
Implemented raw mode detection for Ollama models, specifically for llama2 and llama3 models.

### Other vendor implementations
All other vendor implementations (anthropic, azure, dryrun, exolab, gemini, lmstudio) return `false` for `NeedsRawMode`, indicating they don't require special raw mode handling.

## Reason for Changes

Certain AI models require raw mode to function correctly. Previously, users had to manually enable raw mode for these models, which was error-prone and led to confusion. This change automates the process by detecting when a model requires raw mode and enabling it automatically.

## Impact of Changes

1. **Improved User Experience**: Users no longer need to remember which models require raw mode
2. **Reduced Errors**: Eliminates failures caused by forgetting to enable raw mode for models that require it
3. **Backward Compatibility**: The change is backward compatible - existing code that manually sets raw mode will continue to work
4. **Extensibility**: The interface-based approach makes it easy to add raw mode requirements for new models in the future

## Test Plan

1. Test with OpenAI o1/o3/o4 models to verify raw mode is automatically enabled
2. Test with Ollama llama2/llama3 models to verify raw mode is automatically enabled
3. Test with other models to ensure raw mode is not incorrectly enabled
4. Verify that manually setting raw mode still works as expected
5. Test with empty model selection to ensure default model handling works correctly

## Additional Notes

- The implementation uses a prefix-based approach for model detection, which allows for flexibility with model versions (e.g., "o1-preview", "llama3.1", etc.)
- The `NeedsRawMode` method is called for every chat request, but the overhead is minimal as it's just string comparison
- Future model additions that require raw mode can be easily added to the respective vendor's prefix list



## Screenshots

Before fix:

![image](https://github.com/user-attachments/assets/eed58c12-516c-414c-b324-cf1b0961e76c)

After fix:

![image](https://github.com/user-attachments/assets/4e05a4a2-cb68-4061-9e00-5985bf567bb9)
