### PR TITLE
Together AI Support with OpenAI Fallback Mechanism Added

### DIFF
--- a/internal/plugins/ai/openai_compatible/direct_models_call.go
+++ b/internal/plugins/ai/openai_compatible/direct_models_call.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
+	"net/url"
 	"time"
 )
 
@@ -19,20 +19,18 @@ type Model struct {
 // when the standard OpenAI SDK method fails due to a nonstandard format.
 // This is useful for providers like Together that return a direct array of models.
 func (c *Client) DirectlyGetModels() ([]string, error) {
-	url := c.ApiBaseURL.Value
-	if url == "" {
+	baseURL := c.ApiBaseURL.Value
+	if baseURL == "" {
 		return nil, fmt.Errorf("API base URL not configured")
 	}
 
-	// Ensure URL ends with /models
-	if !strings.HasSuffix(url, "/models") {
-		if !strings.HasSuffix(url, "/") {
-			url += "/"
-		}
-		url += "models"
+	// Build the /models endpoint URL
+	fullURL, err := url.JoinPath(baseURL, "models")
+	if err != nil {
+		return nil, fmt.Errorf("failed to create models URL: %w", err)
 	}
 
-	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", fullURL, nil)
 	if err != nil {
 		return nil, err
 	} else {

--- a/internal/plugins/ai/openai_compatible/direct_models_call.go
+++ b/internal/plugins/ai/openai_compatible/direct_models_call.go
@@ -88,7 +88,13 @@ func (c *Client) DirectlyGetModels(ctx context.Context) ([]string, error) {
 		return extractModelIDs(directArray), nil
 	}
 
-	return nil, fmt.Errorf("unable to parse models response; raw response: %s", string(bodyBytes)[:errorResponseLimit])
+	var truncatedBody string
+	if len(bodyBytes) > errorResponseLimit {
+		truncatedBody = string(bodyBytes[:errorResponseLimit]) + "..."
+	} else {
+		truncatedBody = string(bodyBytes)
+	}
+	return nil, fmt.Errorf("unable to parse models response; raw response: %s", truncatedBody)
 }
 
 func extractModelIDs(models []Model) []string {

--- a/internal/plugins/ai/openai_compatible/direct_models_call.go
+++ b/internal/plugins/ai/openai_compatible/direct_models_call.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"strings"
 )
@@ -41,7 +42,14 @@ func (c *Client) DirectlyGetModels() ([]string, error) {
 	defer resp.Body.Close()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+		// Read the response body for debugging
+		bodyBytes, _ := io.ReadAll(resp.Body)
+		bodyString := string(bodyBytes)
+		if len(bodyString) > 500 { // Truncate if too large
+			bodyString = bodyString[:500] + "..."
+		}
+		return nil, fmt.Errorf("unexpected status code: %d from provider %s, response body: %s",
+			resp.StatusCode, c.GetName(), bodyString)
 	}
 
 	// Read the response body
@@ -78,5 +86,5 @@ func (c *Client) DirectlyGetModels() ([]string, error) {
 		return modelIDs, nil
 	}
 
-	return nil, fmt.Errorf("unable to parse models response")
+	return nil, fmt.Errorf("unable to parse models response; raw response: %s", string(body))
 }

--- a/internal/plugins/ai/openai_compatible/direct_models_call.go
+++ b/internal/plugins/ai/openai_compatible/direct_models_call.go
@@ -66,7 +66,6 @@ func (c *Client) DirectlyGetModels(ctx context.Context) ([]string, error) {
 			resp.StatusCode, c.GetName(), bodyString)
 	}
 
-	// Read the response body
 	// Read the response body once
 	bodyBytes, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -98,7 +97,7 @@ func (c *Client) DirectlyGetModels(ctx context.Context) ([]string, error) {
 }
 
 func extractModelIDs(models []Model) []string {
-	var modelIDs []string
+	modelIDs := make([]string, 0, len(models))
 	for _, model := range models {
 		modelIDs = append(modelIDs, model.ID)
 	}

--- a/internal/plugins/ai/openai_compatible/direct_models_call.go
+++ b/internal/plugins/ai/openai_compatible/direct_models_call.go
@@ -39,10 +39,12 @@ func (c *Client) DirectlyGetModels(ctx context.Context) ([]string, error) {
 	req, err := http.NewRequestWithContext(ctx, "GET", fullURL, nil)
 	if err != nil {
 		return nil, err
-	} else {
-		req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.ApiKey.Value))
-		req.Header.Set("Accept", "application/json")
 	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.ApiKey.Value))
+	req.Header.Set("Accept", "application/json")
+
+	// TODO: Consider reusing a single http.Client instance (e.g., as a field on Client) instead of allocating a new one for each request.
 
 	client := &http.Client{
 		Timeout: 10 * time.Second,
@@ -86,7 +88,7 @@ func (c *Client) DirectlyGetModels(ctx context.Context) ([]string, error) {
 		return extractModelIDs(directArray), nil
 	}
 
-	return nil, fmt.Errorf("unable to parse models response; raw response: %s", string(bodyBytes))
+	return nil, fmt.Errorf("unable to parse models response; raw response: %s", string(bodyBytes)[:errorResponseLimit])
 }
 
 func extractModelIDs(models []Model) []string {

--- a/internal/plugins/ai/openai_compatible/direct_models_call.go
+++ b/internal/plugins/ai/openai_compatible/direct_models_call.go
@@ -26,7 +26,7 @@ func (c *Client) DirectlyGetModels(ctx context.Context) ([]string, error) {
 	}
 	baseURL := c.ApiBaseURL.Value
 	if baseURL == "" {
-		return nil, fmt.Errorf("API base URL not configured")
+		return nil, fmt.Errorf("API base URL not configured for provider %s", c.GetName())
 	}
 
 	// Build the /models endpoint URL

--- a/internal/plugins/ai/openai_compatible/direct_models_call.go
+++ b/internal/plugins/ai/openai_compatible/direct_models_call.go
@@ -1,0 +1,82 @@
+package openai_compatible
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+// DirectlyGetModels is used to fetch models directly from the API
+// when the standard OpenAI SDK method fails due to a nonstandard format.
+// This is useful for providers like Together that return a direct array of models.
+func (c *Client) DirectlyGetModels() ([]string, error) {
+	url := c.ApiBaseURL.Value
+	if url == "" {
+		return nil, fmt.Errorf("API base URL not configured")
+	}
+
+	// Ensure URL ends with /models
+	if !strings.HasSuffix(url, "/models") {
+		if !strings.HasSuffix(url, "/") {
+			url += "/"
+		}
+		url += "models"
+	}
+
+	req, err := http.NewRequestWithContext(context.Background(), "GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", c.ApiKey.Value))
+	req.Header.Set("Accept", "application/json")
+
+	client := &http.Client{}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("unexpected status code: %d", resp.StatusCode)
+	}
+
+	// Read the response body
+	var body json.RawMessage
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return nil, err
+	}
+
+	// Try to parse as an object with data field (OpenAI format)
+	var openAIFormat struct {
+		Data []struct {
+			ID string `json:"id"`
+		} `json:"data"`
+	}
+
+	if err := json.Unmarshal(body, &openAIFormat); err == nil && len(openAIFormat.Data) > 0 {
+		var modelIDs []string
+		for _, model := range openAIFormat.Data {
+			modelIDs = append(modelIDs, model.ID)
+		}
+		return modelIDs, nil
+	}
+
+	// Try to parse as a direct array (Together format)
+	var directArray []struct {
+		ID string `json:"id"`
+	}
+
+	if err := json.Unmarshal(body, &directArray); err == nil {
+		var modelIDs []string
+		for _, model := range directArray {
+			modelIDs = append(modelIDs, model.ID)
+		}
+		return modelIDs, nil
+	}
+
+	return nil, fmt.Errorf("unable to parse models response")
+}

