### PR TITLE
fix: Add configurable HTTP timeout for Ollama client

### DIFF
--- a/plugins/ai/ollama/ollama.go
+++ b/plugins/ai/ollama/ollama.go
@@ -33,6 +33,9 @@ func NewClient() (ret *Client) {
 	ret.ApiUrl.Value = defaultBaseUrl
 	ret.ApiKey = ret.PluginBase.AddSetupQuestion("API key", false)
 	ret.ApiKey.Value = ""
+	ret.ApiHttpTimeout = ret.AddSetupQuestionCustom("HTTP Timeout", true,
+		"Specify HTTP timeout duration for Ollama requests (e.g. 30s, 5m, 1h)")
+	ret.ApiHttpTimeout.Value = "20m"
 
 	return
 }
@@ -43,6 +46,7 @@ type Client struct {
 	ApiKey *plugins.SetupQuestion
 	apiUrl *url.URL
 	client *ollamaapi.Client
+	ApiHttpTimeout *plugins.SetupQuestion
 }
 
 type transport_sec struct {
@@ -63,7 +67,19 @@ func (o *Client) configure() (err error) {
 		return
 	}
 
-	o.client = ollamaapi.NewClient(o.apiUrl, &http.Client{Timeout: 1200000 * time.Millisecond, Transport: &transport_sec{underlyingTransport: http.DefaultTransport, ApiKey: o.ApiKey}})
+	timeout := 20 * time.Minute // Default timeout
+
+	if o.ApiHttpTimeout != nil {
+		parsed, err := time.ParseDuration(o.ApiHttpTimeout.Value)
+		if err == nil && o.ApiHttpTimeout.Value != "" {
+			timeout = parsed
+		} else if o.ApiHttpTimeout.Value != "" {
+			fmt.Printf("Invalid HTTP timeout format (%q), using default (20m): %v\n", o.ApiHttpTimeout.Value, err)
+		}
+	}
+
+	o.client = ollamaapi.NewClient(o.apiUrl, &http.Client{Timeout: timeout, Transport: &transport_sec{underlyingTransport: http.DefaultTransport, ApiKey: o.ApiKey}})
+
 	return
 }
 


### PR DESCRIPTION
# Pull Request Description

## Summary

This pull request introduces a configurable HTTP timeout for Ollama API requests within the `ollama.go` file. It adds a new setup question allowing users to specify a custom HTTP timeout duration with validation and default handling.

## Files Changed

- **plugins/ai/ollama/ollama.go**: Modified to include a new configuration option for setting an HTTP timeout for Ollama API requests.

### Detailed Changes in `ollama.go`

#### New Setup Question
- Added a setup question `ApiHttpTimeout` which allows users to specify the desired HTTP request timeout duration.
  ```go
  ret.ApiHttpTimeout = ret.AddSetupQuestionCustom("HTTP Timeout", true,
      "Specify HTTP timeout duration for Ollama requests (e.g. 30s, 5m, 1h)")
  ret.ApiHttpTimeout.Value = "20m"
  ```

#### Client Configuration Update
- Modified the `configure` function to parse and apply this custom timeout value:
  ```go
  timeout := 20 * time.Minute // Default timeout

  if o.ApiHttpTimeout != nil {
      parsed, err := time.ParseDuration(o.ApiHttpTimeout.Value)
      if err == nil && o.ApiHttpTimeout.Value != "" {
          timeout = parsed
      } else if o.ApiHttpTimeout.Value != "" {
          fmt.Printf("Invalid HTTP timeout format (%q), using default (20m): %v\n", o.ApiHttpTimeout.Value, err)
      }
  }

  o.client = ollamaapi.NewClient(o.apiUrl, &http.Client{Timeout: timeout, Transport: &transport_sec{underlyingTransport: http.DefaultTransport, ApiKey: o.ApiKey}})
  ```

## Reason for Changes

The primary reason for this update is to provide flexibility in network conditions by allowing users to specify how long the Ollama client should wait before timing out on API requests. This change helps in environments with variable network performance, where a fixed timeout might either be too short or unnecessarily long.

## Impact of Changes

- **Flexibility**: Users now have control over the timeout settings which can lead to improved reliability and user experience under different network conditions.
- **Error Handling**: The implementation includes handling for invalid formats, falling back to a default 20-minute timeout if parsing fails. This ensures robustness and informs users of incorrect inputs.

## Test Plan

1. **Functional Testing**:
   - Verify that the `HTTP Timeout` setup question appears correctly in the configuration interface.
   - Check that valid input values (e.g., "30s", "5m", "1h") are parsed correctly and applied as expected.

2. **Error Handling**:
   - Test with invalid timeout formats to ensure appropriate error messages are logged and the default value is used.

3. **Default Behavior**:
   - Confirm that when no custom timeout is set, the client defaults to a 20-minute timeout.

## Additional Notes

This change assumes that the user has familiarity with Go's time parsing capabilities (`time.ParseDuration`). The implementation ensures backward compatibility by maintaining existing behavior if no new configuration is provided. Future enhancements could include more descriptive error messages or additional validation for extreme values.
