### PR TITLE
[issue #1195] only call ollama and bedrock APIs when configured.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -353,3 +353,6 @@ tmp/
 
 # Ignore .claude/
 .claude/
+
+# debug builds
+__debug*exe*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -6,12 +6,20 @@
     "configurations": [
 
         {
-            "name": "Launch Package",
+            "name": "listmodels",
             "type": "go",
             "request": "launch",
             "mode": "auto",
             "program": "${workspaceFolder}\\cmd\\fabric",
             "args": ["/listmodels"]
+        },
+        {
+            "name": "basic request via gemini",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}\\cmd\\fabric",
+            "args": ["introduction to powershell"]
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,17 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+
+        {
+            "name": "Launch Package",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}\\cmd\\fabric",
+            "args": ["/listmodels"]
+        }
+    ]
+}

--- a/internal/core/plugin_registry.go
+++ b/internal/core/plugin_registry.go
@@ -43,6 +43,7 @@ import (
 // potential authentication source exists so we can safely initialize the
 // Bedrock client without causing the AWS SDK to search for credentials.
 func hasAWSCredentials() bool {
+	return false
 	if os.Getenv("AWS_PROFILE") != "" ||
 		os.Getenv("AWS_ROLE_SESSION_NAME") != "" ||
 		(os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "") {
@@ -62,6 +63,10 @@ func hasAWSCredentials() bool {
 		}
 	}
 	return false
+}
+
+func hasOllama() bool {
+	return os.Getenv("OLLAMA_URL") != ""
 }
 
 func NewPluginRegistry(db *fsdb.Db) (ret *PluginRegistry, err error) {
@@ -91,7 +96,6 @@ func NewPluginRegistry(db *fsdb.Db) (ret *PluginRegistry, err error) {
 	// Add non-OpenAI compatible clients
 	vendors = append(vendors,
 		openai.NewClient(),
-		ollama.NewClient(),
 		azure.NewClient(),
 		gemini.NewClient(),
 		anthropic.NewClient(),
@@ -100,6 +104,9 @@ func NewPluginRegistry(db *fsdb.Db) (ret *PluginRegistry, err error) {
 		perplexity.NewClient(), // Added Perplexity client
 	)
 
+	if hasOllama() {
+		vendors = append(vendors, ollama.NewClient())
+	}
 	if hasAWSCredentials() {
 		vendors = append(vendors, bedrock.NewClient())
 	}

--- a/internal/core/plugin_registry.go
+++ b/internal/core/plugin_registry.go
@@ -43,7 +43,10 @@ import (
 // potential authentication source exists so we can safely initialize the
 // Bedrock client without causing the AWS SDK to search for credentials.
 func hasAWSCredentials() bool {
-	return false
+	if os.Getenv("BEDROCK_AWS_REGION") == "" {
+		return false
+	}
+
 	if os.Getenv("AWS_PROFILE") != "" ||
 		os.Getenv("AWS_ROLE_SESSION_NAME") != "" ||
 		(os.Getenv("AWS_ACCESS_KEY_ID") != "" && os.Getenv("AWS_SECRET_ACCESS_KEY") != "") {


### PR DESCRIPTION
## What this Pull Request (PR) does
* Avoid Calling ollama and bedrock (aws) API when not configured

## Related issues
closes issue #1195 

# Steps to Repeat
1. set up fabric .env file ONLY with `GEMINI_API_KEY`
2.  run `fabric /listmodels`


## Screenshots

### Before 

```
Ollama Get "http://localhost:11434/api/tags": dial tcp [::1]:11434: connectex: No connection could be made because the target machine actively refused it.
Bedrock failed to list foundation models: operation error Bedrock: ListFoundationModels, https response error StatusCode: 403, RequestID: fee42150-dcfa-4204-9ef0-f0e12d47fdd9, api error UnrecognizedClientException: The security token included in the request is invalid.

Available models:

Gemini
```

### AFTER

```
 go run .\cmd\fabric /listmodels

Available models:

Gemini

        [1]     aqa
        [2]     embedding-001
```

## OLD
* ~~`hasAwsCredentials` is broken .  Need to discuss cases where AWS credentials are available but not needed (e.g. AWS cli is used for other services, not fabric)~~