--- a/internal/plugins/ai/openai_compatible/direct_models_call.go
+++ b/internal/plugins/ai/openai_compatible/direct_models_call.go
@@ -15,7 +15,8 @@ type Model struct {
 	ID string `json:"id"`
 }
 
-const errorResponseLimit = 500
+// ErrorResponseLimit defines the maximum length of error response bodies for truncation.
+const errorResponseLimit = 1024 // Limit for error response body size
 
 // DirectlyGetModels is used to fetch models directly from the API
 // when the standard OpenAI SDK method fails due to a nonstandard format.
@@ -77,20 +78,20 @@ func (c *Client) DirectlyGetModels(ctx context.Context) ([]string, error) {
 	var directArray []Model
 
 	if err := json.Unmarshal(body, &openAIFormat); err == nil && len(openAIFormat.Data) > 0 {
-		return extractModelIDs(openAIFormat.Data)
+		return extractModelIDs(openAIFormat.Data), nil
 	}
 
 	if err := json.Unmarshal(body, &directArray); err == nil && len(directArray) > 0 {
-		return extractModelIDs(directArray)
+		return extractModelIDs(directArray), nil
 	}
 
 	return nil, fmt.Errorf("unable to parse models response; raw response: %s", string(body))
 }
 
-func extractModelIDs(models []Model) ([]string, error) {
+func extractModelIDs(models []Model) []string {
 	var modelIDs []string
 	for _, model := range models {
 		modelIDs = append(modelIDs, model.ID)
 	}
-	return modelIDs, nil
+	return modelIDs
 }

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -40,6 +40,8 @@ func (c *Client) ListModels() ([]string, error) {
 		return models, nil
 	}
 
+	// TODO: Handle context properly in Fabric by accepting and propagating a context.Context
+	// instead of creating a new one here.
 	return c.DirectlyGetModels(context.Background())
 }
 

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -31,6 +31,17 @@ func NewClient(providerConfig ProviderConfig) *Client {
 	return client
 }
 
