### PR TITLE
Fix Fabric Web timeout error

### DIFF
--- a/cmd/generate_changelog/incoming/1641.txt
+++ b/cmd/generate_changelog/incoming/1641.txt
@@ -1,0 +1,5 @@
+### PR [#1641](https://github.com/danielmiessler/Fabric/pull/1641) by [ksylvan](https://github.com/ksylvan): Fix Fabric Web timeout error
+
+- Chore: extend proxy timeout in `vite.config.ts` to 15 minutes
+- Increase `/api` proxy timeout to 900,000 ms
+- Increase `/names` proxy timeout to 900,000 ms

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -44,7 +44,7 @@ export default defineConfig({
       '/api': {
         target: FABRIC_BASE_URL,
         changeOrigin: true,
-        timeout: 30000,
+        timeout: 900000,
         rewrite: (path) => path.replace(/^\/api/, ''),
         configure: (proxy, _options) => {
           proxy.on('error', (err, req, res) => {
@@ -59,7 +59,7 @@ export default defineConfig({
       '^/(patterns|models|sessions)/names': {
         target: FABRIC_BASE_URL,
         changeOrigin: true,
-        timeout: 30000,
+        timeout: 900000,
         configure: (proxy, _options) => {
           proxy.on('error', (err, req, res) => {
             console.log('proxy error', err);


### PR DESCRIPTION
# Fix Fabric Web timeout error

## Summary

This pull request increases the proxy timeout configuration in the Vite development server from 30 seconds to 15 minutes (900,000ms) for API requests and pattern/model/session name endpoints.

## Related Issues

Closes #1604

## Files Changed

- **web/vite.config.ts**: Modified proxy timeout settings for development server configuration

## Code Changes

The changes involve updating two proxy configurations in the Vite config file:

1. **API proxy timeout update**:
```typescript
'/api': {
  target: FABRIC_BASE_URL,
  changeOrigin: true,
- timeout: 30000,
+ timeout: 900000,
  rewrite: (path) => path.replace(/^\/api/, ''),
```

2. **Patterns/models/sessions proxy timeout update**:
```typescript
'^/(patterns|models|sessions)/names': {
  target: FABRIC_BASE_URL,
  changeOrigin: true,
- timeout: 30000,
+ timeout: 900000,
```

## Reason for Changes

The timeout increase from 30 seconds to 15 minutes addresses scenarios where:
- API requests may take longer to process, particularly for complex operations
- Pattern, model, or session name retrieval operations may require extended processing time
- Network latency or server processing delays could cause legitimate requests to timeout prematurely

This change prevents development workflow interruptions caused by timeout errors on slower operations.

## Impact of Changes

**Positive impacts:**
- Eliminates premature timeouts during development for long-running operations
- Improves developer experience by allowing complex requests to complete
- Reduces frustration from timeout errors on legitimate operations

**Potential concerns:**
- Longer timeout periods may mask actual performance issues
- Failed requests will now hang for up to 15 minutes before timing out
- Memory usage could increase if multiple long-running requests accumulate

## Test Plan

- Test API endpoints that previously timed out at 30 seconds
- Verify that legitimate long-running operations now complete successfully
- Confirm that truly failed requests still eventually timeout (within 15 minutes)
- Monitor development server performance with the extended timeout

## Additional Notes

This change only affects the development environment proxy configuration and will not impact production deployments. The 15-minute timeout should accommodate most legitimate long-running operations while still providing an upper bound for failed requests. Consider monitoring actual request durations to determine if this timeout value needs further adjustment based on real-world usage patterns.