### PR TITLE
chore: update `NeedsRawMode` to include `mistral` prefix for Ollama

### DIFF
--- a/internal/plugins/ai/ollama/ollama.go
+++ b/internal/plugins/ai/ollama/ollama.go
@@ -160,6 +160,7 @@ func (o *Client) NeedsRawMode(modelName string) bool {
 	ollamaPrefixes := []string{
 		"llama3",
 		"llama2",
+		"mistral",
 	}
 	for _, prefix := range ollamaPrefixes {
 		if strings.HasPrefix(modelName, prefix) {


### PR DESCRIPTION
# chore: update `NeedsRawMode` to include `mistral` prefix for Ollama

## Summary

Added "mistral" to the list of model prefixes that require raw mode in the Ollama AI plugin. This is a single-line addition to support Mistral models when using the Ollama integration.

## Related Issues

Closes #1636 

## Files Changed

- **`internal/plugins/ai/ollama/ollama.go`**: Added "mistral" to the `ollamaPrefixes` slice in the `NeedsRawMode` function.

## Code Changes

In the `NeedsRawMode` function, the `ollamaPrefixes` slice was updated to include Mistral models:

```go
ollamaPrefixes := []string{
    "llama3",
    "llama2",
+   "mistral",
}
```

This change ensures that any model name starting with "mistral" will be identified as requiring raw mode processing.

## Reason for Changes

This change extends support for Mistral models in the Ollama plugin. The `NeedsRawMode` function appears to determine which models require special handling (raw mode) based on their name prefixes. Mistral models likely have similar characteristics to the existing Llama models that necessitate this special processing mode.

## Impact of Changes

- **Functionality**: Enables proper handling of Mistral models when used with the Ollama AI plugin
- **Compatibility**: Maintains backward compatibility while extending model support
- **Performance**: Minimal impact - only adds one string comparison to the existing prefix matching logic

## Test Plan

- Verify that models with names starting with "mistral" (e.g., "mistral-7b", "mistral-instruct") properly trigger raw mode
- Ensure existing functionality for "llama2" and "llama3" prefixes remains unchanged
- Test with actual Mistral models through Ollama to confirm proper behavior

## Additional Notes

This is a straightforward addition that follows the existing pattern for model prefix detection. The change is minimal and low-risk, as it only adds support for an additional model family without modifying existing logic. However, it would be beneficial to verify that Mistral models indeed require raw mode processing similar to Llama models, and that this addition doesn't inadvertently affect other models that might have "mistral" in their names but don't require raw mode.
