### PR TITLE
Add Support for Claude Opus 4.1 Model

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,39 @@ jobs:
       - name: Run tests
         run: go test -v ./...
 
+  get_version:
+    name: Get version
+    runs-on: ubuntu-latest
+    outputs:
+      latest_tag: ${{ steps.get_version.outputs.latest_tag }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get version from source
+        id: get_version
+        shell: bash
+        run: |
+          if [ ! -f "nix/pkgs/fabric/version.nix" ]; then
+            echo "Error: version.nix file not found"
+            exit 1
+          fi
+          version=$(cat nix/pkgs/fabric/version.nix | tr -d '"' | tr -cd '0-9.')
+          if [ -z "$version" ]; then
+            echo "Error: version is empty"
+            exit 1
+          fi
+          if ! echo "$version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' > /dev/null; then
+            echo "Error: Invalid version format: $version"
+            exit 1
+          fi
+          echo "latest_tag=v$version" >> $GITHUB_OUTPUT
+
   build:
     name: Build binaries for Windows, macOS, and Linux
+    needs: [test, get_version]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write
@@ -51,25 +82,14 @@ jobs:
         with:
           go-version-file: ./go.mod
 
-      - name: Determine OS Name
-        id: os-name
-        run: |
-          if [ "${{ matrix.os }}" == "ubuntu-latest" ]; then
-            echo "OS=linux" >> $GITHUB_ENV
-          elif [ "${{ matrix.os }}" == "macos-latest" ]; then
-            echo "OS=darwin" >> $GITHUB_ENV
-          else
-            echo "OS=windows" >> $GITHUB_ENV
-          fi
-        shell: bash
-
       - name: Build binary on Linux and macOS
         if: matrix.os != 'windows-latest'
         env:
-          GOOS: ${{ env.OS }}
+          GOOS: ${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}
           GOARCH: ${{ matrix.arch }}
         run: |
-          go build -o fabric-${OS}-${{ matrix.arch }} ./cmd/fabric
+          OS_NAME="${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}"
+          go build -o fabric-${OS_NAME}-${{ matrix.arch }} ./cmd/fabric
 
       - name: Build binary on Windows
         if: matrix.os == 'windows-latest'
@@ -83,8 +103,8 @@ jobs:
         if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@v4
         with:
-          name: fabric-${OS}-${{ matrix.arch }}
-          path: fabric-${OS}-${{ matrix.arch }}
+          name: fabric-${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}-${{ matrix.arch }}
+          path: fabric-${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}-${{ matrix.arch }}
 
       - name: Upload build artifact
         if: matrix.os == 'windows-latest'
@@ -93,34 +113,15 @@ jobs:
           name: fabric-windows-${{ matrix.arch }}.exe
           path: fabric-windows-${{ matrix.arch }}.exe
 
-      - name: Get version from source
-        id: get_version
-        shell: bash
-        run: |
-          if [ ! -f "nix/pkgs/fabric/version.nix" ]; then
-            echo "Error: version.nix file not found"
-            exit 1
-          fi
-          version=$(cat nix/pkgs/fabric/version.nix | tr -d '"' | tr -cd '0-9.')
-          if [ -z "$version" ]; then
-            echo "Error: version is empty"
-            exit 1
-          fi
-          if ! echo "$version" | grep -E '^[0-9]+\.[0-9]+\.[0-9]+' > /dev/null; then
-            echo "Error: Invalid version format: $version"
-            exit 1
-          fi
-          echo "latest_tag=v$version" >> $GITHUB_ENV
-
       - name: Create release if it doesn't exist
         shell: bash
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if ! gh release view ${{ env.latest_tag }} >/dev/null 2>&1; then
-            gh release create ${{ env.latest_tag }} --title "Release ${{ env.latest_tag }}" --notes "Automated release for ${{ env.latest_tag }}"
+          if ! gh release view ${{ needs.get_version.outputs.latest_tag }} >/dev/null 2>&1; then
+            gh release create ${{ needs.get_version.outputs.latest_tag }} --title "Release ${{ needs.get_version.outputs.latest_tag }}" --notes "Automated release for ${{ needs.get_version.outputs.latest_tag }}"
           else
-            echo "Release ${{ env.latest_tag }} already exists."
+            echo "Release ${{ needs.get_version.outputs.latest_tag }} already exists."
           fi
 
       - name: Upload release artifact
@@ -128,16 +129,18 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ env.latest_tag }} fabric-windows-${{ matrix.arch }}.exe
+          gh release upload ${{ needs.get_version.outputs.latest_tag }} fabric-windows-${{ matrix.arch }}.exe
 
       - name: Upload release artifact
         if: matrix.os != 'windows-latest'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          gh release upload ${{ env.latest_tag }} fabric-${OS}-${{ matrix.arch }}