+// ListModels overrides the default ListModels to handle different response formats
+func (c *Client) ListModels() ([]string, error) {
+	// First try the standard OpenAI SDK approach
+	models, err := c.Client.ListModels()
+	if err == nil && len(models) > 0 { // only return if OpenAI SDK returns models
+		return models, nil
+	}
+
+	return c.DirectlyGetModels()
+}
+
 // ProviderMap is a map of provider name to ProviderConfig for O(1) lookup
 var ProviderMap = map[string]ProviderConfig{
 	"AIML": {
@@ -81,6 +92,11 @@ var ProviderMap = map[string]ProviderConfig{
 	"SiliconCloud": {
 		Name:                "SiliconCloud",
 		BaseURL:             "https://api.siliconflow.cn/v1",
+		ImplementsResponses: false,
+	},
+	"Together": {
+		Name:                "Together",
+		BaseURL:             "https://api.together.xyz/v1",
 		ImplementsResponses: false,
 	},
 }

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -1,6 +1,7 @@
 package openai_compatible
 
 import (
+	"context"
 	"os"
 	"strings"
 
@@ -39,7 +40,7 @@ func (c *Client) ListModels() ([]string, error) {
 		return models, nil
 	}
 
-	return c.DirectlyGetModels()
+	return c.DirectlyGetModels(context.Background())
 }
 
 // ProviderMap is a map of provider name to ProviderConfig for O(1) lookup


### PR DESCRIPTION
# Together AI Support with OpenAI Fallback Mechanism Added

## Summary

This pull request adds support for the Together AI provider and implements a fallback mechanism for fetching models from OpenAI-compatible APIs that return non-standard response formats. The changes include a new direct API call method and enhanced model listing functionality.

## Related Issues

Closes #1602 

## Demo

```text
$ git diff --staged | summarize_git_diff -m deepseek-ai/DeepSeek-R1-Distill-Llama-70B-free
<think>
Okay, so I need to figure out the major changes and upgrades from the given Git diff.
Let's look at the input files.

First, there's a new file added: direct_models_call.go. It contains a function DirectlyGetModels which seems
to fetch models directly from an API. The function constructs a URL, makes a GET request, handles
different response formats (OpenAI and Together), and parses the JSON responses.

Next, in providers_config.go, the ListModels method is overridden. It first tries the standard OpenAI SDK
method. If that doesn't return models, it falls back to the new DirectlyGetModels function. Also, a new
provider "Together" is added to the ProviderMap with its configuration.

So the main changes are adding a new method to handle direct model fetching and updating the provider
list to include Together. The intro should reflect that a new method was added and the provider was included.

Now, for the CHANGES section, I need to create succinct bullets. Each bullet should describe a feature 
change. The first bullet could be about adding the new method. The second about adding Together as a
provider. The third about the fallback behavior in ListModels.

I need to keep each bullet under 10 words and use imperative verbs. Also, ensure the commit prefix is
correct. Since this is a new feature, it should be "feat:".

Putting it all together, the intro sentence and the three bullets should cover the main points 
without being too wordy.
</think>

**feat: add direct model fetching support for non-standard providers**

**CHANGES**
- Add `DirectlyGetModels` function to handle non-standard API responses
- Add Together provider configuration to ProviderMap
- Implement fallback to direct model fetching when standard method fails
```

## Files Changed

### `internal/plugins/ai/openai_compatible/direct_models_call.go` (New File)
- **Added**: New file containing the `DirectlyGetModels()` method
- **Purpose**: Provides a fallback mechanism for fetching models when the standard OpenAI SDK fails due to non-standard API response formats

### `internal/plugins/ai/openai_compatible/providers_config.go` (Modified)
- **Added**: New `ListModels()` method that overrides the default implementation
- **Added**: Together AI provider configuration in the `ProviderMap`
- **Purpose**: Enhances model listing with fallback support and adds Together AI as a supported provider

## Code Changes

### New Direct Models Call Implementation

```go
func (c *Client) DirectlyGetModels() ([]string, error) {
    // Constructs API URL and makes direct HTTP request
    // Handles both OpenAI format (object with data field) and direct array format
    // Returns list of model IDs
}
```

The method implements dual parsing logic:
1. First attempts to parse as OpenAI standard format (`{data: [{id: "model"}]}`)
2. Falls back to direct array format (`[{id: "model"}]`) for providers like Together

### Enhanced Model Listing

```go
func (c *Client) ListModels() ([]string, error) {
    models, err := c.Client.ListModels()
    if err == nil && len(models) > 0 {
        return models, nil
    }
    return c.DirectlyGetModels()
}
```

This method provides a graceful fallback mechanism that tries the standard OpenAI SDK first, then falls back to the direct API call if needed.

## Reason for Changes

The changes address compatibility issues with OpenAI-compatible API providers that don't strictly follow the OpenAI API response format. Specifically:

1. **Together AI Support**: Adds Together AI as a supported provider, which returns models in a direct array format rather than the standard OpenAI object format
2. **Improved Robustness**: Provides fallback mechanisms for model fetching when providers use non-standard response formats
3. **Backward Compatibility**: Maintains existing functionality while adding enhanced support for edge cases

## Impact of Changes

### Positive Impacts
- **Extended Provider Support**: Users can now use Together AI as an OpenAI-compatible provider
- **Improved Reliability**: Model fetching is more robust and handles various API response formats
- **Better User Experience**: Reduces failures when working with non-standard OpenAI-compatible APIs

### Potential Risks
- **Additional HTTP Requests**: The fallback mechanism may result in extra API calls if the primary method fails
- **Response Parsing Complexity**: The dual parsing logic adds complexity and potential points of failure
- **Error Handling**: If both methods fail, error messages may not clearly indicate which approach failed

## Test Plan

The changes should be tested with:

1. **Standard OpenAI API**: Verify that existing functionality remains intact
2. **Together AI Provider**: Test model listing and basic functionality with Together AI
3. **Other OpenAI-compatible providers**: Ensure the fallback mechanism doesn't break existing providers
4. **Error Scenarios**: Test behavior when API calls fail, return invalid JSON, or return unexpected formats
5. **Edge Cases**: Test with empty responses, malformed JSON, and network timeouts

## Additional Notes

- The implementation assumes that model objects contain an `id` field, which is standard across most providers
- The method uses `json.RawMessage` to efficiently handle dual parsing without multiple JSON decoding operations
- Error handling could be enhanced to provide more specific error messages indicating which parsing method failed
- Consider adding logging to track which parsing method is used for debugging purposes
- The Together AI provider is configured with `ImplementsResponses: false`, which may need adjustment based on actual API capabilities