### PR TITLE
Do not pass non-default TopP values

### DIFF
--- a/plugins/ai/openai/chat_completions.go
+++ b/plugins/ai/openai/chat_completions.go
@@ -69,7 +69,9 @@ func (o *Client) buildChatCompletionParams(
 
 	if !opts.Raw {
 		ret.Temperature = openai.Float(opts.Temperature)
-		ret.TopP = openai.Float(opts.TopP)
+		if opts.TopP != 0 {
+			ret.TopP = openai.Float(opts.TopP)
+		}
 		if opts.MaxTokens != 0 {
 			ret.MaxTokens = openai.Int(int64(opts.MaxTokens))
 		}

--- a/plugins/ai/openai/openai.go
+++ b/plugins/ai/openai/openai.go
@@ -221,7 +221,9 @@ func (o *Client) buildResponseParams(
 
 	if !opts.Raw {
 		ret.Temperature = openai.Float(opts.Temperature)
-		ret.TopP = openai.Float(opts.TopP)
+		if opts.TopP != 0 {
+			ret.TopP = openai.Float(opts.TopP)
+		}
 		if opts.MaxTokens != 0 {
 			ret.MaxOutputTokens = openai.Int(int64(opts.MaxTokens))
 		}


### PR DESCRIPTION
# Do not pass non-default TopP values

## Summary

This pull request adds conditional logic to prevent setting the `TopP` parameter when its value is 0 (zero) in OpenAI API requests. The change affects both chat completions and general response parameter building functions.

## Related Issues

Closes #1588 

## Files Changed

- **`plugins/ai/openai/chat_completions.go`**: Modified the `buildChatCompletionParams` function to conditionally set the `TopP` parameter
- **`plugins/ai/openai/openai.go`**: Modified the `buildResponseParams` function to conditionally set the `TopP` parameter

## Code Changes

### plugins/ai/openai/chat_completions.go
```go
// Before
ret.TopP = openai.Float(opts.TopP)

// After  
if opts.TopP != 0 {
    ret.TopP = openai.Float(opts.TopP)
}
```

### plugins/ai/openai/openai.go
```go
// Before
ret.TopP = openai.Float(opts.TopP)

// After
if opts.TopP != 0 {
    ret.TopP = openai.Float(opts.TopP)
}
```

Both changes follow the same pattern as the existing `MaxTokens` parameter handling, where the parameter is only set when the value is non-zero.

## Reason for Changes

The changes prevent sending a `TopP` value of 0 to the OpenAI API when it hasn't been explicitly set by the user. This is likely to:

1. Allow OpenAI to use its default `TopP` value instead of forcing it to 0
2. Maintain consistency with how other optional parameters like `MaxTokens` are handled
3. Avoid potential issues where a `TopP` of 0 might cause unexpected behavior in the API

## Impact of Changes

- **Positive Impact**: The OpenAI API will receive more appropriate default parameters when `TopP` is not explicitly configured
- **Behavioral Change**: When `opts.TopP` is 0, the parameter will now be omitted from API requests rather than explicitly set to 0
- **Consistency**: Aligns `TopP` parameter handling with the existing `MaxTokens` parameter logic

## Test Plan

The changes should be tested by:

1. Verifying that API requests work correctly when `TopP` is not set (should omit the parameter)
2. Confirming that API requests still include `TopP` when explicitly set to a non-zero value
3. Testing both chat completions and general response scenarios
4. Ensuring backward compatibility with existing configurations

## Screenshots

This was causing this error in the Web UI

![image](https://github.com/user-attachments/assets/64394dff-e27c-42f4-8615-44932cc97c36)

## Additional Notes

**Potential Considerations:**
- The change assumes that a `TopP` value of 0 indicates "not set" rather than an intentional setting. If there are legitimate use cases for explicitly setting `TopP` to 0, this change could break that functionality
- The logic treats 0 as the "unset" value, which is consistent with Go's zero-value semantics but may not align with OpenAI's API expectations if 0 is a valid `TopP` value
- Consider whether a pointer type or optional wrapper might be more appropriate for truly optional parameters to distinguish between "not set" and "set to 0"

The changes are minimal and follow established patterns in the codebase, reducing the risk of introducing bugs while improving parameter handling consistency.