### PR TITLE
Update GitHub Workflow to Ignore Additional File Paths

### DIFF
--- a/.github/workflows/update-version-and-create-tag.yml
+++ b/.github/workflows/update-version-and-create-tag.yml
@@ -7,6 +7,8 @@ on:
     paths-ignore:
       - "data/patterns/**"
       - "**/*.md"
+      - "data/strategies/**"
+      - "cmd/generate_changelog/*.db"
 
 permissions:
   contents: write # Ensure the workflow has write permissions


### PR DESCRIPTION

# Update GitHub Workflow to Ignore Additional File Paths

## Summary

This PR modifies the GitHub workflow configuration to exclude additional file paths from triggering the version update and tag creation workflow. The changes add two new path patterns to the `paths-ignore` list in the workflow trigger configuration.

## Files Changed

- **`.github/workflows/update-version-and-create-tag.yml`**: Updated the workflow trigger configuration to ignore additional file paths that should not trigger version updates and tag creation.

## Code Changes

The following paths were added to the `paths-ignore` section of the workflow trigger:

```yaml
- "data/strategies/**"
- "cmd/generate_changelog/*.db"
```

These additions expand the existing ignore patterns which already included:
- `"data/patterns/**"`
- `"**/*.md"`

## Reason for Changes

These changes prevent the version update and tag creation workflow from being triggered by:

1. **Strategy files** (`data/strategies/**`): Changes to strategy files do not merit a new release.
2. **Database files** (`cmd/generate_changelog/*.db`): Database files in the changelog generation command are cache files used to regenerate the CHANGELOG.md file.

This follows the same pattern as the existing ignores for pattern data files and markdown documentation, which are considered non-release-worthy changes.

## Impact of Changes

- **Reduced unnecessary workflow runs**: The workflow will no longer trigger for changes to strategy files or changelog database files, reducing CI/CD resource usage
- **More precise release triggers**: Version updates and tags will only be created for substantive code changes, not for data or temporary file updates
- **Improved workflow efficiency**: Fewer false-positive triggers will result in a cleaner release history

## Test Plan

- Verify that changes to files matching `data/strategies/**` do not trigger the workflow
- Verify that changes to files matching `cmd/generate_changelog/*.db` do not trigger the workflow
- Confirm that substantive code changes outside these paths still trigger the workflow as expected
- Test that the existing ignore patterns continue to work correctly

## Additional Notes

This change maintains consistency with the existing workflow design philosophy of ignoring non-code changes that don't impact the application's functionality. The workflow will continue to trigger for all other file changes, ensuring that actual code modifications still result in appropriate version updates and tag creation.