### PR TITLE
Fix Cross-Platform Compatibility in Release Workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Go Release
 
 on:
   repository_dispatch:
-    types: [ tag_created ]
+    types: [tag_created]
   push:
     tags:
       - "v*"
@@ -108,6 +108,7 @@ jobs:
           Add-Content -Path $env:GITHUB_ENV -Value "latest_tag=$latest_tag"
 
       - name: Create release if it doesn't exist
+        shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |


### PR DESCRIPTION
# Fix Cross-Platform Compatibility in Release Workflow

## Summary

This PR addresses cross-platform compatibility issues in the GitHub Actions release workflow by explicitly specifying the bash shell for a command that was previously failing on Windows runners.

## Related Issues

Closes #1561 

## Files Changed

- `.github/workflows/release.yml`: Added explicit shell specification and minor formatting adjustment

## Code Changes

### `.github/workflows/release.yml`

1. **Formatting adjustment** (line 5):
   ```yaml
   - types: [ tag_created ]
   + types: [tag_created]
   ```
   Minor formatting change removing spaces inside brackets for consistency.

2. **Shell specification added** (line 111):
   ```yaml
   - name: Create release if it doesn't exist
   + shell: bash
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   ```
   Added explicit `shell: bash` directive to ensure the step runs with bash shell across all platforms.

## Reason for Changes

The "Create release if it doesn't exist" step was likely failing on Windows runners because it was using shell-specific commands or syntax that are not compatible with the default Windows shell (PowerShell/cmd). By explicitly specifying `shell: bash`, we ensure that:

1. The step uses bash regardless of the runner's operating system
2. Shell commands and syntax remain consistent across all platforms
3. The workflow can successfully execute on Windows, macOS, and Linux runners

## Impact of Changes

- **Improved reliability**: The release workflow will now work consistently across all GitHub Actions runner platforms
- **No functional changes**: The actual release process remains unchanged; only the execution environment is specified
- **Better maintainability**: Explicit shell specification makes the workflow's requirements clear to future contributors

## Test Plan

To verify these changes:
1. The workflow should be triggered on the next tag push or repository dispatch event
2. Monitor the "Create release if it doesn't exist" step execution on Windows runners
3. Confirm that the step completes successfully without shell-related errors

## Additional Notes

This is a common issue in GitHub Actions workflows where steps that work on Linux/macOS runners fail on Windows due to shell differences. Best practice is to always specify the shell when using shell-specific syntax or commands to ensure cross-platform compatibility.
