### PR TITLE
fix: fix web search tool location

### DIFF
--- a/cli/flags.go
+++ b/cli/flags.go
@@ -159,7 +159,7 @@ func Init() (ret *Flags, err error) {
 	// Handle stdin and messages
 	// Handle stdin and messages
 	info, _ := os.Stdin.Stat()
-	pipedToStdin := (info.Mode()&os.ModeCharDevice) == 0 && !debug
+	pipedToStdin := (info.Mode() & os.ModeCharDevice) == 0
 
 	// Append positional arguments to the message (custom message)
 	if len(args) > 0 {

--- a/plugins/ai/anthropic/anthropic.go
+++ b/plugins/ai/anthropic/anthropic.go
@@ -137,7 +137,7 @@ func (an *Client) buildMessageParams(msgs []anthropic.MessageParam, opts *common
 			// MaxUses:        anthropic.Opt[int64](5),
 		}
 
-		if an.WebToolLocation.Value == "" {
+		if an.WebToolLocation.Value != "" {
 			webTool.UserLocation.Type = "approximate"
 			webTool.UserLocation.Timezone = anthropic.Opt(an.WebToolLocation.Value)
 		}


### PR DESCRIPTION
## What this Pull Request (PR) does

This PR implements support for the Anthropic Web Search Tool, allowing the AI model to perform web searches to enhance its responses.
See https://docs.anthropic.com/en/docs/agents-and-tools/tool-use/web-search-tool

Additionally, new configuration parameters have been added to facilitate the setup and customization of the Anthropic AI integration.

## Changes:

* **`plugins/ai/anthropic/anthropic.go`**:
    * Introduced `UseWebTool` and `WebToolLocation` as new `SetupQuestion` parameters for enabling and configuring the web search tool.
    * Modified `SendStream` and `Send` methods to incorporate the web search tool definition within the Anthropic `MessageNewParams` when `UseWebTool` is enabled.
    * Refactored message parameter building into a new `buildMessageParams` function for reusability.
    * Improved handling of content blocks from Anthropic responses to correctly extract and join text content.
* **`plugins/plugin.go`**:
    * Added `SettingTypeBool` constant and `Type` field to the `Setting` struct to support boolean configuration values.
    * Implemented `AddSetupQuestionBool` and `AddSetupQuestionCustomBool` methods to simplify the creation of boolean setup questions.
    * Updated `IsValid` and `Print` methods of `Setting` to correctly handle and display boolean values.
    * Adjusted `FillEnvFileContent` to write boolean values appropriately to the `.env` file.
    * Modified `SetupQuestion.Ask` and `SetupQuestion.OnAnswer` to provide appropriate prompts and handle input for boolean settings.

## How to test

1.  Configure the Anthropic plugin.
2.  Enable the "Web Search Tool Enabled" option during setup.
3.  Optionally, specify a "Web Search Tool Location".
4.  Interact with the Anthropic model and observe if it utilizes web search for relevant queries.