### PR TITLE
Web UI: Centralize Environment Configuration and Make Fabric Base URL Configurable

### DIFF
--- a/web/src/lib/config/environment.ts
+++ b/web/src/lib/config/environment.ts
@@ -1,0 +1,62 @@
+/**
+ * Environment configuration for the Fabric web app
+ * Centralizes all environment variable handling
+ */
+
+// Default values
+const DEFAULT_FABRIC_BASE_URL = 'http://localhost:8080';
+
+/**
+ * Get the Fabric base URL from environment variable or default
+ * This function works in both server and client contexts
+ */
+export function getFabricBaseUrl(): string {
+  // In server context (Node.js), use process.env
+  if (typeof process !== 'undefined' && process.env) {
+    return process.env.FABRIC_BASE_URL || DEFAULT_FABRIC_BASE_URL;
+  }
+
+  // In client context, check if the environment was injected via Vite
+  if (typeof window !== 'undefined' && (window as any).__FABRIC_CONFIG__) {
+    return (window as any).__FABRIC_CONFIG__.FABRIC_BASE_URL || DEFAULT_FABRIC_BASE_URL;
+  }
+
+  // Fallback to default
+  return DEFAULT_FABRIC_BASE_URL;
+}
+
+/**
+ * Get the Fabric API base URL (adds /api if not present)
+ */
+export function getFabricApiUrl(): string {
+  const baseUrl = getFabricBaseUrl();
+
+  // Remove trailing slash if present
+  const cleanBaseUrl = baseUrl.replace(/\/$/, '');
+
+  // Check if it already ends with /api
+  if (cleanBaseUrl.endsWith('/api')) {
+    return cleanBaseUrl;
+  }
+
+  return `${cleanBaseUrl}/api`;
+}
+
+/**
+ * Configuration object for easy access to all environment settings
+ */
+export const config = {
+  fabricBaseUrl: getFabricBaseUrl(),
+  fabricApiUrl: getFabricApiUrl(),
+} as const;
+
+// Type definitions
+export interface FabricConfig {
+  FABRIC_BASE_URL: string;
+}
+
+declare global {
+  interface Window {
+    __FABRIC_CONFIG__?: FabricConfig;
+  }
+}

--- a/web/src/routes/chat/+server.ts
+++ b/web/src/routes/chat/+server.ts
@@ -15,11 +15,11 @@ export const POST: RequestHandler = async ({ request }) => {
         language: body.language,
         hasLanguageParam: true
       });
