### PR TITLE
Fix: Prevent race conditions in versioning workflow.

### DIFF
--- a/.github/workflows/update-version-and-create-tag.yml
+++ b/.github/workflows/update-version-and-create-tag.yml
@@ -11,6 +11,10 @@ on:
 permissions:
   contents: write  # Ensure the workflow has write permissions
 
+concurrency:
+  group: version-update
+  cancel-in-progress: false
+
 jobs:
   update-version:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
@@ -29,6 +33,11 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Pull latest main and tags
+        run: |
+          git pull --rebase origin main
+          git fetch --tags
 
       - name: Get the latest tag
         id: get_latest_tag


### PR DESCRIPTION
# Fix: Prevent race conditions in versioning workflow.

## Summary

This PR adds concurrency control and improves git synchronization to the GitHub Actions workflow that handles automatic version updates and tag creation. The changes prevent race conditions when multiple workflow runs are triggered and ensure the workflow always operates on the latest state of the repository.

## Related Issues

Closes #1501 

## Files Changed

- **.github/workflows/update-version-and-create-tag.yml**: Added concurrency group configuration and enhanced git synchronization steps to prevent conflicts and ensure the workflow operates on the latest repository state.

## Code Changes

### .github/workflows/update-version-and-create-tag.yml

#### Added concurrency control:
```yaml
concurrency:
  group: version-update
  cancel-in-progress: false
```
This ensures only one instance of the version update workflow runs at a time, preventing race conditions when multiple commits trigger the workflow simultaneously.

#### Added git synchronization step:
```yaml
- name: Pull latest main and tags
  run: |
    git pull --rebase origin main
    git fetch --tags
```
This new step ensures the workflow has the latest changes from the main branch and all tags before attempting to create a new version tag.

## Reason for Changes

These changes address potential race conditions and synchronization issues in the automated versioning workflow:

1. **Concurrency Control**: Without concurrency limits, multiple workflow runs could execute simultaneously (e.g., from rapid successive merges), potentially creating duplicate tags or version conflicts.

2. **Git Synchronization**: The workflow needs to ensure it has the latest state of the repository before determining the next version number and creating tags, especially important when multiple PRs are merged in quick succession.

## Impact of Changes

- **Improved Reliability**: The workflow will now handle rapid successive merges more reliably without creating duplicate tags or version conflicts.
- **Sequential Processing**: Version updates will be processed sequentially rather than in parallel, ensuring consistent version numbering.
- **No Workflow Cancellation**: Setting `cancel-in-progress: false` ensures that once a version update starts, it will complete even if another trigger occurs.
- **Better State Management**: The workflow will always operate on the most current repository state, reducing the chance of conflicts during tag creation.

## Test Plan

1. Merge multiple PRs in quick succession to verify only one version update runs at a time
2. Verify that the workflow correctly pulls the latest changes before creating new tags
3. Confirm that version numbers increment correctly without gaps or duplicates
4. Test that the workflow handles scenarios where tags have been created externally between workflow runs

## Concurrent PR Merge Process

The diagram below illustrates how the `update-version-and-create-tag` workflow behaves when multiple pull requests are merged into `main` at nearly the same time.

```mermaid
flowchart TD
    subgraph Merge Events
        PR1[PR 1 merges] --> WF1[Workflow Run 1]
        PR2[PR 2 merges] --> WF2[Workflow Run 2]
    end

    subgraph GitHub Actions
        WF1 --> Checkout1[Checkout repo]
        WF2 -. queued .-> Wait[Waiting for concurrency slot]
        Checkout1 --> Rebase1[Rebase & fetch tags]
        Rebase1 --> Version1[Compute new tag]
        Version1 --> Commit1[Commit & push]
        Commit1 --> Complete1[Run 1 complete]
        Wait --> Checkout2[Checkout repo]
        Checkout2 --> Rebase2[Rebase & fetch tags]
        Rebase2 --> Version2[Compute new tag]
        Version2 --> Commit2[Commit & push]
        Commit2 --> Complete2[Run 2 complete]
    end
```

The concurrency settings ensure that while Workflow Run 1 is executing, Workflow Run 2 is paused. Once Run 1 finishes updating the version and pushing the tag, Run 2 resumes and rebases on the latest `main` so that it can apply its own version bump safely.


## Additional Notes

- The concurrency group name "version-update" is unique to this workflow, preventing interference with other workflows
- The `cancel-in-progress: false` setting is crucial here as we don't want to cancel a version update that's already in progress
- The git pull uses `--rebase` to maintain a clean history when pulling the latest changes