+          OS_NAME="${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}"
+          gh release upload ${{ needs.get_version.outputs.latest_tag }} fabric-${OS_NAME}-${{ matrix.arch }}
 
   update_release_notes:
+    needs: [build, get_version]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -155,4 +158,4 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           go run ./cmd/generate_changelog --sync-db
-          go run ./cmd/generate_changelog --release ${{ env.latest_tag }}
+          go run ./cmd/generate_changelog --release ${{ needs.get_version.outputs.latest_tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,8 +122,6 @@ jobs:
           else
             echo "Release ${{ env.latest_tag }} already exists."
           fi
-          go run ./cmd/generate_changelog --sync-db
-          go run ./cmd/generate_changelog --release ${{ env.latest_tag }}
 
       - name: Upload release artifact
         if: matrix.os == 'windows-latest'
@@ -138,3 +136,23 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           gh release upload ${{ env.latest_tag }} fabric-${OS}-${{ matrix.arch }}
+
+  update_release_notes:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version-file: ./go.mod
+
+      - name: Update release description
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          go run ./cmd/generate_changelog --sync-db
+          go run ./cmd/generate_changelog --release ${{ env.latest_tag }}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -73,6 +73,7 @@
 		"jessevdk",
 		"Jina",
 		"joho",
+		"Keploy",
 		"Kore",
 		"ksylvan",
 		"Langdock",

--- a/cmd/generate_changelog/incoming/1673.txt
+++ b/cmd/generate_changelog/incoming/1673.txt
@@ -3,5 +3,5 @@
 - Add Claude Opus 4.1 model support
 - Upgrade anthropic-sdk-go from v1.4.0 to v1.7.0
 - Fix temperature/topP parameter conflict for models
+- Refactor chat parameter defaults handling with domain constants
 - Move changelog generation to separate workflow job
-- Refactor release workflow to use shared version job and simplify OS handling

--- a/cmd/generate_changelog/incoming/1673.txt
+++ b/cmd/generate_changelog/incoming/1673.txt
@@ -4,4 +4,4 @@
 - Upgrade anthropic-sdk-go from v1.4.0 to v1.7.0
 - Fix temperature/topP parameter conflict for models
 - Move changelog generation to separate workflow job
-- Add dedicated update_release_notes job configuration
+- Refactor release workflow to use shared version job and simplify OS handling

--- a/cmd/generate_changelog/incoming/1673.txt
+++ b/cmd/generate_changelog/incoming/1673.txt
@@ -1,0 +1,7 @@
+### PR [#1673](https://github.com/danielmiessler/Fabric/pull/1673) by [ksylvan](https://github.com/ksylvan): Add Support for Claude Opus 4.1 Model
+
+- Add Claude Opus 4.1 model support
+- Upgrade anthropic-sdk-go from v1.4.0 to v1.7.0
+- Fix temperature/topP parameter conflict for models
+- Move changelog generation to separate workflow job
+- Add dedicated update_release_notes job configuration

--- a/cmd/generate_changelog/incoming/1673.txt
+++ b/cmd/generate_changelog/incoming/1673.txt
@@ -3,5 +3,5 @@
 - Add Claude Opus 4.1 model support
 - Upgrade anthropic-sdk-go from v1.4.0 to v1.7.0
 - Fix temperature/topP parameter conflict for models
-- Refactor chat parameter defaults handling with domain constants
-- Move changelog generation to separate workflow job
+- Refactor release workflow to use shared version job and simplify OS handling
+- Improve chat parameter defaults handling with domain constants

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24.0
 toolchain go1.24.2
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.4.0
+	github.com/anthropics/anthropic-sdk-go v1.7.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/aws/aws-sdk-go-v2 v1.36.4
 	github.com/aws/aws-sdk-go-v2/config v1.27.27

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/anthropics/anthropic-sdk-go v1.4.0 h1:fU1jKxYbQdQDiEXCxeW5XZRIOwKevn/PMg8Ay1nnUx0=
 github.com/anthropics/anthropic-sdk-go v1.4.0/go.mod h1:AapDW22irxK2PSumZiQXYUFvsdQgkwIWlpESweWZI/c=
+github.com/anthropics/anthropic-sdk-go v1.7.0 h1:5iVf5fG/2gqVsOce8mq02r/WdgqpokM/8DXg2Ue6C9Y=
+github.com/anthropics/anthropic-sdk-go v1.7.0/go.mod h1:3qSNQ5NrAmjC8A2ykuruSQttfqfdEYNZY5o8c0XSHB8=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -20,6 +20,8 @@ import (
 )
 
 // Flags create flags struct. the users flags go into this, this will be passed to the chat struct in cli
+// Chat parameter defaults set in the struct tags must match domain.Default* constants
+
 type Flags struct {
 	Pattern                         string            `short:"p" long:"pattern" yaml:"pattern" description:"Choose a pattern from the available patterns" default:""`
 	PatternVariables                map[string]string `short:"v" long:"variable" description:"Values for pattern variables, e.g. -v=#role:expert -v=#points:30"`

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -4,6 +4,14 @@ import "github.com/danielmiessler/fabric/internal/chat"
 
 const ChatMessageRoleMeta = "meta"
 
+// Default values for chat options (must match cli/flags.go defaults)
+const (
+	DefaultTemperature      = 0.7
+	DefaultTopP             = 0.9
+	DefaultPresencePenalty  = 0.0
+	DefaultFrequencyPenalty = 0.0
+)
+
 type ChatRequest struct {
 	ContextName      string
 	SessionName      string

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -188,9 +188,13 @@ func (an *Client) buildMessageParams(msgs []anthropic.MessageParam, opts *domain
 	}
 
 	// Only set one of Temperature or TopP as some models don't allow both
-	if opts.Temperature != 0 {
+	// Check if values were explicitly set (different from defaults)
+	tempExplicitlySet := opts.Temperature != domain.DefaultTemperature
+	topPExplicitlySet := opts.TopP != domain.DefaultTopP
+
+	if tempExplicitlySet {
 		params.Temperature = anthropic.Opt(opts.Temperature)
-	} else if opts.TopP != 0 {
+	} else if topPExplicitlySet {
 		params.TopP = anthropic.Opt(opts.TopP)
 	}
 

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -46,6 +46,7 @@ func NewClient() (ret *Client) {
 		string(anthropic.ModelClaude_3_5_Sonnet_20240620), string(anthropic.ModelClaude3OpusLatest),
 		string(anthropic.ModelClaude_3_Opus_20240229), string(anthropic.ModelClaude_3_Haiku_20240307),
 		string(anthropic.ModelClaudeOpus4_20250514), string(anthropic.ModelClaudeSonnet4_20250514),
+		string(anthropic.ModelClaudeOpus4_1_20250805),
 	}
 
 	return
@@ -181,11 +182,16 @@ func (an *Client) buildMessageParams(msgs []anthropic.MessageParam, opts *domain
 	params anthropic.MessageNewParams) {
 
 	params = anthropic.MessageNewParams{
-		Model:       anthropic.Model(opts.Model),
-		MaxTokens:   int64(an.maxTokens),
-		TopP:        anthropic.Opt(opts.TopP),
-		Temperature: anthropic.Opt(opts.Temperature),
-		Messages:    msgs,
+		Model:     anthropic.Model(opts.Model),
+		MaxTokens: int64(an.maxTokens),
+		Messages:  msgs,
+	}
+
+	// Only set one of Temperature or TopP as some models don't allow both
+	if opts.Temperature != 0 {
+		params.Temperature = anthropic.Opt(opts.Temperature)
+	} else if opts.TopP != 0 {
+		params.TopP = anthropic.Opt(opts.TopP)
 	}
 
 	// Add Claude Code spoofing system message for OAuth authentication

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -188,14 +188,13 @@ func (an *Client) buildMessageParams(msgs []anthropic.MessageParam, opts *domain
 	}
 
 	// Only set one of Temperature or TopP as some models don't allow both
-	// Check if values were explicitly set (different from defaults)
-	tempExplicitlySet := opts.Temperature != domain.DefaultTemperature
-	topPExplicitlySet := opts.TopP != domain.DefaultTopP
-
-	if tempExplicitlySet {
-		params.Temperature = anthropic.Opt(opts.Temperature)
-	} else if topPExplicitlySet {
+	// Always set temperature to ensure consistent behavior (Anthropic default is 1.0, Fabric default is 0.7)
+	if opts.TopP != domain.DefaultTopP {
+		// User explicitly set TopP, so use that instead of temperature
 		params.TopP = anthropic.Opt(opts.TopP)
+	} else {
+		// Use temperature (always set to ensure Fabric's default of 0.7, not Anthropic's 1.0)
+		params.Temperature = anthropic.Opt(opts.Temperature)
 	}
 
 	// Add Claude Code spoofing system message for OAuth authentication


### PR DESCRIPTION
# Add Support for Claude Opus 4.1 Model

## Summary

This PR refactors the GitHub Actions release workflow to improve build reliability and adds support for the Claude Opus 4.1 model. The main changes include separating the version retrieval into its own job, simplifying OS detection logic, fixing parameter conflicts for Anthropic models, and updating the anthropic-sdk-go dependency.

## Files Changed

- **.github/workflows/release.yml**: Restructured the release workflow to separate concerns and improve maintainability
- **cmd/generate_changelog/incoming/1673.txt**: Added changelog entry documenting these changes
- **go.mod / go.sum**: Updated anthropic-sdk-go dependency from v1.4.0 to v1.7.0
- **internal/plugins/ai/anthropic/anthropic.go**: Added Claude Opus 4.1 model support and fixed parameter handling

## Code Changes

### Release Workflow Refactoring
The workflow now has a dedicated `get_version` job that runs before the build:
```yaml
get_version:
  name: Get version
  runs-on: ubuntu-latest
  outputs:
    latest_tag: ${{ steps.get_version.outputs.latest_tag }}
```

OS detection has been simplified from a multi-step process to inline ternary operators:
```yaml
GOOS: ${{ matrix.os == 'ubuntu-latest' && 'linux' || 'darwin' }}
```

Changelog generation has been moved to a separate `update_release_notes` job that runs after all builds complete:
```yaml
update_release_notes:
  needs: [build, get_version]
  runs-on: ubuntu-latest
```

### Anthropic Client Updates
Added support for the new Claude Opus 4.1 model:
```go
string(anthropic.ModelClaudeOpus4_1_20250805),
```

Fixed temperature/topP parameter conflict issue:
```go
// Only set one of Temperature or TopP as some models don't allow both
if opts.Temperature != 0 {
    params.Temperature = anthropic.Opt(opts.Temperature)
} else if opts.TopP != 0 {
    params.TopP = anthropic.Opt(opts.TopP)
}
```

## Reason for Changes

1. **Workflow Reliability**: The previous workflow had version retrieval duplicated across matrix jobs, which could lead to race conditions and inefficiencies. Separating this into its own job ensures it runs once and provides consistent output.

2. **Claude Opus 4.1 Support**: Adding support for the latest Claude model provides users with access to improved AI capabilities.

3. **Parameter Conflict Fix**: Some Anthropic models don't allow both temperature and topP parameters to be set simultaneously, which was causing API errors.

4. **Simplified OS Detection**: The previous multi-step OS detection was unnecessarily complex and could be replaced with inline conditionals.

## Impact of Changes

- **Improved CI/CD Performance**: Version retrieval now happens once instead of multiple times across matrix jobs
- **Better Error Handling**: The temperature/topP fix prevents API errors when using certain Anthropic models
- **Enhanced Model Support**: Users can now leverage the latest Claude Opus 4.1 model
- **Cleaner Workflow**: Separation of concerns makes the workflow easier to maintain and debug

## Test Plan

1. Verify the workflow runs successfully on push to main branch
2. Confirm version is correctly extracted from `nix/pkgs/fabric/version.nix`
3. Test that binaries are built for all OS/architecture combinations
4. Verify release notes are properly generated after all builds complete
5. Test Claude Opus 4.1 model integration with various temperature/topP combinations

## Additional Notes

- The workflow now has explicit job dependencies (`needs: [test, get_version]`) ensuring proper execution order
- The changelog generation runs as a final step to avoid conflicts with concurrent build jobs
- The anthropic-sdk-go upgrade from v1.4.0 to v1.7.0 may include additional improvements beyond the Opus 4.1 model support

**Potential Issues to Monitor:**
- The ternary operator approach for OS detection should be tested across all matrix combinations
- The temperature/topP logic prioritizes temperature when both are set - this behavior should be documented
- The separate `update_release_notes` job requires all builds to complete successfully before running