### PR TITLE
Fix abort in Exo-Labs provider plugin; with credit to @sakithahSenid

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,6 +80,7 @@
 		"nometa",
 		"numpy",
 		"ollama",
+		"openaiapi",
 		"opencode",
 		"openrouter",
 		"otiai",

--- a/internal/plugins/ai/exolab/exolab.go
+++ b/internal/plugins/ai/exolab/exolab.go
@@ -13,6 +13,7 @@ func NewClient() (ret *Client) {
 	ret = &Client{}
 	ret.Client = openai.NewClientCompatibleNoSetupQuestions("Exolab", ret.configure)
 
+	ret.ApiKey = ret.AddSetupQuestion("API Key", false)
 	ret.ApiBaseURL = ret.AddSetupQuestion("API Base URL", true)
 	ret.ApiBaseURL.Value = "http://localhost:52415"
 


### PR DESCRIPTION
# Fix abort in Exo-Labs provider plugin; with credit to @sakithahSenid

## Summary

This pull request adds API key configuration support to the Exolab AI plugin and updates the VS Code spell checker dictionary to include the new "openaiapi" term.

## Related Issues

Closes #1622 

## Files Changed

- `.vscode/settings.json`: Added "openaiapi" to the spell checker dictionary
- `internal/plugins/ai/exolab/exolab.go`: Added API key setup question to the Exolab client configuration

## Code Changes

### `.vscode/settings.json`
```json
"openaiapi",
```
Added the term "openaiapi" to the `cSpell.words` array to prevent spell checker warnings.

### `internal/plugins/ai/exolab/exolab.go`
```go
ret.ApiKey = ret.AddSetupQuestion("API Key", false)
```
Added a new setup question for API key configuration.

## Reason for Changes

Prevents the following abort when trying to set up exolabs:

<img width="1176" height="646" alt="exo-labs-fail" src="https://github.com/user-attachments/assets/58e2f28f-9396-444c-b2d0-27240679fabb" />

## Impact of Changes

1. **Improved User Experience**: The setup process now guides users through both URL and authentication configuration
2. **Consistency**: Aligns the Exolab plugin with other AI plugins. The API Key is optional.

## Test Plan

- Verify that the Exolab plugin setup process now prompts for both API Base URL and API Key
- Confirm that the API key is properly stored and used in subsequent API calls
- Validate that existing configurations continue to work after the update
