### PR TITLE
Fix to persist the CUSTOM_PATTERNS_DIRECTORY variable

### DIFF
--- a/plugins/tools/custom_patterns/custom_patterns.go
+++ b/plugins/tools/custom_patterns/custom_patterns.go
@@ -59,6 +59,8 @@ func (o *CustomPatterns) configure() error {
 
 // IsConfigured returns true if a custom patterns directory has been set
 func (o *CustomPatterns) IsConfigured() bool {
+	// First configure to load values from environment variables
+	o.Configure()
 	// Check if the plugin has been configured with a directory
 	return o.CustomPatternsDir.Value != ""
 }


### PR DESCRIPTION
# Fix to persist the CUSTOM_PATTERNS_DIRECTORY variable

## Summary

Fixed a configuration issue in the CustomPatterns plugin where the `IsConfigured()` method was not properly initializing configuration values from environment variables before checking if the plugin was configured.

## Files Changed

- **plugins/tools/custom_patterns/custom_patterns.go**: Modified the `IsConfigured()` method to ensure proper configuration loading before validation.

## Code Changes

### plugins/tools/custom_patterns/custom_patterns.go

Added a call to `Configure()` at the beginning of the `IsConfigured()` method:

```go
func (o *CustomPatterns) IsConfigured() bool {
	// First configure to load values from environment variables
	o.Configure()
	// Check if the plugin has been configured with a directory
	return o.CustomPatternsDir.Value != ""
}
```

The change adds two lines:
1. A comment explaining the purpose of the configuration call
2. A call to `o.Configure()` to ensure configuration values are loaded

## Reason for Changes

This change addresses a potential race condition or initialization issue where `IsConfigured()` could return false even when valid configuration exists in environment variables. Without calling `Configure()` first, the `CustomPatternsDir.Value` field might not be populated from environment variables, leading to incorrect configuration state detection.

## Impact of Changes

- **Positive Impact**: Ensures reliable configuration state detection by guaranteeing that environment variables are loaded before validation
- **Behavioral Change**: `IsConfigured()` will now have the side effect of loading configuration if not already loaded
- **Performance**: Minimal impact as `Configure()` should be idempotent and only perform initialization once

## Test Plan

The changes should be tested by:
1. Setting custom patterns directory via environment variables
2. Calling `IsConfigured()` before any explicit `Configure()` calls
3. Verifying that `IsConfigured()` returns true when environment variables are properly set
4. Testing that multiple calls to `IsConfigured()` don't cause issues (idempotency)

## Additional Notes

**Potential Considerations:**
- The `Configure()` method should be idempotent to avoid issues with multiple calls
- This change makes `IsConfigured()` have side effects, which may not be expected behavior for a query method
- Consider if there are any error conditions from `Configure()` that should be handled
- Verify that concurrent access to `IsConfigured()` is safe if the plugin is used in multi-threaded contexts

**Alternative Approach**: Consider whether the configuration should be loaded once during plugin initialization rather than on-demand in `IsConfigured()` to maintain cleaner separation of concerns.