### PR TITLE
Prevent duplicate text output in OpenAI streaming responses

### DIFF
--- a/cmd/generate_changelog/incoming/1686.txt
+++ b/cmd/generate_changelog/incoming/1686.txt
@@ -1,0 +1,7 @@
+### PR [#1686](https://github.com/danielmiessler/Fabric/pull/1686) by [ksylvan](https://github.com/ksylvan): Prevent duplicate text output in OpenAI streaming responses
+
+- Fix: prevent duplicate text output in OpenAI streaming responses
+- Skip processing of ResponseOutputTextDone events
+- Prevent doubled text in stream output
+- Add clarifying comment about API behavior
+- Maintain delta chunk streaming functionality

--- a/internal/plugins/ai/openai/openai.go
+++ b/internal/plugins/ai/openai/openai.go
@@ -115,7 +115,11 @@ func (o *Client) sendStreamResponses(
 		case string(constant.ResponseOutputTextDelta("").Default()):
 			channel <- event.AsResponseOutputTextDelta().Delta
 		case string(constant.ResponseOutputTextDone("").Default()):
-			channel <- event.AsResponseOutputTextDone().Text
+			// The Responses API sends the full text again in the
+			// final "done" event. Since we've already streamed all
+			// delta chunks above, sending it would duplicate the
+			// output. Ignore it here to prevent doubled results.
+			continue
 		}
 	}
 	if stream.Err() == nil {


### PR DESCRIPTION
# Prevent duplicate text output in OpenAI streaming responses

## Summary

Stop forwarding the final ResponseOutputTextDone text payload in streaming responses to prevent duplicated output. The OpenAI Responses API sends the full accumulated text again in the “done” event; since we already stream all deltas, emitting the final text duplicates content. We now ignore the final text and rely on the stream closing to signal completion.

## Related Issues

Closes #1684 

## Files Changed

- internal/plugins/ai/openai/openai.go
  - Modified sendStreamResponses to no longer send the final text on ResponseOutputTextDone events. Added an explanatory comment.

## Code Changes

- In sendStreamResponses, replace emitting the final text with a no-op:

```go
case string(constant.ResponseOutputTextDone("").Default()):
    // The Responses API sends the full text again in the
    // final "done" event. Since we've already streamed all
    // delta chunks above, sending it would duplicate the
    // output. Ignore it here to prevent doubled results.
    continue
```

Previously this branch sent the final text:
```go
channel <- event.AsResponseOutputTextDone().Text
```

## Reason for Changes

- Bug fix: Streaming consumers were receiving duplicated output because we:
  1) streamed text via ResponseOutputTextDelta chunks, and then
  2) sent the full accumulated text again on ResponseOutputTextDone.
- This resulted in repeated content in UIs and logs and forced downstream consumers to implement deduplication. Ignoring the final text eliminates the duplication.

## Impact of Changes

- Behavior:
  - Consumers of the streaming channel will no longer get a final “full text” message. They will only receive the deltas and must assemble them if they need the full text.
  - The end of the stream (and channel closure) remains the signal for completion.
- Compatibility:
  - If any downstream logic relied on the content of the done event (rather than the deltas) to render the final output, it will need to switch to aggregating deltas.
- Reliability vs duplication trade-off:
  - Previously, the done event could act as a “fallback” full text if a delta were missed. We are opting for correctness (no duplication) and consistency with typical streaming semantics. If needed, we can revisit with an opt-in behavior or conditional logic (see Additional Notes).

## Test Plan

- Unit tests:
  - Simulate a stream of:
    - ResponseOutputTextDelta: “Hel”, “lo”
    - ResponseOutputTextDone: “Hello”
  - Assert the channel yields only “Hel”, “lo” and does not include “Hello”.
  - Verify the channel closes properly and that stream.Err() handling is unchanged.
- Integration tests:
  - Manual test against the OpenAI Responses API to confirm:
    - No duplicated content is rendered in the UI/logs.
    - Finalization and channel closure still occur as expected.
- Regression:
  - Confirm non-text events and error propagation are unaffected.

## Additional Notes

- If we later discover providers that include additional metadata (not just duplicated text) in the done event, we may:
  - Forward only metadata while skipping text, or
  - Make forwarding the done payload configurable.
- As a future improvement, we could conditionally drop the done text only if at least one delta has been streamed or if the done payload equals the concatenation of deltas, but this adds buffering/complexity and was not necessary for this fix.