### PR TITLE
0626 fix yt in web interface

### DIFF
--- a/restapi/serve.go
+++ b/restapi/serve.go
@@ -26,6 +26,7 @@ func Serve(registry *core.PluginRegistry, address string, apiKey string) (err er
 	NewContextsHandler(r, fabricDb.Contexts)
 	NewSessionsHandler(r, fabricDb.Sessions)
 	NewChatHandler(r, registry, fabricDb)
+	NewYouTubeHandler(r, registry)
 	NewConfigHandler(r, fabricDb)
 	NewModelsHandler(r, registry.VendorManager)
 	NewStrategiesHandler(r)

--- a/restapi/youtube.go
+++ b/restapi/youtube.go
@@ -1,0 +1,70 @@
+package restapi
+
+import (
+	"net/http"
+
+	"github.com/danielmiessler/fabric/core"
+	"github.com/danielmiessler/fabric/plugins/tools/youtube"
+	"github.com/gin-gonic/gin"
+)
+
+type YouTubeHandler struct {
+	yt *youtube.YouTube
+}
+
+type YouTubeRequest struct {
+	URL        string `json:"url"`
+	Language   string `json:"language"`
+	Timestamps bool   `json:"timestamps"`
+}
+
+type YouTubeResponse struct {
+	Transcript string `json:"transcript"`
+	Title      string `json:"title"`
+}
+
+func NewYouTubeHandler(r *gin.Engine, registry *core.PluginRegistry) *YouTubeHandler {
+	handler := &YouTubeHandler{yt: registry.YouTube}
+	r.POST("/youtube/transcript", handler.Transcript)
+	return handler
+}
+
+func (h *YouTubeHandler) Transcript(c *gin.Context) {
+	var req YouTubeRequest
+	if err := c.BindJSON(&req); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "invalid request"})
+		return
+	}
+	if req.URL == "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "url is required"})
+		return
+	}
+	language := req.Language
+	if language == "" {
+		language = "en"
+	}
+
+	var videoID, playlistID string
+	var err error
+	if videoID, playlistID, err = h.yt.GetVideoOrPlaylistId(req.URL); err != nil {
+		c.JSON(http.StatusBadRequest, gin.H{"error": err.Error()})
+		return
+	}
+	if videoID == "" && playlistID != "" {
+		c.JSON(http.StatusBadRequest, gin.H{"error": "URL is a playlist, not a video"})
+		return
+	}
+
+	var transcript string
+	if req.Timestamps {
+		transcript, err = h.yt.GrabTranscriptWithTimestamps(videoID, language)
+	} else {
+		transcript, err = h.yt.GrabTranscript(videoID, language)
+	}
+	if err != nil {
+		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
+		return
+	}
+
+	c.JSON(http.StatusOK, YouTubeResponse{Transcript: transcript, Title: videoID})
+}