-      
+
       // Extract video ID
       const match = body.url.match(/(?:youtube\.com\/(?:[^\/]+\/.+\/|(?:v|e(?:mbed)?)\/|.*[?&]v=)|youtu\.be\/)([^"&?\/\s]{11})/);
       const videoId = match ? match[1] : null;
-      
+
       if (!videoId) {
         return json({ error: 'Invalid YouTube URL' }, { status: 400 });
       }

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -2,6 +2,9 @@ import { purgeCss } from 'vite-plugin-tailwind-purgecss';
 import { sveltekit } from '@sveltejs/kit/vite';
 import { defineConfig } from 'vite';
 
+// Get the Fabric base URL from environment variable with fallback
+const FABRIC_BASE_URL = process.env.FABRIC_BASE_URL || 'http://localhost:8080';
+
 export default defineConfig({
   plugins: [sveltekit(), purgeCss()],
   build: {
@@ -18,6 +21,10 @@ export default defineConfig({
     'process.browser': true,
     'process': {
       cwd: () => ('/')
+    },
+    // Inject Fabric configuration for client-side access
+    '__FABRIC_CONFIG__': {
+      FABRIC_BASE_URL: JSON.stringify(FABRIC_BASE_URL)
     }
   },
   resolve: {
@@ -31,11 +38,11 @@ export default defineConfig({
     },
     proxy: {
       '/api': {
-        target: 'http://localhost:8080',
+        target: FABRIC_BASE_URL,
         changeOrigin: true,
         timeout: 30000,
         rewrite: (path) => path.replace(/^\/api/, ''),
-        configure: (proxy, options) => {
+        configure: (proxy, _options) => {
           proxy.on('error', (err, req, res) => {
             console.log('proxy error', err);
             res.writeHead(500, {
@@ -46,10 +53,10 @@ export default defineConfig({
         }
       },
       '^/(patterns|models|sessions)/names': {
-        target: 'http://localhost:8080',
+        target: FABRIC_BASE_URL,
         changeOrigin: true,
         timeout: 30000,
-        configure: (proxy, options) => {
+        configure: (proxy, _options) => {
           proxy.on('error', (err, req, res) => {
             console.log('proxy error', err);
             res.writeHead(500, {


### PR DESCRIPTION
# Web UI: Centralize Environment Configuration and Make Fabric Base URL Configurable

## What this Pull Request (PR) does

This PR introduces centralized environment configuration management for the Fabric web application. The main change is making the Fabric base URL configurable through environment variables instead of being hardcoded to `localhost:8080`. This enhancement improves deployment flexibility and follows configuration best practices.

## Related issues

N/A - This simple change makes it possible to point instances of the frontend Web UI to a more powerful machine on the network running Fabric (or even a cloud instance).

## Screenshots

![image](https://github.com/user-attachments/assets/68b0fa72-595a-4f21-8f6f-53d3aeac9a62)

![image](https://github.com/user-attachments/assets/f1f1cd23-5904-4932-acee-90cdf7eead42)

## Files Changed

### Added Files
- **`web/src/lib/config/environment.ts`** - New centralized configuration module that handles environment variable access for both server and client contexts

### Modified Files
- **`web/src/routes/chat/+server.ts`** - Minor whitespace cleanup (trailing spaces removed)
- **`web/vite.config.ts`** - Updated to use configurable Fabric base URL and inject configuration for client-side access

## Code Changes

### New Environment Configuration Module
```typescript
export function getFabricBaseUrl(): string {
  // Server context (Node.js)
  if (typeof process !== 'undefined' && process.env) {
    return process.env.FABRIC_BASE_URL || DEFAULT_FABRIC_BASE_URL;
  }
  
  // Client context with injected config
  if (typeof window !== 'undefined' && (window as any).__FABRIC_CONFIG__) {
    return (window as any).__FABRIC_CONFIG__.FABRIC_BASE_URL || DEFAULT_FABRIC_BASE_URL;
  }
  
  return DEFAULT_FABRIC_BASE_URL;
}
```

### Vite Configuration Updates
```typescript
// Environment variable with fallback
const FABRIC_BASE_URL = process.env.FABRIC_BASE_URL || 'http://localhost:8080';

// Proxy configuration now uses variable
proxy: {
  '/api': {
    target: FABRIC_BASE_URL,
    // ...
  }
}
```

## Reason for Changes

1. **Configuration Flexibility**: Hardcoded URLs make deployment to different environments (staging, production, development) difficult
2. **Best Practices**: Centralizing environment configuration reduces code duplication and improves maintainability
3. **Universal Context Support**: The new configuration works in both server-side (SSR) and client-side contexts
4. **Deployment Ready**: Applications can now be easily configured for different Fabric backend instances

## Impact of Changes

### Positive Impacts
- **Deployment Flexibility**: Can now deploy to any environment by setting `FABRIC_BASE_URL` environment variable
- **Code Organization**: Centralized configuration makes the codebase more maintainable
- **Development Experience**: Developers can easily point to different Fabric instances during development

### Potential Risks
- **Runtime Configuration**: Client-side configuration relies on Vite's build-time injection, which could fail silently if misconfigured
- **Type Safety**: The global window extension uses `any` type, reducing type safety
- **Fallback Dependency**: Heavy reliance on fallback values might mask configuration issues

## Test Plan

1. [✅] **Default Behavior**: Verify application works without `FABRIC_BASE_URL` set (should use `localhost:8080`)
2. [✅] **Environment Variable**: Test with `FABRIC_BASE_URL=http://localhost:7777` and verify proxy targets update
3. [✅] **Client-Side Access**: Confirm `getFabricBaseUrl()` returns correct values in browser context
4. [✅] **API Endpoint Construction**: Validate `getFabricApiUrl()` correctly appends `/api` when needed
5. [✅] **Test Web UI manually**: Works as before

## Additional Notes

- The configuration module includes TypeScript definitions for better IDE support
- Unused parameters in Vite config are now properly prefixed with underscore to avoid linting warnings
- The implementation maintains backward compatibility - existing deployments will continue working without changes
- **Breaking Changes**: None - this is a backward-compatible enhancement.
