### PR TITLE
Refactor authentication to support GITHUB_TOKEN and GH_TOKEN

### DIFF
--- a/cmd/generate_changelog/internal/git/walker.go
+++ b/cmd/generate_changelog/internal/git/walker.go
@@ -2,12 +2,12 @@ package git
 
 import (
 	"fmt"
-	"os"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
 
+	"github.com/danielmiessler/fabric/cmd/generate_changelog/util"
 	"github.com/go-git/go-git/v5"
 	"github.com/go-git/go-git/v5/plumbing"
 	"github.com/go-git/go-git/v5/plumbing/object"
@@ -520,7 +520,7 @@ func (w *Walker) PushToRemote() error {
 	pushOptions := &git.PushOptions{}
 
 	// Check if we have a GitHub token for authentication
-	if githubToken := os.Getenv("GITHUB_TOKEN"); githubToken != "" {
+	if githubToken := util.GetTokenFromEnv(""); githubToken != "" {
 		// Get remote URL to check if it's a GitHub repository
 		remotes, err := w.repo.Remotes()
 		if err == nil && len(remotes) > 0 {

--- a/cmd/generate_changelog/main.go
+++ b/cmd/generate_changelog/main.go
@@ -5,9 +5,10 @@ import (
 	"os"
 	"path/filepath"
 
-	internal "github.com/danielmiessler/fabric/cmd/generate_changelog/internal"
+	"github.com/danielmiessler/fabric/cmd/generate_changelog/internal"
 	"github.com/danielmiessler/fabric/cmd/generate_changelog/internal/changelog"
 	"github.com/danielmiessler/fabric/cmd/generate_changelog/internal/config"
+	"github.com/danielmiessler/fabric/cmd/generate_changelog/util"
 	"github.com/joho/godotenv"
 	"github.com/spf13/cobra"
 )
@@ -55,9 +56,7 @@ func run(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("--release cannot be used with other processing flags")
 	}
 
-	if cfg.GitHubToken == "" {
-		cfg.GitHubToken = os.Getenv("GITHUB_TOKEN")
-	}
+	cfg.GitHubToken = util.GetTokenFromEnv(cfg.GitHubToken)
 
 	generator, err := changelog.New(cfg)
 	if err != nil {

--- a/cmd/generate_changelog/util/token.go
+++ b/cmd/generate_changelog/util/token.go
@@ -1,0 +1,15 @@
+package util
+
+import (
+	"os"
+)
+
+func GetTokenFromEnv(tokenValue string) string {
+	if tokenValue == "" {
+		tokenValue = os.Getenv("GITHUB_TOKEN")
+		if tokenValue == "" {
+			tokenValue = os.Getenv("GH_TOKEN")
+		}
+	}
+	return tokenValue
+}


### PR DESCRIPTION
# Refactor authentication to support GITHUB_TOKEN and GH_TOKEN

## Summary

This pull request introduces a centralized token retrieval utility function that enhances GitHub authentication flexibility by supporting multiple environment variables. The changes refactor existing hardcoded environment variable checks and consolidate token retrieval logic into a reusable utility function.

## Files Changed

- **`cmd/generate_changelog/util/token.go`** - New file containing centralized token retrieval logic
- **`cmd/generate_changelog/main.go`** - Refactored to use the new utility function and updated import statements
- **`cmd/generate_changelog/internal/git/walker.go`** - Updated to use the new utility function instead of direct `os.Getenv` calls

## Code Changes

### New Utility Function
```go
func GetTokenFromEnv(tokenValue string) string {
	if tokenValue == "" {
		tokenValue = os.Getenv("GITHUB_TOKEN")
		if tokenValue == "" {
			tokenValue = os.Getenv("GH_TOKEN")
		}
	}
	return tokenValue
}
```

### Main Function Simplification
```go
// Before
if cfg.GitHubToken == "" {
    cfg.GitHubToken = os.Getenv("GITHUB_TOKEN")
}

// After
cfg.GitHubToken = util.GetTokenFromEnv(cfg.GitHubToken)
```

### Walker Function Update
```go
// Before
if githubToken := os.Getenv("GITHUB_TOKEN"); githubToken != "" {

// After
if githubToken := util.GetTokenFromEnv(""); githubToken != "" {
```

## Reason for Changes

The primary motivation for these changes is to:
1. **Improve flexibility**: Support both `GITHUB_TOKEN` and `GH_TOKEN` environment variables, accommodating different GitHub CLI and tooling conventions
2. **Reduce code duplication**: Centralize token retrieval logic that was previously scattered across multiple files
3. **Enhance maintainability**: Create a single point of control for authentication token logic

## Impact of Changes

- **Enhanced compatibility**: Users can now use either `GITHUB_TOKEN` or `GH_TOKEN` environment variables
- **Improved code organization**: Token retrieval logic is now centralized and reusable
- **Better maintainability**: Future changes to token handling only need to be made in one location
- **No breaking changes**: Existing functionality remains intact while adding new capabilities

## Test Plan

The changes should be tested by:
1. Verifying that existing `GITHUB_TOKEN` environment variable usage continues to work
2. Testing that `GH_TOKEN` environment variable is now recognized as a fallback
3. Confirming that explicitly provided tokens still take precedence over environment variables
4. Testing both the changelog generation and git push functionality with different token configurations

## Additional Notes

**Potential considerations:**
- The function follows a clear precedence order: explicit token → `GITHUB_TOKEN` → `GH_TOKEN`
- The utility function is simple and focused, making it easy to extend in the future if additional token sources are needed
- Import cleanup was performed to remove unused `os` import from `walker.go` and fix import aliasing in `main.go`

**Potential risks:**
- Minimal risk as this is primarily a refactoring that maintains backward compatibility
- The fallback to `GH_TOKEN` is additive functionality that shouldn't affect existing workflows