### PR TITLE
Add Web Search Tool Support for Gemini Models

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,7 +536,7 @@ Application Options:
       --liststrategies              List all strategies
       --listvendors                 List all vendors
       --shell-complete-list         Output raw list without headers/formatting (for shell completion)
-      --search                      Enable web search tool for supported models (Anthropic, OpenAI)
+      --search                      Enable web search tool for supported models (Anthropic, OpenAI, Gemini)
       --search-location=            Set location for web search results (e.g., 'America/Los_Angeles')
       --image-file=                 Save generated image to specified file path (e.g., 'output.png')
       --image-size=                 Image dimensions: 1024x1024, 1536x1024, 1024x1536, auto (default: auto)

--- a/cmd/generate_changelog/incoming/1687.txt
+++ b/cmd/generate_changelog/incoming/1687.txt
@@ -1,0 +1,7 @@
+### PR [#1687](https://github.com/danielmiessler/Fabric/pull/1687) by [ksylvan](https://github.com/ksylvan): Add Web Search Tool Support for Gemini Models
+
+- Enable Gemini models to use web search tool with --search flag
+- Add validation for search-location timezone and language code formats
+- Normalize language codes from underscores to hyphenated form
+- Append deduplicated web citations under standardized Sources section
+- Improve robustness for nil candidates and content parts

