### PR TITLE
YouTube VTT Processing Enhancement

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -53,6 +53,7 @@
 		"hasura",
 		"hormozi",
 		"Hormozi's",
+		"horts",
 		"HTMLURL",
 		"jaredmontoya",
 		"jessevdk",
@@ -74,6 +75,7 @@
 		"markmap",
 		"matplotlib",
 		"mattn",
+		"mbed",
 		"Miessler",
 		"nometa",
 		"numpy",
@@ -114,11 +116,13 @@
 		"updatepatterns",
 		"videoid",
 		"webp",
+		"WEBVTT",
 		"wipecontext",
 		"wipesession",
 		"writeups",
 		"xclip",
-		"yourpatternname"
+		"yourpatternname",
+		"youtu"
 	],
 	"cSpell.ignorePaths": ["go.mod", ".gitignore", "CHANGELOG.md"],
 	"markdownlint.config": {

--- a/internal/tools/youtube/timestamp_test.go
+++ b/internal/tools/youtube/timestamp_test.go
@@ -44,9 +44,10 @@ func TestShouldIncludeRepeat(t *testing.T) {
 		description      string
 	}{
 		{"00:30", "01:30", true, "60 second gap should allow repeat"},
-		{"00:30", "00:45", false, "15 second gap should not allow repeat"},
-		{"01:00", "01:30", true, "30 second gap should allow repeat (boundary case)"},
-		{"01:00", "01:29", false, "29 second gap should not allow repeat"},
+		{"00:30", "00:45", true, "15 second gap should allow repeat"},
+		{"01:00", "01:10", true, "10 second gap should allow repeat (boundary case)"},
+		{"01:00", "01:09", false, "9 second gap should not allow repeat"},
+		{"00:30", "00:35", false, "5 second gap should not allow repeat"},
 		{"invalid", "01:30", true, "invalid timestamp should err on side of inclusion"},
 		{"01:30", "invalid", true, "invalid timestamp should err on side of inclusion"},
 	}

--- a/internal/tools/youtube/timestamp_test.go
+++ b/internal/tools/youtube/timestamp_test.go
@@ -1,0 +1,60 @@
+package youtube
+
+import (
+	"testing"
+)
+
+func TestParseTimestampToSeconds(t *testing.T) {
+	tests := []struct {
+		timestamp string
+		expected  int
+		shouldErr bool
+	}{
+		{"00:30", 30, false},
+		{"01:30", 90, false},
+		{"01:05:30", 3930, false}, // 1 hour 5 minutes 30 seconds
+		{"10:00", 600, false},
+		{"invalid", 0, true},
+		{"1:2:3:4", 0, true}, // too many parts
+	}
+
+	for _, test := range tests {
+		result, err := parseTimestampToSeconds(test.timestamp)
+
+		if test.shouldErr {
+			if err == nil {
+				t.Errorf("Expected error for timestamp %s, but got none", test.timestamp)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("Unexpected error for timestamp %s: %v", test.timestamp, err)
+			}
+			if result != test.expected {
+				t.Errorf("For timestamp %s, expected %d seconds, got %d", test.timestamp, test.expected, result)
+			}
+		}
+	}
+}
+
+func TestShouldIncludeRepeat(t *testing.T) {
+	tests := []struct {
+		lastTimestamp    string
+		currentTimestamp string
+		expected         bool
+		description      string
+	}{
+		{"00:30", "01:30", true, "60 second gap should allow repeat"},
+		{"00:30", "00:45", false, "15 second gap should not allow repeat"},
+		{"01:00", "01:30", true, "30 second gap should allow repeat (boundary case)"},
+		{"01:00", "01:29", false, "29 second gap should not allow repeat"},
+		{"invalid", "01:30", true, "invalid timestamp should err on side of inclusion"},
+		{"01:30", "invalid", true, "invalid timestamp should err on side of inclusion"},
+	}
+
+	for _, test := range tests {
+		result := shouldIncludeRepeat(test.lastTimestamp, test.currentTimestamp)
+		if result != test.expected {
+			t.Errorf("%s: expected %v, got %v", test.description, test.expected, result)
+		}
+	}
+}

--- a/internal/tools/youtube/youtube.go
+++ b/internal/tools/youtube/youtube.go
@@ -29,6 +29,9 @@ import (
 	"google.golang.org/api/youtube/v3"
 )
 
+// Match timestamps like "00:00:01.234" or just numbers or sequence numbers
+var timestampRegex = regexp.MustCompile(`^\d+$|^\d{1,2}:\d{2}:\d{2}|^\d{2}:\d{2}\.\d{3}|^\d{1,2}:\d{2}:\d{2}\.\d{3}`)
+
 func NewYouTube() (ret *YouTube) {
 
 	label := "YouTube"
@@ -278,8 +281,6 @@ func formatVTTTimestamp(vttTime string) string {
 }
 
 func isTimeStamp(s string) bool {
-	// Match timestamps like "00:00:01.234" or just numbers or sequence numbers
-	timestampRegex := regexp.MustCompile(`^\d+$|^\d{1,2}:\d{2}:\d{2}|^\d{2}:\d{2}\.\d{3}|^\d{1,2}:\d{2}:\d{2}\.\d{3}`)
 	return timestampRegex.MatchString(s)
 }
 


### PR DESCRIPTION
# YouTube VTT Processing Enhancement

## Summary

This pull request implements intelligent duplicate content filtering for YouTube VTT (WebVTT) subtitle processing. The changes introduce time-based deduplication logic that preserves legitimate repeated content (like choruses or recurring phrases) while filtering out immediate duplicates caused by VTT formatting issues.

## Related Issues

Closes #1614 
Closes #1632 

## Demo

```text
fabric-v1.4.258 -y 'https://www.youtube.com/watch?v=mzSjAxYCEow' --transcript-with-timestamps | wc -l
    5132

fabric -y 'https://www.youtube.com/watch?v=mzSjAxYCEow' --transcript-with-timestamps | wc -l
    1711
```

And even without transcript timestamps:

```text
fabric-v1.4.258 -y 'https://www.youtube.com/watch?v=mzSjAxYCEow' | wc -c
  192314

fabric -y 'https://www.youtube.com/watch?v=mzSjAxYCEow' | wc -c
   64128
```

## Files Changed

### `.vscode/settings.json`
- **Added**: New words to the spell checker dictionary: "horts", "mbed", "WEBVTT", "youtu"
- **Purpose**: Prevents false positive spelling errors for YouTube-related terminology and technical terms

### `internal/tools/youtube/timestamp_test.go` (New File)
- **Added**: Comprehensive test suite for timestamp parsing and repeat detection logic
- **Purpose**: Ensures reliability of the new deduplication functionality with edge cases

### `internal/tools/youtube/youtube.go`
- **Modified**: Enhanced VTT processing with intelligent duplicate detection
- **Added**: New constants, helper functions, and time-based filtering logic

## Code Changes

### Core Algorithm Enhancement

The main improvement is in the `readAndFormatVTTWithTimestamps` function:

```go
// Track content with timestamps to allow repeats after significant time gaps
seenSegments := make(map[string]string) // text -> last timestamp seen

// Check if we should include this segment
shouldInclude := true
if lastTimestamp, exists := seenSegments[cleanText]; exists {
    if !shouldIncludeRepeat(lastTimestamp, currentTimestamp) {
        shouldInclude = false
    }
}
```

### New Helper Functions

1. **`shouldIncludeRepeat`**: Determines if repeated content should be included based on a 10-second time gap threshold
2. **`parseTimestampToSeconds`**: Converts timestamp strings (HH:MM:SS or MM:SS) to total seconds for comparison

### Constants and Regex Updates

```go
const TimeGapForRepeats = 10 // seconds
var timestampRegex = regexp.MustCompile(`^\d+$|^\d{1,2}:\d{2}(:\d{2})?(\.\d{3})?$`)
```

## Reason for Changes

This change addresses a common issue with YouTube VTT subtitle files where the same content appears multiple times due to formatting quirks or overlapping subtitle segments. The previous implementation either kept all duplicates or removed all duplicates, which could eliminate legitimate repeated content like song choruses or important repeated phrases.

## Impact of Changes

### Positive Impacts
- **Improved Content Quality**: Eliminates redundant subtitle text while preserving meaningful repetitions
- **Better User Experience**: Cleaner, more readable transcript output
- **Configurable Threshold**: The 10-second gap can be easily adjusted for different use cases

### Potential Considerations
- **Memory Usage**: The `seenSegments` map grows with unique content, but this is typically manageable for video transcripts
- **Processing Time**: Slight increase due to timestamp parsing and comparison, but negligible for typical use cases
- **Threshold Sensitivity**: The 10-second threshold may need adjustment based on content type (music vs. speech)

## Test Plan

The new test suite covers:
- **Timestamp Parsing**: Various formats (MM:SS, HH:MM:SS) and edge cases
- **Repeat Detection**: Time gap calculations and boundary conditions
- **Error Handling**: Invalid timestamp formats and malformed input

Tests can be run with:
```bash
go test ./internal/tools/youtube/
```

## Additional Notes

- The implementation errs on the side of inclusion when timestamp parsing fails, ensuring no legitimate content is lost
- The 10-second threshold is conservative and works well for most content types
- Future enhancements could make the time gap threshold configurable via command-line flags or configuration files
- The regex pattern has been moved to package level for better performance and reusability