### PR TITLE
Document Custom Patterns Directory Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,9 @@ Keep in mind that many of these were recorded when Fabric was Python-based, so r
   - [Just use the Patterns](#just-use-the-patterns)
     - [Prompt Strategies](#prompt-strategies)
   - [Custom Patterns](#custom-patterns)
+    - [Setting Up Custom Patterns](#setting-up-custom-patterns)
+    - [Using Custom Patterns](#using-custom-patterns)
+    - [How It Works](#how-it-works)
   - [Helper Apps](#helper-apps)
     - [`to_pdf`](#to_pdf)
     - [`to_pdf` Installation](#to_pdf-installation)
@@ -652,11 +655,48 @@ Use `fabric -S` and select the option to install the strategies in your `~/.conf
 
 You may want to use Fabric to create your own custom Patterns—but not share them with others. No problem!
 
-Just make a directory in `~/.config/custompatterns/` (or wherever) and put your `.md` files in there.
+Fabric now supports a dedicated custom patterns directory that keeps your personal patterns separate from the built-in ones. This means your custom patterns won't be overwritten when you update Fabric's built-in patterns.
 
-When you're ready to use them, copy them into `~/.config/fabric/patterns/`
+### Setting Up Custom Patterns
 
-You can then use them like any other Patterns, but they won't be public unless you explicitly submit them as Pull Requests to the Fabric project. So don't worry—they're private to you.
+1. Run the Fabric setup:
+
+   ```bash
+   fabric --setup
+   ```
+
+2. Select the "Custom Patterns" option from the Tools menu and enter your desired directory path (e.g., `~/my-custom-patterns`)
+
+3. Fabric will automatically create the directory if it does not exist.
+
+### Using Custom Patterns
+
+1. Create your custom pattern directory structure:
+
+   ```bash
+   mkdir -p ~/my-custom-patterns/my-analyzer
+   ```
+
+2. Create your pattern file
+
+   ```bash
+   echo "You are an expert analyzer of ..." > ~/my-custom-patterns/my-analyzer/system.md
+   ```
+
+3. **Use your custom pattern:**
+
+   ```bash
+   fabric --pattern my-analyzer "analyze this text"
+   ```
+
+### How It Works
+
+- **Priority System**: Custom patterns take precedence over built-in patterns with the same name
+- **Seamless Integration**: Custom patterns appear in `fabric --listpatterns` alongside built-in ones
+- **Update Safe**: Your custom patterns are never affected by `fabric --updatepatterns`
+- **Private by Default**: Custom patterns remain private unless you explicitly share them
+
+Your custom patterns are completely private and won't be affected by Fabric updates!
 
 ## Helper Apps
 


### PR DESCRIPTION
# Document Custom Patterns Directory Support

## Summary

This PR introduces a dedicated custom patterns directory feature that allows users to create and manage personal patterns separately from Fabric's built-in patterns. The implementation provides a clean separation between user-created patterns and the core pattern library, ensuring custom patterns persist through updates.

## Files Changed

- **README.md**: Updated documentation to reflect the new custom patterns functionality, replacing the previous manual workflow with an automated setup process.

## Code Changes

The documentation changes include:

1. **Enhanced Table of Contents**: Added three new subsections under "Custom Patterns":
   ```markdown
   - [Setting Up Custom Patterns](#setting-up-custom-patterns)
   - [Using Custom Patterns](#using-custom-patterns)
   - [How It Works](#how-it-works)
   ```

2. **Replaced Manual Process**: The old documentation described a manual copy-paste workflow:
   ```markdown
   Just make a directory in `~/.config/custompatterns/` (or wherever) and put your `.md` files in there.
   When you're ready to use them, copy them into `~/.config/fabric/patterns/`
   ```

3. **New Automated Setup**: Introduced setup command integration:
   ```bash
   fabric --setup
   ```

4. **Clear Usage Instructions**: Added step-by-step pattern creation and usage examples with proper directory structure and command syntax.

## Reason for Changes

This change addresses several pain points in the previous custom patterns workflow:

- **Manual Management**: Users previously had to manually copy patterns between directories
- **Update Conflicts**: Custom patterns could be overwritten during built-in pattern updates
- **Poor User Experience**: The workflow was cumbersome and error-prone
- **No Integration**: Custom patterns weren't properly integrated with Fabric's pattern discovery system

## Impact of Changes

**Positive Impacts:**
- **Improved User Experience**: Streamlined setup process through the `--setup` command
- **Data Safety**: Custom patterns are protected from being overwritten during updates
- **Better Organization**: Clear separation between built-in and custom patterns
- **Enhanced Discoverability**: Custom patterns appear in `--listpatterns` output
- **Priority System**: Custom patterns can override built-in patterns with the same name

**Potential Considerations:**
- **Migration Path**: Existing users with custom patterns in the old location may need guidance on migration
- **Directory Management**: Users need to understand the new directory structure
- **Pattern Naming**: Name conflicts between custom and built-in patterns are resolved by priority system

## Test Plan

The documentation changes should be tested by:

1. **Setup Process**: Verify the `fabric --setup` command correctly creates custom pattern directories
2. **Pattern Creation**: Test creating custom patterns in the new directory structure
3. **Pattern Discovery**: Confirm custom patterns appear in `--listpatterns` output
4. **Pattern Execution**: Validate custom patterns can be executed with `--pattern` flag
5. **Priority System**: Test that custom patterns override built-in patterns with identical names
6. **Update Safety**: Verify `--updatepatterns` doesn't affect custom patterns

## Additional Notes

- The documentation maintains backward compatibility information while promoting the new workflow
- The feature appears to integrate with Fabric's existing setup system, suggesting minimal disruption to current users
- The priority system design allows for pattern customization and extension of built-in functionality
- This change positions Fabric for better extensibility and user customization in future releases