### PR TITLE
Add AIML provider configuration

### DIFF
--- a/plugins/ai/openai_compatible/providers_config.go
+++ b/plugins/ai/openai_compatible/providers_config.go
@@ -56,6 +56,10 @@ var ProviderMap = map[string]ProviderConfig{
 		Name:    "SiliconCloud",
 		BaseURL: "https://api.siliconflow.cn/v1",
 	},
+	"AIML": {
+		Name:    "AIML",
+		BaseURL: "https://api.aimlapi.com/v1",
+	},
 }
 
 // GetProviderByName returns the provider configuration for a given name with O(1) lookup


### PR DESCRIPTION
## What this Pull Request (PR) does

This pull request adds support for a new OpenAI-compatible provider, AIML, by including its configuration in the `ProviderMap`. This allows users to configure and utilize AIML's API endpoints through our system.

## Related issues
closes #1493 

### Files Changed

*   **`plugins/ai/openai_compatible/providers_config.go`**: Modified to add the AIML provider configuration to the list of supported providers.

### Code Changes

A new entry for `AIML` has been added to the `ProviderMap` variable.

```go
 // plugins/ai/openai_compatible/providers_config.go
 "SiliconCloud": {
  Name:    "SiliconCloud",
  BaseURL: "https://api.siliconflow.cn/v1",
 },
+"AIML": {
+ Name:    "AIML",
+ BaseURL: "https://api.aimlapi.com/v1",
+},
```

### Reason for Changes

The goal is to expand the range of supported third-party, OpenAI-compatible AI services. By adding AIML to our provider list, we enable users who have accounts with AIML to integrate their services directly with our platform without needing to manually specify the base URL.

### Impact of Changes

*   **Functionality**: Users can now select `AIML` as a provider in their configuration. The system will automatically use `https://api.aimlapi.com/v1` as the base URL for all API requests to this provider.
*   **Backward Compatibility**: This change is purely additive and does not affect any existing provider configurations. There is no impact on users who are not using the new AIML provider.
*   **Potential Bugs**: If the AIML API endpoint (`https://api.aimlapi.com/v1`) changes in the future, this configuration will become outdated and require an update. There are no other anticipated risks, as this is a simple configuration addition.

### Test Plan

To ensure the changes work as expected, manual testing is recommended:

1.  Configure the application to use the `AIML` provider.
2.  Provide a valid AIML API key in the local environment/configuration.
3.  Execute a feature that makes a call to the AI provider (e.g., generate a text completion).
4.  Verify that the API call is successful and that the request was routed to the AIML endpoint.
5.  Optionally, test an existing provider (like `OpenAI` or `SiliconCloud`) to confirm that its functionality remains unaffected.

### Additional Notes

This change only registers the provider's name and base URL. Users are still responsible for obtaining and configuring their own API keys for the AIML service.

Once you have the API key, you have access to all the models (203 new models on the date of this PR)

## Screenshots

![image](https://github.com/user-attachments/assets/fd3bba39-10c4-4135-a087-458c6d189c14)

![image](https://github.com/user-attachments/assets/347092b1-4086-4a88-97e7-33f69bd87a58)



