### PR TITLE
Grant GITHUB_TOKEN write permissions for release notes job

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,8 @@ jobs:
   update_release_notes:
     needs: [build, get_version]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v4


### PR DESCRIPTION
# Grant GITHUB_TOKEN write permissions for release notes job

## Summary

Grant write permissions to the GITHUB_TOKEN for the update_release_notes job in the release workflow to enable updating GitHub Releases (release notes) during the pipeline.

## Files Changed

- .github/workflows/release.yml
  - Added a job-level permissions block to allow writing to repository contents for the update_release_notes job.

## Code Changes

In the update_release_notes job, explicitly request write permissions for repository contents:

```yaml
jobs:
  update_release_notes:
    needs: [build, get_version]
    runs-on: ubuntu-latest
    permissions:
      contents: write
    steps:
      - name: Checkout code
        uses: actions/checkout@v4
```

## Reason for Changes

- The update_release_notes job needs to create or update release notes via the GitHub API, which requires contents: write. Without this explicit permission, the default GITHUB_TOKEN may only have read access, causing failures such as “Resource not accessible by integration.”
- Scoping permissions at the job level follows the principle of least privilege and avoids granting elevated permissions to other jobs.

## Impact of Changes

- The release pipeline should now be able to successfully update or publish release notes.
- Scope of elevated permissions is limited to the update_release_notes job only, reducing security risk while ensuring required functionality.
- No impact on other jobs; their permissions remain unchanged.

## Test Plan

- Trigger the release workflow (e.g., via workflow_dispatch or a tag push) and verify:
  - The update_release_notes job completes successfully without 403/permission errors.
  - The target GitHub Release has updated notes as expected.
- If available, re-run a previously failing workflow to confirm the fix.
- Validate that other jobs in the workflow are unaffected.

## Additional Notes

- If the repository or organization enforces stricter global workflow permissions, this job-level override should generally suffice, but an org policy could still prevent escalation; if failures persist, confirm org/repo “Workflow permissions” settings.
- actions/checkout@v4 remains compatible, as contents: write includes read access necessary for checkout.
