### PR TITLE
feat: cleanup after `yt-dlp` addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,12 @@ Fabric is graciously supported by…
 ## Updates
 
 > [!NOTE]
+>June 11, 2025
+>
+> - Fabric's YouTube transcription now needs `yt-dlp` to be installed. Make sure to install the latest
+>   version (2025.06.09 as of this note). The YouTube API key is only needed for comments (the `--comments` flag)
+>   and metadata extraction (the `--metadata` flag).
+>
 > May 22, 2025
 >
 > - Fabric now supports Anthropic's Claude 4. Read the [blog post from Anthropic](https://www.anthropic.com/news/claude-4).


### PR DESCRIPTION
# feat: cleanup after `yt-dlp` addition

## Summary

This PR updates Fabric's YouTube functionality to clarify that `yt-dlp` is now the primary requirement for transcript extraction, while the YouTube API key is only needed for optional features like comments and metadata extraction.

## Files Changed

### README.md
Added a new update note to inform users about the YouTube transcription changes and requirements.

### plugins/tools/youtube/youtube.go
- Updated package documentation to clarify requirements
- Modified setup description to be more explicit about what each component does
- Added validation to ensure API key is present when needed for comments/metadata
- Removed unnecessary service initialization from `GetVideoOrPlaylistId`

## Code Changes

### README.md
```diff
+>June 11, 2025
+>
+> - Fabric's YouTube transcription now needs `yt-dlp` to be installed. Make sure to install the latest
+>   version (2025.06.09 as of this note). The YouTube API key is only needed for comments (the `--comments` flag)
+>   and metadata extraction (the `--metadata` flag).
```

### plugins/tools/youtube/youtube.go

**Package Documentation Update:**
```diff
 // Package youtube provides YouTube video transcript and comment extraction functionality.
-// This implementation relies on yt-dlp for reliable transcript extraction, which must be
-// installed separately. The old YouTube API scraping methods have been removed due to
-// YouTube's frequent changes and rate limiting.
+//
+// Requirements:
+// - yt-dlp: Required for transcript extraction (must be installed separately)
+// - YouTube API key: Optional, only needed for comments and metadata extraction
+//
+// The implementation uses yt-dlp for reliable transcript extraction and the YouTube API
+// for comments/metadata. Old YouTube scraping methods have been removed due to
+// frequent changes and rate limiting.
```

**Setup Description Clarification:**
```diff
-SetupDescription: label + " - to grab video transcripts and comments",
+SetupDescription: label + " - to grab video transcripts (via yt-dlp) and comments/metadata (via YouTube API)",
```

**API Key Validation:**
```diff
 func (o *YouTube) initService() (err error) {
 	if o.service == nil {
+		if o.ApiKey.Value == "" {
+			err = fmt.Errorf("YouTube API key required for comments and metadata. Run 'fabric --setup' to configure")
+			return
+		}
```

**Removed Unnecessary Service Initialization:**
```diff
 func (o *YouTube) GetVideoOrPlaylistId(url string) (videoId string, playlistId string, err error) {
-	if err = o.initService(); err != nil {
-		return
-	}
-
```

## Reason for Changes

These changes address user confusion about YouTube functionality requirements. Previously, users might assume they needed a YouTube API key for all features, when in fact:
- Transcript extraction only requires `yt-dlp` (no API key needed)
- Only comments and metadata extraction require the YouTube API key

This separation allows users who only need transcripts to use the tool without obtaining an API key.

## Impact of Changes

1. **Improved User Experience**: Users can now use transcript extraction without needing to set up a YouTube API key
2. **Clearer Error Messages**: When API key is required but missing, users get a helpful error message
3. **Better Documentation**: Both code comments and README clearly explain what's required for each feature
4. **Performance**: Slight improvement by not initializing the YouTube service when just parsing video IDs

## Test Plan

1. Test transcript extraction without API key configured - should work with yt-dlp
2. Test comments extraction without API key - should fail with clear error message
3. Test metadata extraction without API key - should fail with clear error message
4. Test all features with API key configured - should work as before
5. Verify `GetVideoOrPlaylistId` works without initializing the service

## Additional Notes

- Users upgrading should ensure they have the latest version of `yt-dlp` (2025.06.09 or later)
- This change maintains backward compatibility for users who have API keys configured
- The error message directs users to run `fabric --setup` if they need to configure an API key

## Screenshot of new setup

![image](https://github.com/user-attachments/assets/78d4f0fc-b97a-49a7-a8b8-3ba7d4eaa5b8)