--- a/web/src/lib/services/transcriptService.ts
+++ b/web/src/lib/services/transcriptService.ts
@@ -18,13 +18,13 @@ export async function getTranscript(url: string): Promise<TranscriptResponse> {
     console.log('\n=== YouTube Transcript Service Start ===');
     console.log('1. Request details:', {
       url,
-      endpoint: '/youtube/transcript',
+      endpoint: '/api/youtube/transcript',
       method: 'POST',
       isYouTubeURL: url.includes('youtube.com') || url.includes('youtu.be'),
       originalLanguage
     });
 
-    const response = await fetch('/youtube/transcript', {
+    const response = await fetch('/api/youtube/transcript', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',

--- a/web/src/lib/services/transcriptService.ts
+++ b/web/src/lib/services/transcriptService.ts
@@ -1,5 +1,5 @@
-import { get } from 'svelte/store';
 import { languageStore } from '$lib/store/language-store';
+import { get } from 'svelte/store';
 
 export interface TranscriptResponse {
   transcript: string;
@@ -18,18 +18,18 @@ export async function getTranscript(url: string): Promise<TranscriptResponse> {
     console.log('\n=== YouTube Transcript Service Start ===');
     console.log('1. Request details:', {
       url,
-      endpoint: '/chat',
+      endpoint: '/youtube/transcript',
       method: 'POST',
       isYouTubeURL: url.includes('youtube.com') || url.includes('youtu.be'),
       originalLanguage
     });
 
-    const response = await fetch('/chat', {
+    const response = await fetch('/youtube/transcript', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
       },
-      body: JSON.stringify({ 
+      body: JSON.stringify({
         url,
         language: originalLanguage // Pass original language to server
       })


### PR DESCRIPTION
# 

## Summary

This PR adds a dedicated YouTube transcript endpoint to the REST API, separating YouTube transcript functionality from the general chat endpoint. The implementation includes a new handler for YouTube-specific operations and updates the frontend to use this new endpoint.

## Related issues

Closes #1520 

## Screenshots

![image](https://github.com/user-attachments/assets/e0d5108c-3b52-4551-992d-0ad922a1e7d6)

This produced this output:

![image](https://github.com/user-attachments/assets/6d3a07c7-face-46d6-89b1-79789fd3284b)

## Summary

This PR adds a dedicated YouTube transcript endpoint to the REST API, separating YouTube transcript functionality from the general chat endpoint. The implementation includes a new handler for YouTube-specific operations and updates the frontend to use this new endpoint.

## Files Changed

- **restapi/serve.go**: Added registration for the new YouTube handler in the API server initialization
- **restapi/youtube.go**: New file implementing the YouTube transcript endpoint with proper request/response structures
- **web/src/lib/services/transcriptService.ts**: Updated the frontend service to use the new dedicated YouTube endpoint instead of the general chat endpoint

## Code Changes

### restapi/serve.go
```go
+	NewYouTubeHandler(r, registry)
```
Added handler registration to expose the YouTube functionality through the REST API.

### restapi/youtube.go
```go
+type YouTubeRequest struct {
+	URL        string `json:"url"`
+	Language   string `json:"language"`
+	Timestamps bool   `json:"timestamps"`
+}
+
+type YouTubeResponse struct {
+	Transcript string `json:"transcript"`
+	Title      string `json:"title"`
+}
```
Defined clear request/response structures for the YouTube transcript API, supporting language selection and optional timestamps.

```go
+func (h *YouTubeHandler) Transcript(c *gin.Context) {
+	// ... validation and processing logic
+	if req.Timestamps {
+		transcript, err = h.yt.GrabTranscriptWithTimestamps(videoID, language)
+	} else {
+		transcript, err = h.yt.GrabTranscript(videoID, language)
+	}
+	// ...
+}
```
Implemented the transcript endpoint with proper validation, error handling, and support for both timestamped and non-timestamped transcripts.

### web/src/lib/services/transcriptService.ts
```typescript
-      endpoint: '/chat',
+      endpoint: '/api/youtube/transcript',
```
Updated the frontend to use the new dedicated YouTube endpoint.

## Reason for Changes

This change improves the API design by:
1. **Separation of Concerns**: YouTube transcript functionality now has its own dedicated endpoint rather than being mixed with general chat functionality
2. **Better API Design**: Clear, purpose-built request/response structures for YouTube operations
3. **Enhanced Features**: Added support for timestamp inclusion in transcripts
4. **Improved Error Handling**: Specific validation for YouTube URLs and playlist detection

## Impact of Changes

- **API Structure**: Introduces a new `/youtube/transcript` endpoint, making the API more RESTful and organized
- **Backward Compatibility**: The old chat endpoint remains unchanged, ensuring existing integrations continue to work
- **Frontend Integration**: The web UI now uses the dedicated endpoint for YouTube transcripts
- **Performance**: No performance impact expected; the underlying YouTube service remains the same

## Test Plan

1. Test valid YouTube video URLs return transcripts successfully
2. Test language parameter properly affects transcript language selection
3. Test timestamp flag correctly includes/excludes timestamps in response
4. Test error cases:
   - Invalid URLs
   - Playlist URLs (should return error)
   - Missing required parameters
   - Invalid video IDs
5. Verify frontend correctly displays transcripts from the new endpoint

## Additional Notes

- The handler properly validates playlist URLs and returns an appropriate error message
- Default language is set to "en" if not specified
- The response includes both transcript and title (currently using videoID as title, which might need refinement in future iterations)
- Error responses follow consistent JSON structure with error messages