--- a/completions/_fabric
+++ b/completions/_fabric
@@ -98,7 +98,7 @@ _fabric() {
     '(--api-key)--api-key[API key used to secure server routes]:api-key:' \
     '(--config)--config[Path to YAML config file]:config file:_files -g "*.yaml *.yml"' \
     '(--version)--version[Print current version]' \
-    '(--search)--search[Enable web search tool for supported models (Anthropic, OpenAI)]' \
+    '(--search)--search[Enable web search tool for supported models (Anthropic, OpenAI, Gemini)]' \
     '(--search-location)--search-location[Set location for web search results]:location:' \
     '(--image-file)--image-file[Save generated image to specified file path]:image file:_files -g "*.png *.webp *.jpeg *.jpg"' \
     '(--image-size)--image-size[Image dimensions]:size:(1024x1024 1536x1024 1024x1536 auto)' \

--- a/completions/fabric.fish
+++ b/completions/fabric.fish
@@ -99,7 +99,7 @@ complete -c fabric -l yt-dlp-args -d "Additional arguments to pass to yt-dlp (e.
 complete -c fabric -l readability -d "Convert HTML input into a clean, readable view"
 complete -c fabric -l input-has-vars -d "Apply variables to user input"
 complete -c fabric -l dry-run -d "Show what would be sent to the model without actually sending it"
-complete -c fabric -l search -d "Enable web search tool for supported models (Anthropic, OpenAI)"
+complete -c fabric -l search -d "Enable web search tool for supported models (Anthropic, OpenAI, Gemini)"
 complete -c fabric -l serve -d "Serve the Fabric Rest API"
 complete -c fabric -l serveOllama -d "Serve the Fabric Rest API with ollama endpoints"
 complete -c fabric -l version -d "Print current version"

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -79,7 +79,7 @@ type Flags struct {
 	ListStrategies                  bool              `long:"liststrategies" description:"List all strategies"`
 	ListVendors                     bool              `long:"listvendors" description:"List all vendors"`
 	ShellCompleteOutput             bool              `long:"shell-complete-list" description:"Output raw list without headers/formatting (for shell completion)"`
-	Search                          bool              `long:"search" description:"Enable web search tool for supported models (Anthropic, OpenAI)"`
+	Search                          bool              `long:"search" description:"Enable web search tool for supported models (Anthropic, OpenAI, Gemini)"`
 	SearchLocation                  string            `long:"search-location" description:"Set location for web search results (e.g., 'America/Los_Angeles')"`
 	ImageFile                       string            `long:"image-file" description:"Save generated image to specified file path (e.g., 'output.png')"`
 	ImageSize                       string            `long:"image-size" description:"Image dimensions: 1024x1024, 1536x1024, 1024x1536, auto (default: auto)"`


### PR DESCRIPTION
# Add Web Search Tool Support for Gemini Models

## Summary

Add first-class web search tool support for Gemini models behind the existing --search flag, with optional location controls, and append standardized citations to Gemini responses. Update CLI help text, README, and shell completions to reflect Gemini support.

## Related Issues

Closes #1656

## Demo of Change

Before change:

```text
fabric --search -m gemini-2.5-flash 'What are the top three news items for today?'
I am sorry, but I do not have access to real-time news feeds or current events. My knowledge base was last updated at a specific point in time, and I cannot provide information on "today's" top three news items.

To find out the top news items for today, I recommend checking reputable news sources such as:

*   **Major News Websites:** BBC News, Reuters, Associated Press, The New York Times, The Wall Street Journal, The Guardian, CNN, Fox News, etc.
*   **News Aggregators:** Google News, Apple News, Flipboard.
*   **Local News Outlets:** For news specific to your region.
```

After change:

```text
fabric --search -m gemini-2.5-flash 'What are the top three news items for today?'
Here are the top three news items for August 11, 2025:

*   **INDIA Bloc's Protest March to Election Commission:** The INDIA bloc, led by Rahul Gandhi, is scheduled to march to the Election Commission of India (ECI) headquarters to protest against alleged electoral malpractices and "vote chori" (vote theft) in Bihar. Congress president Mallikarjun Kharge is set to host a dinner meeting with MPs to strategize on this issue.
*   **Israel's Plans for Gaza and International Reactions:** Israeli Prime Minister Benjamin Netanyahu has defended his plan to take control of Gaza City and target remaining Hamas strongholds, stating it is "the best way to end the war." The United States has supported Israel's right to decide its security, while other UN Security Council members and officials have expressed alarm over the humanitarian crisis, with China calling the "collective punishment" of people in Gaza unacceptable.
*   **Europe Advocates for Ukraine's Inclusion in Trump-Putin Talks:** European leaders are pushing for Ukraine to be part of negotiations between the United States and Russia, ahead of anticipated talks between presidents Vladimir Putin and Donald Trump.

## Sources

- [indiatimes.com](https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQERkrlC-VmVMPstFBPEimkuA0KPydcS868jLIjOGgk3Ph3D6SVSoo7MzItKUPBDl1zieJFLNGEQTLFHAgrVu-XFy3Q-8o1uPt36RIw7aRJDU5qgy3NAk-IHn-kSJAim7kj9nQkJKJU9aemY5igLXxWHBfRPYXOzfarZ60PVwZD-feUsLezPkUgGjzvlQZJY6aejJltrxZ9ogw==)
- [thehindu.com](https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQFWFC-DJZlK1QvOrD9XgCvUzgtUWOV-LqD61JGZreiJP5OcUCXYq8bcDGeeAEL3bfsoTb9XipDQ8fKPA-CVTZu-eHgkUVXlNQbIpNsQsvc2rR7n_n-8VoFl9yDB-TyfHi7tBHlPu7yg1qyeoss9s1g0bhNv7LsoNjdKeqPgdwKB-VFt2Ivu2a9KsIc=)
- [youtube.com](https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQEnYKg5VKnewAh6pou9YvY--w1k6-ChD652Z915CWmnbSS1mtUGfbKSw0XTWHgyIS_-Te8KX2gjBudTpWoHpE5C_yHKtgLnbCsM7G9lqLiHgAFFrD0zcTk0Atrx66z0Wo4IG-monFU=)
- [leverageedu.com](https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQGW5tuMkLCc3PFRNrMsHsjLyL_q94AjOV_vP1E9fk1nhdxa17J_ogqSPVLvIYQmt922KQERhvqL3RBZ7iuqCexe5GeY2C3mYy90eSaGG4ZB38t_QyY_sBrYsxXTOZ94l0DtfAbkJTzgXW1IywTAd_REv-4jw7S0kYKlgRdfzsXxl53up7e27bhC4UiDgxVjfLK_SAnMs6qwD6alVg==)
- [hindustantimes.com](https://vertexaisearch.cloud.google.com/grounding-api-redirect/AUZIYQEJas8rf8KiIzJvxr4BYnjiwE7OB2wjBQD0uaCvWPMigp6j46dfHoUv7_AVYh8HPKyraIJqb36tOsqrhYLEqfidC777c67BNMUT0-VFGAP8dlQTPE7lt01rgyzN4XlVd6f0V3LYBHzlU9HkqMM2xIjOZBf0ydxVnF7arAgh0Myi8kI-a2PbS1_MuTIq0Q_g_nXnpk4VkD0Ap6kDcvtnMwheaejd6_gg8znj3IeSf3-EqTSobC4fDqbqCIpDKOQMBhZnylT7qIGveK6dimPdms949i6l8JF7)
```

## Files Changed

- README.md
  - Updated the --search flag description to include Gemini.
- completions/_fabric (zsh)
  - Updated the --search completion description to include Gemini.
- completions/fabric.fish (fish)
  - Updated the --search completion description to include Gemini.
- internal/cli/flags.go
  - Updated the --search flag description string to include Gemini.
- internal/plugins/ai/gemini/gemini.go
  - Inject Google Search tool for Gemini when --search is enabled, validate and normalize search-location, and append deduplicated web citations to responses.
  - Small refactors and constants to improve readability and reusability.
- internal/plugins/ai/gemini/gemini_test.go
  - Added unit tests for search tooling, location validation/normalization, and citation formatting.

## Code Changes

- Enable Google Search tool for Gemini models:

```go
func (o *Client) buildGenerateContentConfig(opts *domain.ChatOptions) (*genai.GenerateContentConfig, error) {
  temperature := float32(opts.Temperature)
  topP := float32(opts.TopP)
  cfg := &genai.GenerateContentConfig{
    Temperature:     &temperature,
    TopP:            &topP,
    MaxOutputTokens: int32(opts.ModelContextLength),
  }

  if opts.Search {
    cfg.Tools = []*genai.Tool{{GoogleSearch: &genai.GoogleSearch{}}}
    if loc := opts.SearchLocation; loc != "" {
      if isValidLocationFormat(loc) {
        loc = normalizeLocation(loc) // e.g., en_US -> en-US
        cfg.ToolConfig = &genai.ToolConfig{
          RetrievalConfig: &genai.RetrievalConfig{LanguageCode: loc},
        }
      } else {
        return nil, fmt.Errorf(errInvalidLocationFormat, loc)
      }
    }
  }
  return cfg, nil
}
```

- Validate and normalize location input:
  - Accept either timezone-like strings "Continent/City" or language codes "ll" or "ll-CC".
  - Normalize underscores to hyphens for language codes:
```go
func isValidLocationFormat(location string) bool { ... }
func normalizeLocation(location string) string { ... }
func isValidLanguageCode(code string) bool { ... }
```

- Append citations to Gemini responses when present, with deduplication and stable formatting:

```go
const (
  citationHeader = "\n\n## Sources\n\n"
  citationFormat = "- [%s](%s)"
)

func (o *Client) extractTextFromResponse(response *genai.GenerateContentResponse) string {
  if response == nil { return "" }
  text := o.extractTextParts(response)
  citations := o.extractCitations(response)
  if len(citations) > 0 {
    return text + citationHeader + strings.Join(citations, "\n")
  }
  return text
}
```

- Minor refactors:
  - Centralized "models/" prefix constant:
    ```go
    const modelPrefix = "models/"
    ...
    func (o *Client) buildModelNameFull(modelName string) string { ... }
    ```
  - TTS detection uses constants for model type tokens.

- CLI/documentation updates:
  - README, zsh, fish completions, and flag descriptions now include “Gemini” for --search.

## Reason for Changes

- Feature parity: Extend the web search capability previously available for Anthropic and OpenAI to Gemini.
- Better results and transparency: Enable grounding via Google Search and provide inline citations to improve verifiability of model outputs.
- UX consistency: Reflect Gemini support across help, README, and shell completions.

## Impact of Changes

- New behavior for Gemini when --search is provided:
  - The Google Search tool is enabled, potentially improving factuality.
  - If --search-location is provided, it is validated and normalized (e.g., en_US → en-US). Invalid values now produce an error.
- Output format change for Gemini responses:
  - When citations are available, the text will include a “## Sources” section with a bulleted list of unique sources, e.g.:
    - [- [Title](https://example.com)]
  - This can affect downstream consumers expecting only raw model text. Consumers should strip or handle the Sources section if necessary.
- Performance/latency:
  - Searches can add latency and token usage; users can disable with --search=false (default behavior unchanged).

## Test Plan

- Unit tests (internal/plugins/ai/gemini/gemini_test.go):
  - buildGenerateContentConfig: with/without search, valid/invalid search-location, and normalization (en_US → en-US).
  - extractTextFromResponse: nil response, empty grounding chunks, and citation formatting with deduplication.
- Manual tests:
  - Run with Gemini models:
    - fabric --vendor Gemini --search "What’s the latest on X?"
    - fabric --vendor Gemini --search --search-location en-US "topic"
    - fabric --vendor Gemini --search --search-location America/Los_Angeles "local news"
  - Verify Sources section presence when web grounding occurs.
  - Validate errors for invalid --search-location (e.g., "invalid").
  - Streamed mode: confirm streaming works and errors surface early for invalid location.

## Additional Notes

- Location semantics: The search-location supports either timezone (“Continent/City”) or language code (“ll”/“ll-CC”). Internally this is applied to RetrievalConfig.LanguageCode. Depending on upstream API behavior, timezone strings may be treated similarly to locale; if the API changes, we may need to map timezones to locales explicitly.
- Language code validation is intentionally strict (ll or ll-CC). Locales with script codes (e.g., zh-Hans-CN) are not currently supported and will be rejected.
- Citation deduplication uses the (URI|Title) pair as the uniqueness key. Items missing either title or URI are ignored.