### PR TITLE
Fix Custom Patterns Directory Creation Logic

### DIFF
--- a/plugins/tools/custom_patterns/custom_patterns.go
+++ b/plugins/tools/custom_patterns/custom_patterns.go
@@ -1,6 +1,7 @@
 package custom_patterns
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -44,10 +45,12 @@ func (o *CustomPatterns) configure() error {
 			o.CustomPatternsDir.Value = absPath
 		}
 
-		// Create the directory if it doesn't exist
-		if err := os.MkdirAll(o.CustomPatternsDir.Value, 0755); err != nil {
-			// If we can't create it, clear the value to avoid errors
-			o.CustomPatternsDir.Value = ""
+		// Check if directory exists, create only if it doesn't
+		if _, err := os.Stat(o.CustomPatternsDir.Value); os.IsNotExist(err) {
+			if err := os.MkdirAll(o.CustomPatternsDir.Value, 0755); err != nil {
+				// Log the error but don't clear the value - let it persist in env file
+				fmt.Printf("Warning: Could not create custom patterns directory %s: %v\n", o.CustomPatternsDir.Value, err)
+			}
 		}
 	}
 


### PR DESCRIPTION
# Fix Custom Patterns Directory Creation Logic

## Summary

This pull request improves the directory creation logic in the custom patterns plugin by adding proper existence checks and better error handling. The changes prevent unnecessary directory creation attempts and provide more informative error messages while preserving the configured directory path.

## Files Changed

- `plugins/tools/custom_patterns/custom_patterns.go`: Modified the `configure()` method to improve directory creation logic and error handling

## Code Changes

### plugins/tools/custom_patterns/custom_patterns.go

**Added import:**
```go
import (
+	"fmt"
	"os"
	"path/filepath"
	"strings"
```

**Modified directory creation logic:**
```go
-		// Create the directory if it doesn't exist
-		if err := os.MkdirAll(o.CustomPatternsDir.Value, 0755); err != nil {
-			// If we can't create it, clear the value to avoid errors
-			o.CustomPatternsDir.Value = ""
+		// Check if directory exists, create only if it doesn't
+		if _, err := os.Stat(o.CustomPatternsDir.Value); os.IsNotExist(err) {
+			if err := os.MkdirAll(o.CustomPatternsDir.Value, 0755); err != nil {
+				// Log the error but don't clear the value - let it persist in env file
+				fmt.Printf("Warning: Could not create custom patterns directory %s: %v\n", o.CustomPatternsDir.Value, err)
+			}
+		}
```

## Reason for Changes

The original implementation had several issues:
1. It attempted to create the directory every time `configure()` was called, even if the directory already existed
2. It cleared the configured directory path on creation failure, which could lead to loss of user configuration
3. It provided no feedback when directory creation failed

## Impact of Changes

**Positive impacts:**
- **Performance improvement**: Eliminates unnecessary `os.MkdirAll()` calls when the directory already exists
- **Configuration preservation**: The configured directory path is now preserved even if creation fails, allowing users to fix permissions or create the directory manually
- **Better user experience**: Users now receive clear warning messages when directory creation fails
- **Reduced system calls**: The `os.Stat()` check is more efficient than always attempting directory creation

**Potential considerations:**
- The warning message is printed to stdout, which may not be ideal for all deployment scenarios
- The code now makes an additional system call (`os.Stat()`) before directory creation, though this is offset by avoiding unnecessary `MkdirAll()` calls

## Test Plan

The changes should be tested by:
1. Verifying that existing directories are not recreated unnecessarily
2. Testing directory creation when the path doesn't exist
3. Confirming that configuration values persist when directory creation fails due to permissions
4. Validating that appropriate warning messages are displayed on creation failures

## Additional Notes

- The `fmt` package import was added to support the new warning message functionality
- The error handling approach now follows a "fail gracefully" pattern, allowing the application to continue functioning even when the custom patterns directory cannot be created
- Users can now manually create the directory or fix permissions after seeing the warning message, and the configuration will remain intact