### PR TITLE
Add Custom Patterns Directory Support

### DIFF
--- a/core/plugin_registry.go
+++ b/core/plugin_registry.go
@@ -31,6 +31,7 @@ import (
 	"github.com/danielmiessler/fabric/plugins/db/fsdb"
 	"github.com/danielmiessler/fabric/plugins/template"
 	"github.com/danielmiessler/fabric/plugins/tools"
+	"github.com/danielmiessler/fabric/plugins/tools/custom_patterns"
 	"github.com/danielmiessler/fabric/plugins/tools/jina"
 	"github.com/danielmiessler/fabric/plugins/tools/lang"
 	"github.com/danielmiessler/fabric/plugins/tools/youtube"
@@ -69,6 +70,7 @@ func NewPluginRegistry(db *fsdb.Db) (ret *PluginRegistry, err error) {
 		VendorManager:  ai.NewVendorsManager(),
 		VendorsAll:     ai.NewVendorsManager(),
 		PatternsLoader: tools.NewPatternsLoader(db.Patterns),
+		CustomPatterns: custom_patterns.NewCustomPatterns(),
 		YouTube:        youtube.NewYouTube(),
 		Language:       lang.NewLanguage(),
 		Jina:           jina.NewClient(),
@@ -138,6 +140,7 @@ type PluginRegistry struct {
 	VendorsAll         *ai.VendorsManager
 	Defaults           *tools.Defaults
 	PatternsLoader     *tools.PatternsLoader
+	CustomPatterns     *custom_patterns.CustomPatterns
 	YouTube            *youtube.YouTube
 	Language           *lang.Language
 	Jina               *jina.Client
@@ -151,6 +154,7 @@ func (o *PluginRegistry) SaveEnvFile() (err error) {
 
 	o.Defaults.Settings.FillEnvFileContent(&envFileContent)
 	o.PatternsLoader.SetupFillEnvFileContent(&envFileContent)
+	o.CustomPatterns.SetupFillEnvFileContent(&envFileContent)
 	o.Strategies.SetupFillEnvFileContent(&envFileContent)
 
 	for _, vendor := range o.VendorManager.Vendors {
@@ -183,7 +187,7 @@ func (o *PluginRegistry) Setup() (err error) {
 			return vendor
 		})...)
 
-	groupsPlugins.AddGroupItems("Tools", o.Defaults, o.Jina, o.Language, o.PatternsLoader, o.Strategies, o.YouTube)
+	groupsPlugins.AddGroupItems("Tools", o.CustomPatterns, o.Defaults, o.Jina, o.Language, o.PatternsLoader, o.Strategies, o.YouTube)
 
 	for {
 		groupsPlugins.Print(false)

--- a/plugins/db/fsdb/db.go
+++ b/plugins/db/fsdb/db.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/joho/godotenv"
@@ -15,10 +16,22 @@ func NewDb(dir string) (db *Db) {
 
 	db.EnvFilePath = db.FilePath(".env")
 
+	// Check for custom patterns directory from environment variable
+	customPatternsDir := os.Getenv("CUSTOM_PATTERNS_DIRECTORY")
+	if customPatternsDir != "" {
+		// Expand home directory if needed
+		if strings.HasPrefix(customPatternsDir, "~/") {
+			if homeDir, err := os.UserHomeDir(); err == nil {
+				customPatternsDir = filepath.Join(homeDir, customPatternsDir[2:])
+			}
+		}
+	}
+
 	db.Patterns = &PatternsEntity{
 		StorageEntity:          &StorageEntity{Label: "Patterns", Dir: db.FilePath("patterns"), ItemIsDir: true},
 		SystemPatternFile:      "system.md",
 		UniquePatternsFilePath: db.FilePath("unique_patterns.txt"),
+		CustomPatternsDir:      customPatternsDir,
 	}
 
 	db.Sessions = &SessionsEntity{

--- a/plugins/tools/custom_patterns/custom_patterns.go
+++ b/plugins/tools/custom_patterns/custom_patterns.go
@@ -1,0 +1,61 @@
+package custom_patterns
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/danielmiessler/fabric/plugins"
+)
+
+func NewCustomPatterns() (ret *CustomPatterns) {
+	label := "Custom Patterns"
+	ret = &CustomPatterns{}
+
+	ret.PluginBase = &plugins.PluginBase{
+		Name:             label,
+		SetupDescription: "Custom Patterns - Set directory for your custom patterns (optional)",
+		EnvNamePrefix:    plugins.BuildEnvVariablePrefix(label),
+		ConfigureCustom:  ret.configure,
+	}
+
+	ret.CustomPatternsDir = ret.AddSetupQuestionCustom("Directory", false,
+		"Enter the path to your custom patterns directory (leave empty to skip)")
+
+	return
+}
+
+type CustomPatterns struct {
+	*plugins.PluginBase
+	CustomPatternsDir *plugins.SetupQuestion
+}
+
+func (o *CustomPatterns) configure() error {
+	if o.CustomPatternsDir.Value != "" {
+		// Expand home directory if needed
+		if strings.HasPrefix(o.CustomPatternsDir.Value, "~/") {
+			if homeDir, err := os.UserHomeDir(); err == nil {
+				o.CustomPatternsDir.Value = filepath.Join(homeDir, o.CustomPatternsDir.Value[2:])
+			}
+		}
+
+		// Convert to absolute path
+		if absPath, err := filepath.Abs(o.CustomPatternsDir.Value); err == nil {
+			o.CustomPatternsDir.Value = absPath
+		}
+
+		// Create the directory if it doesn't exist
+		if err := os.MkdirAll(o.CustomPatternsDir.Value, 0755); err != nil {
+			// If we can't create it, clear the value to avoid errors
+			o.CustomPatternsDir.Value = ""
+		}
+	}
+
+	return nil
+}
+
+// IsConfigured returns true if a custom patterns directory has been set
+func (o *CustomPatterns) IsConfigured() bool {
+	// Check if the plugin has been configured with a directory
+	return o.CustomPatternsDir.Value != ""
+}

--- a/plugins/tools/custom_patterns/custom_patterns_test.go
+++ b/plugins/tools/custom_patterns/custom_patterns_test.go
@@ -1,0 +1,79 @@
+package custom_patterns
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestNewCustomPatterns(t *testing.T) {
+	plugin := NewCustomPatterns()
+
+	assert.NotNil(t, plugin)
+	assert.Equal(t, "Custom Patterns", plugin.GetName())
+	assert.Equal(t, "Custom Patterns - Set directory for your custom patterns (optional)", plugin.GetSetupDescription())
+	assert.False(t, plugin.IsConfigured()) // Should not be configured initially
+}
+func TestCustomPatterns_Configure(t *testing.T) {
+	plugin := NewCustomPatterns()
+
+	// Test with empty directory (should work)
+	plugin.CustomPatternsDir.Value = ""
+	err := plugin.configure()
+	assert.NoError(t, err)
+
+	// Test with home directory expansion
+	plugin.CustomPatternsDir.Value = "~/test-patterns"
+	err = plugin.configure()
+	assert.NoError(t, err)
+
+	homeDir, _ := os.UserHomeDir()
+	expectedPath := filepath.Join(homeDir, "test-patterns")
+	absExpected, _ := filepath.Abs(expectedPath)
+	assert.Equal(t, absExpected, plugin.CustomPatternsDir.Value)
+
+	// Clean up
+	os.RemoveAll(plugin.CustomPatternsDir.Value)
+}
+
+func TestCustomPatterns_ConfigureWithTempDir(t *testing.T) {
+	plugin := NewCustomPatterns()
+
+	// Test with a temporary directory
+	tmpDir, err := os.MkdirTemp("", "test-custom-patterns-*")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmpDir)
+
+	plugin.CustomPatternsDir.Value = tmpDir
+	err = plugin.configure()
+	assert.NoError(t, err)
+
+	absPath, _ := filepath.Abs(tmpDir)
+	assert.Equal(t, absPath, plugin.CustomPatternsDir.Value)
+
+	// Verify directory exists
+	info, err := os.Stat(plugin.CustomPatternsDir.Value)
+	assert.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// Should be configured now
+	assert.True(t, plugin.IsConfigured())
+}
+
+func TestCustomPatterns_IsConfigured(t *testing.T) {
+	plugin := NewCustomPatterns()
+
+	// Initially not configured
+	assert.False(t, plugin.IsConfigured())
+
+	// Set a directory
+	plugin.CustomPatternsDir.Value = "/some/path"
+	assert.True(t, plugin.IsConfigured())
+
+	// Clear the directory
+	plugin.CustomPatternsDir.Value = ""
+	assert.False(t, plugin.IsConfigured())
+}


### PR DESCRIPTION
# Add Custom Patterns Directory Support

## Summary

This pull request adds support for custom patterns directories in the Fabric application, allowing users to specify an external directory for storing and loading custom patterns alongside the default patterns. The implementation includes proper plugin registration, environment variable support, and comprehensive test coverage.

## Related Issues

Closes #1567 #1404 #972 #331

## Files Changed

### `core/plugin_registry.go`
- Added import for the new `custom_patterns` plugin
- Integrated `CustomPatterns` plugin into the registry structure
- Added plugin to the setup flow and environment file management

### `plugins/db/fsdb/db.go`
- Added support for `CUSTOM_PATTERNS_DIRECTORY` environment variable
- Implemented home directory expansion for custom patterns path
- Extended `PatternsEntity` to include custom patterns directory configuration

### `plugins/db/fsdb/patterns.go`
- Modified `getFromDB()` to check custom patterns directory first before fallback to main patterns
- Overrode `GetNames()` to include patterns from both main and custom directories
- Added logic to handle custom patterns taking precedence over main patterns with the same name

### `plugins/db/fsdb/patterns_test.go`
- Added comprehensive test coverage for custom patterns functionality
- Tests cover pattern override behavior, directory precedence, and error handling

### `plugins/tools/custom_patterns/custom_patterns.go` (New)
- Created new plugin for managing custom patterns directory configuration
- Implements directory path validation, home directory expansion, and automatic directory creation
- Provides setup interface for user configuration

### `plugins/tools/custom_patterns/custom_patterns_test.go` (New)
- Complete test suite for the custom patterns plugin
- Tests configuration, directory handling, and validation logic

## Code Changes

### Key Implementation Details

The custom patterns functionality works by:

1. **Plugin Registration**: The `CustomPatterns` plugin is registered in the main plugin registry and appears in the setup flow.

2. **Directory Precedence**: When loading patterns, the system first checks the custom patterns directory, then falls back to the main patterns directory:
```go
// First check custom patterns directory if it exists
if o.CustomPatternsDir != "" {
    customPatternPath := filepath.Join(o.CustomPatternsDir, name, o.SystemPatternFile)
    if pattern, customErr := os.ReadFile(customPatternPath); customErr == nil {
        ret = &Pattern{
            Name:    name,
            Pattern: string(pattern),
        }
        return ret, nil
    }
}
```

3. **Pattern Discovery**: The `GetNames()` method combines patterns from both directories, with custom patterns taking precedence over main patterns with the same name.

## Reason for Changes

This feature addresses the need for users to maintain their own custom patterns separate from the main Fabric patterns repository. It allows for:
- Personal pattern libraries that persist across updates
- Organization-specific patterns
- Testing new patterns without modifying the main patterns directory
- Easy sharing of custom patterns between team members

## Impact of Changes

### Positive Impacts
- **Enhanced Flexibility**: Users can now maintain custom patterns without modifying the core Fabric installation
- **Better Organization**: Separation of custom and default patterns
- **Backward Compatibility**: Existing functionality remains unchanged for users who don't use custom patterns
- **Override Capability**: Custom patterns can override default patterns with the same name

### Potential Considerations
- **Pattern Name Conflicts**: Custom patterns will silently override main patterns with the same name
- **Directory Management**: Users are responsible for managing their custom patterns directory structure
- **Error Handling**: Invalid custom patterns directory paths are handled gracefully but may not provide detailed feedback

## Test Plan

The implementation includes comprehensive unit tests covering:
- Plugin initialization and configuration
- Custom patterns directory setup and validation
- Pattern loading precedence (custom over main)
- Directory expansion and path handling
- Error handling for invalid or missing directories
- Integration with existing patterns functionality

### Manual Testing Recommendations
1. Configure a custom patterns directory through the setup process
2. Create patterns in both main and custom directories with the same name
3. Verify custom patterns take precedence
4. Test with various path formats (relative, absolute, home directory expansion)
5. Verify environment variable `CUSTOM_PATTERNS_DIRECTORY` is respected

## Additional Notes

- The implementation maintains full backward compatibility
- Custom patterns directory is optional and the system works normally without it
- The plugin follows the established patterns for other Fabric plugins
- Error handling is defensive - invalid custom directories are ignored rather than causing failures
- The feature integrates seamlessly with existing pattern management workflows