### PR TITLE
Simplify Workflow with Single Version Retrieval Step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -93,19 +93,24 @@ jobs:
           name: fabric-windows-${{ matrix.arch }}.exe
           path: fabric-windows-${{ matrix.arch }}.exe
 
-      - name: Get latest tag
-        if: matrix.os != 'windows-latest'
-        id: get_latest_tag
+      - name: Get version from source
+        id: get_version
+        shell: bash
         run: |
-          latest_tag=$(git tag --sort=-creatordate | head -n 1)
-          echo "latest_tag=$latest_tag" >> $GITHUB_ENV
-
-      - name: Get latest tag
-        if: matrix.os == 'windows-latest'
-        id: get_latest_tag_windows
-        run: |
-          $latest_tag = git tag --sort=-creatordate | Select-Object -First 1
-          Add-Content -Path $env:GITHUB_ENV -Value "latest_tag=$latest_tag"
+          if [ ! -f "nix/pkgs/fabric/version.nix" ]; then
+            echo "Error: version.nix file not found"
+            exit 1
+          fi
+          version=$(cat nix/pkgs/fabric/version.nix | tr -d '"' | tr -cd '0-9.')
+          if [ -z "$version" ]; then
+            echo "Error: version is empty"
+            exit 1
+          fi
+          if ! echo "$version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' > /dev/null; then
+            echo "Error: Invalid version format: $version"
+            exit 1
+          fi
+          echo "latest_tag=v$version" >> $GITHUB_ENV
 
       - name: Create release if it doesn't exist
         shell: bash

--- a/cmd/generate_changelog/incoming/1647.txt
+++ b/cmd/generate_changelog/incoming/1647.txt
@@ -1,0 +1,7 @@
+### PR [#1647](https://github.com/danielmiessler/Fabric/pull/1647) by [ksylvan](https://github.com/ksylvan): Simplify Workflow with Single Version Retrieval Step
+
+- Replace git tag lookup with version.nix file reading for release workflow
+- Remove OS-specific git tag retrieval steps and add unified version extraction from nix file
+- Include version format validation with regex check
+- Add error handling for missing version file
+- Consolidate cross-platform version logic into single step with bash shell for consistent version parsing


### PR DESCRIPTION
# Simplify Workflow with Single Version Retrieval Step

## Summary

This pull request refactors the version retrieval mechanism in the GitHub Actions release workflow. The changes replace OS-specific git tag commands with a unified approach that reads version information directly from a Nix configuration file.

## Files Changed

- `.github/workflows/release.yml`: Modified the version retrieval step in the release workflow to use a single, cross-platform approach instead of separate OS-specific implementations.

## Code Changes

The most significant change is the replacement of two separate version retrieval steps with a single unified step:

**Removed:**
```yaml
- name: Get latest tag
  if: matrix.os != 'windows-latest'
  id: get_latest_tag
  run: |
    latest_tag=$(git tag --sort=-creatordate | head -n 1)
    echo "latest_tag=$latest_tag" >> $GITHUB_ENV

- name: Get latest tag
  if: matrix.os == 'windows-latest'
  id: get_latest_tag_windows
  run: |
    $latest_tag = git tag --sort=-creatordate | Select-Object -First 1
    Add-Content -Path $env:GITHUB_ENV -Value "latest_tag=$latest_tag"
```

**Added:**
```yaml
- name: Get version from source
  id: get_version
  shell: bash
  run: |
    if [ ! -f "nix/pkgs/fabric/version.nix" ]; then
      echo "Error: version.nix file not found"
      exit 1
    fi
    version=$(cat nix/pkgs/fabric/version.nix | tr -d '"' | tr -cd '0-9.')
    if [ -z "$version" ]; then
      echo "Error: version is empty"
      exit 1
    fi
    if ! echo "$version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' > /dev/null; then
      echo "Error: Invalid version format: $version"
      exit 1
    fi
    echo "latest_tag=v$version" >> $GITHUB_ENV
```

## Reason for Changes

This change addresses several issues with the previous implementation:

1. **Cross-platform compatibility**: Eliminates the need for separate Windows and Unix implementations
2. **Single source of truth**: Uses the version defined in `nix/pkgs/fabric/version.nix` instead of relying on git tags
3. **Improved reliability**: Adds comprehensive error handling and validation
4. **Consistency**: Ensures the same version retrieval logic across all operating systems

## Impact of Changes

- **Positive impacts**:
  - Simplified workflow maintenance with a single version retrieval step
  - More robust error handling prevents silent failures
  - Version format validation ensures consistency
  - Eliminates potential race conditions between git tagging and releases

- **Potential risks**:
  - Dependency on the `nix/pkgs/fabric/version.nix` file existing and being properly formatted
  - If the Nix file format changes, the parsing logic may need updates
  - The `tr` command usage assumes a specific file format that may be fragile

## Test Plan

The changes should be tested by:

1. Verifying the workflow runs successfully on all matrix combinations (Linux, macOS, Windows)
2. Confirming that the version is correctly extracted from `nix/pkgs/fabric/version.nix`
3. Testing error conditions (missing file, empty version, invalid format)
4. Ensuring the `latest_tag` environment variable is properly set for subsequent steps

## Additional Notes

The new implementation uses `shell: bash` to ensure consistent behavior across all platforms, including Windows (which will use Git Bash or WSL). The version parsing logic strips quotes and non-numeric/period characters, then validates the format matches semantic versioning patterns. Consider adding unit tests for the version parsing logic if this becomes a critical path in the release process.