### PR TITLE
Add chat timeout command line argument for Ollama requests

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -256,7 +256,7 @@ func Cli(version string) (err error) {
 	}
 
 	var chatter *core.Chatter
-	if chatter, err = registry.GetChatter(currentFlags.Model, currentFlags.ModelContextLength, currentFlags.Strategy, currentFlags.Stream, currentFlags.DryRun); err != nil {
+	if chatter, err = registry.GetChatter(currentFlags.Model, currentFlags.ModelContextLength, currentFlags.Strategy, currentFlags.Stream, currentFlags.DryRun, currentFlags.ChatTimeout); err != nil {
 		return
 	}
 

--- a/cli/flags.go
+++ b/cli/flags.go
@@ -9,6 +9,7 @@ import (
 	"reflect"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/danielmiessler/fabric/common"
 	"github.com/jessevdk/go-flags"
@@ -74,6 +75,7 @@ type Flags struct {
 	ListStrategies                  bool              `long:"liststrategies" description:"List all strategies"`
 	ListVendors                     bool              `long:"listvendors" description:"List all vendors"`
 	ShellCompleteOutput             bool              `long:"shell-complete-list" description:"Output raw list without headers/formatting (for shell completion)"`
+	ChatTimeout                     time.Duration     `long:"chat-timeout" description:"Chat timeout (currently only affects Ollama requests) (e.g. 30s, 45m)" default:"20m"`
 }
 
 var debug = false

--- a/core/plugin_registry.go
+++ b/core/plugin_registry.go
@@ -9,6 +9,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/danielmiessler/fabric/plugins/ai/exolab"
 	"github.com/danielmiessler/fabric/plugins/strategy"
@@ -230,7 +231,7 @@ func (o *PluginRegistry) Configure() (err error) {
 	return
 }
 
-func (o *PluginRegistry) GetChatter(model string, modelContextLength int, strategy string, stream bool, dryRun bool) (ret *Chatter, err error) {
+func (o *PluginRegistry) GetChatter(model string, modelContextLength int, strategy string, stream bool, dryRun bool, chatTimeout time.Duration) (ret *Chatter, err error) {
 	ret = &Chatter{
 		db:     o.Db,
 		Stream: stream,
@@ -282,6 +283,15 @@ func (o *PluginRegistry) GetChatter(model string, modelContextLength int, strate
 			model, defaultModel, defaultVendor, errMsg)
 		return
 	}
+
+
+	if ret.vendor.GetName() == "Ollama" {
+		if client, ok := ret.vendor.(*ollama.Client); ok {
+			client.ReconfigureHttpTimeout(chatTimeout)
+		}
+	}
+
+
 	ret.strategy = strategy
 	return
 }

--- a/restapi/chat.go
+++ b/restapi/chat.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	goopenai "github.com/sashabaranov/go-openai"
 
@@ -105,7 +106,7 @@ func (h *ChatHandler) HandleChat(c *gin.Context) {
 					}
 				}
 
-				chatter, err := h.registry.GetChatter(p.Model, 2048, "", false, false)
+				chatter, err := h.registry.GetChatter(p.Model, 2048, "", false, false, 20 * time.Minute)
 				if err != nil {
 					log.Printf("Error creating chatter: %v", err)
 					streamChan <- fmt.Sprintf("Error: %v", err)


### PR DESCRIPTION
# Pull Request Description

## Summary

This pull request introduces a configurable chat timeout flag for Ollama requests, replacing the hardcoded 20-minute HTTP timeout with a command-line argument (`--chat-timeout`). The default value remains at 20 minutes if no argument is provided. This change enhances flexibility and robustness, particularly for long-running requests on hardware like Raspberry Pi 5.

## Files Changed

- **Modification**: Updated the call to `registry.GetChatter` to include a new parameter `currentFlags.ChatTimeout`.
- **Addition**: Introduced a new flag `ChatTimeout` of type `time.Duration`.
- **Modification**: Updated the signature of the `GetChatter` function to accept a new parameter `chatTimeout`.
- **New Logic**: Added logic to reconfigure the HTTP timeout for Ollama clients if the vendor is "Ollama".

## Reason for Changes

The primary reason for this change is to address the limitations posed by a hardcoded 20-minute timeout in Ollama requests. This was particularly problematic on hardware like Raspberry Pi 5, where inference times could exceed 20 minutes, resulting in incomplete or failed chat responses. By introducing a configurable timeout, users can adapt the application's behavior to their specific needs without requiring recompilation or forking.

## Impact of Changes

This change significantly enhances the flexibility and usability of the application by allowing dynamic adjustment of request timeouts. Users running on slower hardware or dealing with longer inference times will benefit from this increased robustness. Functionality remains unchanged except where users opt to alter the default timeout, thus maintaining backward compatibility while offering improved performance for specific use cases.

## Test Plan

1. **Default Behavior**: Verify that the application behaves as expected with the default 20-minute timeout.
2. **Custom Timeout**: Test with various custom timeouts (e.g., `30s`, `45m`) to ensure they are correctly applied and do not affect other functionalities.
3. **Edge Cases**: Ensure the system handles edge cases, such as extremely short or long timeouts gracefully without crashing.
4. **Ollama Specific Tests**: Focus on Ollama requests to confirm that the timeout adjustment works specifically for this vendor.
