### PR TITLE
Fix Gemini Role Mapping for API Compatibility

### DIFF
--- a/internal/plugins/ai/gemini/gemini.go
+++ b/internal/plugins/ai/gemini/gemini.go
@@ -336,6 +336,19 @@ func (o *Client) convertMessages(msgs []*chat.ChatCompletionMessage) []*genai.Co
 	for _, msg := range msgs {
 		content := &genai.Content{Parts: []*genai.Part{}}
 
+		switch msg.Role {
+		case chat.ChatMessageRoleAssistant:
+			content.Role = "model"
+		case chat.ChatMessageRoleUser:
+			content.Role = "user"
+		case chat.ChatMessageRoleSystem, chat.ChatMessageRoleDeveloper, chat.ChatMessageRoleFunction, chat.ChatMessageRoleTool:
+			// Gemini's API only accepts "user" and "model" roles.
+			// Map all other roles to "user" to preserve instruction context.
+			content.Role = "user"
+		default:
+			content.Role = "user"
+		}
+
 		if msg.Content != "" {
 			content.Parts = append(content.Parts, &genai.Part{Text: msg.Content})
 		}

--- a/internal/plugins/ai/gemini/gemini_test.go
+++ b/internal/plugins/ai/gemini/gemini_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"google.golang.org/genai"
+
+	"github.com/danielmiessler/fabric/internal/chat"
 )
 
 // Test buildModelNameFull method
@@ -48,6 +50,30 @@ func TestExtractTextFromResponse(t *testing.T) {
 
 	if result != expected {
 		t.Errorf("Expected %v, got %v", expected, result)
+	}
+}
+
+// Test convertMessages handles role mapping correctly
+func TestConvertMessagesRoles(t *testing.T) {
+	client := &Client{}
+	msgs := []*chat.ChatCompletionMessage{
+		{Role: chat.ChatMessageRoleUser, Content: "user"},
+		{Role: chat.ChatMessageRoleAssistant, Content: "assistant"},
+		{Role: chat.ChatMessageRoleSystem, Content: "system"},
+	}
+
+	contents := client.convertMessages(msgs)
+
+	expected := []string{"user", "model", "user"}
+
+	if len(contents) != len(expected) {
+		t.Fatalf("expected %d contents, got %d", len(expected), len(contents))
+	}
+
+	for i, c := range contents {
+		if c.Role != expected[i] {
+			t.Errorf("content %d expected role %s, got %s", i, expected[i], c.Role)
+		}
 	}
 }
 


### PR DESCRIPTION
# Fix Gemini Role Mapping for API Compatibility

## Summary

This PR fixes role mapping in the Gemini AI plugin and adds corresponding test coverage. The changes ensure that chat completion messages are properly converted to Gemini API format by explicitly mapping message roles to the limited role types supported by Gemini's API.

## Files Changed

- **`.vscode/settings.json`**: Added two new words to the spell checker dictionary: "kballard" and "shellquote"
- **`internal/plugins/ai/gemini/gemini.go`**: Added explicit role mapping logic in the `convertMessages` method
- **`internal/plugins/ai/gemini/gemini_test.go`**: Added new test case to verify role mapping functionality

## Code Changes

### internal/plugins/ai/gemini/gemini.go

Added role mapping logic in the `convertMessages` method:

```go
switch msg.Role {
case chat.ChatMessageRoleAssistant:
    content.Role = "model"
case chat.ChatMessageRoleUser:
    content.Role = "user"
case chat.ChatMessageRoleSystem, chat.ChatMessageRoleDeveloper, chat.ChatMessageRoleFunction, chat.ChatMessageRoleTool:
    // Gemini's API only accepts "user" and "model" roles.
    // Map all other roles to "user" to preserve instruction context.
    content.Role = "user"
default:
    content.Role = "user"
}
```

### internal/plugins/ai/gemini/gemini_test.go

Added `TestConvertMessagesRoles` function to verify that:
- User messages are mapped to "user" role
- Assistant messages are mapped to "model" role  
- System messages are mapped to "user" role

## Reason for Changes

The Gemini API only supports two role types: "user" and "model". Previously, the code was not explicitly handling role mapping, which could have caused issues when messages with unsupported roles (like "system", "developer", "function", or "tool") were sent to the API. This change ensures compatibility with Gemini's API requirements while preserving the context of system and other instruction messages by mapping them to the "user" role.

## Impact of Changes

- **Compatibility**: Ensures all message types are properly handled when communicating with Gemini API
- **Reliability**: Prevents potential API errors due to unsupported role types
- **Functionality**: System messages and other instruction types are preserved as user messages, maintaining their instructional context
- **Testing**: Improved test coverage for the role conversion functionality

## Test Plan

The changes include a new unit test `TestConvertMessagesRoles` that verifies:
1. User messages are correctly mapped to "user" role
2. Assistant messages are correctly mapped to "model" role
3. System messages are correctly mapped to "user" role
4. The conversion maintains the correct number of messages

## Additional Notes

### Potential Issues to Monitor

1. **Context Loss**: While system messages are preserved by mapping to "user" role, the semantic distinction between system instructions and user input is lost at the API level
2. **Message Order**: The mapping might affect how Gemini interprets conversation flow, particularly when system messages are interspersed with user/assistant messages
3. **Token Usage**: Converting system messages to user messages might affect token counting and billing
