### PR TITLE
Introduce One-Liner Curl Install for Completions

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Keep in mind that many of these were recorded when Fabric was Python-based, so r
     - [Migration](#migration)
     - [Upgrading](#upgrading)
     - [Shell Completions](#shell-completions)
+      - [Quick install (no clone required)](#quick-install-no-clone-required)
       - [Zsh Completion](#zsh-completion)
       - [Bash Completion](#bash-completion)
       - [Fish Completion](#fish-completion)
@@ -427,6 +428,25 @@ go install github.com/danielmiessler/fabric/cmd/fabric@latest
 Fabric provides shell completion scripts for Zsh, Bash, and Fish
 shells, making it easier to use the CLI by providing tab completion
 for commands and options.
+
+#### Quick install (no clone required)
+
+You can install completions directly via a one-liner:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions/setup-completions.sh | sh
+```
+
+Optional variants:
+
+```bash
+# Dry-run (see actions without changing your system)
+curl -fsSL https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions/setup-completions.sh | sh -s -- --dry-run
+
+# Override the download source (advanced)
+FABRIC_COMPLETIONS_BASE_URL="https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions" \
+    sh -c "$(curl -fsSL https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions/setup-completions.sh)"
+```
 
 #### Zsh Completion
 

--- a/cmd/generate_changelog/incoming/1695.txt
+++ b/cmd/generate_changelog/incoming/1695.txt
@@ -1,0 +1,7 @@
+### PR [#1695](https://github.com/danielmiessler/Fabric/pull/1695) by [ksylvan](https://github.com/ksylvan): Introduce One-Liner Curl Install for Completions
+
+- Add one-liner curl install method for shell completions without requiring repository cloning
+- Support downloading completions when files are missing locally with dry-run option for previewing changes
+- Enable custom download source via environment variable and create temporary directory for downloaded completion files
+- Add automatic cleanup of temporary files and validate downloaded files are non-empty and not HTML
+- Improve error handling and standardize logging by routing informational messages to stderr to avoid stdout pollution

--- a/completions/setup-completions.sh
+++ b/completions/setup-completions.sh
@@ -113,18 +113,19 @@ obtain_completion_files() {
         return 0
     fi
 
-    print_info "Local completion files not found; will download from GitHub." 1>&2
-    print_info "Source: $FABRIC_COMPLETIONS_BASE_URL" 1>&2
+    # Note: write only to stderr in this function except for the final echo which returns the path
+    printf "%s\n" "[INFO] Local completion files not found; will download from GitHub." 1>&2
+    printf "%s\n" "[INFO] Source: $FABRIC_COMPLETIONS_BASE_URL" 1>&2
 
     if [ "$DRY_RUN" = true ]; then
-        print_dry_run "Would create temporary directory for downloads" 1>&2
+    printf "%s\n" "[DRY-RUN] Would create temporary directory for downloads" 1>&2
     echo "$obf_script_dir" # Keep using original for dry-run copies
         return 0
     fi
 
     TEMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t fabric-completions)"
     if [ ! -d "$TEMP_DIR" ]; then
-        print_error "Failed to create temporary directory for downloads."
+    print_error "Failed to create temporary directory for downloads."
         return 1
     fi
 

--- a/docs/Shell-Completions.md
+++ b/docs/Shell-Completions.md
@@ -4,10 +4,24 @@ Fabric comes with shell completion support for Zsh, Bash, and Fish shells. These
 
 ## Quick Setup (Automated)
 
-For a quick automated installation, use the setup script:
+You can install completions without cloning the repo:
 
 ```bash
-# Run the automated setup script
+# No-clone install (Zsh/Bash/Fish supported)
+curl -fsSL https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions/setup-completions.sh | sh
+
+# Optional: dry-run first
+curl -fsSL https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions/setup-completions.sh | sh -s -- --dry-run
+
+# Optional: override the download source
+FABRIC_COMPLETIONS_BASE_URL="https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions" \
+   sh -c "$(curl -fsSL https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions/setup-completions.sh)"
+```
+
+Or, if you have the repository locally:
+
+```bash
+# Run the automated setup script from a cloned repo
 ./completions/setup-completions.sh
 
 # Or see what it would do first
@@ -21,6 +35,8 @@ The script will:
 - Use your existing `$fpath` directories (for zsh) or standard completion directories
 - Install the completion file with the correct name
 - Provide instructions for enabling the completions
+
+If the completion files aren't present locally (e.g., when running via `curl`), the script will automatically download them from GitHub.
 
 For manual installation or troubleshooting, see the detailed instructions below.
 


### PR DESCRIPTION
# Introduce One-Liner Curl Install for Completions

## Summary

Add “no-clone” install support for shell completions by teaching the setup script to fetch completion files from GitHub when they are not present locally. Update README and docs with a one-liner install, dry-run support, and an environment variable to override the download source.

## Files Changed

- README.md
  - Added a “Quick install (no clone required)” section under Shell Completions with:
    - A one-liner install command (curl | sh).
    - Optional dry-run and override source examples.

- completions/setup-completions.sh
  - Enhancements:
    - Auto-download completion files (_fabric, fabric.bash, fabric.fish) if not found locally.
    - Support for overriding download base via FABRIC_COMPLETIONS_BASE_URL.
    - Added curl/wget fallback downloader and GitHub URL “blob/tree” → “raw” conversion.
    - Temporary directory handling and cleanup via trap.
    - Updated help text and examples.
    - Minor API change: setup_other_shell_completions now accepts script_dir.

- docs/Shell-Completions.md
  - Rewrote “Quick Setup (Automated)” to document:
    - No-clone install path.
    - Dry-run and override source examples.
    - Clarification that the script will download files if they aren’t present locally.
  - Retained instructions for running from a cloned repo.

## Code Changes

- New configurable download base (defaults to the repo’s main branch):
```sh
## Base URL to fetch completion files when not available locally
## Can be overridden via environment variable FABRIC_COMPLETIONS_BASE_URL
FABRIC_COMPLETIONS_BASE_URL="${FABRIC_COMPLETIONS_BASE_URL:-https://raw.githubusercontent.com/danielmiessler/Fabric/refs/heads/main/completions}"
```

- GitHub URL normalization for user-supplied override sources:
```sh
to_github_raw_url() {
    in_url="$1"
    case "$in_url" in
        https://github.com/*/*/blob/*)
            echo "$in_url" | sed -E 's#https://github.com/([^/]+)/([^/]+)/blob/([^/]+)/#https://raw.githubusercontent.com/\1/\2/\3/#'
            ;;
        https://github.com/*/*/tree/*)
            echo "$in_url" | sed -E 's#https://github.com/([^/]+)/([^/]+)/tree/([^/]+)/#https://raw.githubusercontent.com/\1/\2/\3/#'
            ;;
        *)
            echo "$in_url"
            ;;
    esac
}
```

- Robust downloader with curl → wget fallback and error messaging:
```sh
download_file() {
    url="$1"; dest="$2"
    [ "$DRY_RUN" = true ] && { print_dry_run "Would download: $url -> $dest"; return 0; }

    eff_url="$(to_github_raw_url "$url")"
    if command -v curl >/dev/null 2>&1; then
        curl -fsSL "$eff_url" -o "$dest"
    elif command -v wget >/dev/null 2>&1; then
        wget -q "$eff_url" -O "$dest"
    else
        print_error "Neither 'curl' nor 'wget' is available to download: $url"
        return 1
    fi
}
```

- Auto-acquire completion files into a temporary directory when missing locally, with basic content validation and cleanup:
```sh
obtain_completion_files() {
    obf_script_dir="$1"
    # If local copies are present, use them
    if [ -f "$obf_script_dir/_fabric" ] && [ -f "$obf_script_dir/fabric.bash" ] && [ -f "$obf_script_dir/fabric.fish" ]; then
        echo "$obf_script_dir"; return 0
    fi

    printf "%s\n" "[INFO] Local completion files not found; will download from GitHub." 1>&2
    printf "%s\n" "[INFO] Source: $FABRIC_COMPLETIONS_BASE_URL" 1>&2

    [ "$DRY_RUN" = true ] && { printf "%s\n" "[DRY-RUN] Would create temporary directory for downloads" 1>&2; echo "$obf_script_dir"; return 0; }

    TEMP_DIR="$(mktemp -d 2>/dev/null || mktemp -d -t fabric-completions)" || { print_error "Failed to create temporary directory for downloads."; return 1; }

    download_file "$FABRIC_COMPLETIONS_BASE_URL/_fabric" "$TEMP_DIR/_fabric"     || { print_error "Failed to download _fabric"; return 1; }
    download_file "$FABRIC_COMPLETIONS_BASE_URL/fabric.bash" "$TEMP_DIR/fabric.bash" || { print_error "Failed to download fabric.bash"; return 1; }
    download_file "$FABRIC_COMPLETIONS_BASE_URL/fabric.fish" "$TEMP_DIR/fabric.fish" || { print_error "Failed to download fabric.fish"; return 1; }

    # Reject obvious HTML/empty responses
    for f in _fabric fabric.bash fabric.fish; do
        if [ ! -s "$TEMP_DIR/$f" ] || head -n1 "$TEMP_DIR/$f" | grep -qi "^<!DOCTYPE\|^<html"; then
            print_error "Downloaded $f appears invalid (empty or HTML). Check FABRIC_COMPLETIONS_BASE_URL."
            return 1
        fi
    done

    echo "$TEMP_DIR"
}
```

- Integrate auto-acquisition and cleanup into main flow; pass script_dir to “other shell” handler:
```sh
script_dir="$(get_script_dir)"
script_dir="$(obtain_completion_files "$script_dir" || echo "")"
[ -z "$script_dir" ] && { print_error "Unable to obtain completion files. Aborting."; exit 1; }

if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then
    trap 'if [ -n "$TEMP_DIR" ] && [ -d "$TEMP_DIR" ]; then rm -rf "$TEMP_DIR"; fi' EXIT INT TERM
fi

## ...
setup_other_shell_completions "$fabric_cmd" "$shell_name" "$script_dir"
```

- Updated usage/help text and examples to reflect new behavior, including override of FABRIC_COMPLETIONS_BASE_URL.

## Reason for Changes

- Improve onboarding and reduce friction: enable users to install completions without cloning the repository.
- Provide a safer, more robust installation path:
  - Dry-run mode to preview actions.
  - Explicit download source overrides for advanced users or mirrors.
  - Curl/wget fallback to work across environments.
  - Sanity checks and cleanup to avoid littering tmp directories and to detect invalid downloads.

## Impact of Changes

- User experience: A single command installs completions for Zsh/Bash/Fish; documentation is clearer.
- Backwards compatibility: Existing workflows that run the script from a cloned repo continue to work unchanged.
- Operational robustness:
  - Works when completion files aren’t next to the script (e.g., curl | sh).
  - Cleaner behavior due to validation and trap-based tmp cleanup.
- Minimal maintenance overhead: Default base URL points at main; advanced users can override to pin to tags/commits or private mirrors.

## Test Plan

Manual verification across shells and platforms:

- Dry-run:
  - curl … | sh -s -- --dry-run on macOS and Linux with zsh/bash/fish to confirm no changes are made and all intended actions are listed.
- No-clone install:
  - zsh: curl … | sh → confirm _fabric installed to a searchable completion dir and zcompinit instructions are shown or appended where appropriate.
  - bash: confirm fabric.bash is installed and either auto-sourced or instructions are shown.
  - fish: confirm fabric.fish installed under ~/.config/fish/completions.
- Override source:
  - Set FABRIC_COMPLETIONS_BASE_URL to:
    - The default raw URL (control).
    - A specific tag/commit raw URL.
    - A GitHub “blob” and “tree” URL to exercise to_github_raw_url conversions.
- Tool availability:
  - Disable curl to force wget path; verify downloads succeed.
  - Disable both curl and wget to verify user-friendly error.
- Validation:
  - Temporarily set FABRIC_COMPLETIONS_BASE_URL to an invalid URL; confirm error about invalid/HTML content.
- Cleanup:
  - Confirm temporary directories are removed after successful and failed runs.
- “Other shell” path:
  - Force unsupported shell_name and verify instructions include correct paths using provided script_dir.

## Additional Notes

- Interpreter compatibility: The docs demonstrate piping to sh. If the script contains bash-specific constructs in parts not modified here, running via sh may fail because piping bypasses the script’s shebang. If we rely on bash features, we should change the docs’ one-liner to use bash explicitly:
  - Example: curl -fsSL …/setup-completions.sh | bash
  Please confirm the script is POSIX-sh clean end-to-end or update the docs accordingly.

- Security: As with any curl | shell pattern, users should review the script or use the dry-run first.

- Potential edge cases:
  - Sudo prompts in non-interactive contexts may fail; dry-run and manual instructions help mitigate.
  - If a user overrides FABRIC_COMPLETIONS_BASE_URL to a directory listing or non-raw endpoint, downloads will fail or be flagged as invalid—this is by design.

- Future improvement:
  - Option to pin FABRIC_COMPLETIONS_BASE_URL to a release tag in the docs to ensure reproducibility.