### PR TITLE
Added check for AWS_DEFAULT_REGION when AWS access keys are configured in the environment

### DIFF
--- a/core/plugin_registry.go
+++ b/core/plugin_registry.go
@@ -44,7 +44,8 @@ import (
 func hasAWSCredentials() bool {
 	if os.Getenv("AWS_PROFILE") != "" ||
 		os.Getenv("AWS_ROLE_SESSION_NAME") != "" ||
-		(os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "") {
+		(os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "" && os.Getenv("AWS_DEFAULT_REGION") != "") {
+
 		return true
 	}
 


### PR DESCRIPTION
Updated hasAWSCredentials to also check for AWS_DEFAULT_REGION when access keys are configured in the environment

## What this Pull Request (PR) does
Adds a check for AWS_DEFAULT_REGION in the hasAWSCredentials function. This is required when using AWS creds set in the environment. 

## Related issues
Extends: [1523](https://github.com/danielmiessler/fabric/pull/1523)
