### PR TITLE
add pattern-model mapping with CLI management and automatic model selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -536,6 +536,8 @@ cp completions/fabric.fish ~/.config/fish/completions/
 
 Once you have it all set up, here's how to use it.
 
+You can assign default models to specific patterns and manage these mappings via `fabric pattern-model set|unset|list`. See the [Pattern Model Mapping documentation](./docs/Pattern-Models.md) for details.
+
 ```bash
 fabric -h
 ```

--- a/docs/Pattern-Models.md
+++ b/docs/Pattern-Models.md
@@ -1,0 +1,26 @@
+# Pattern Model Mapping
+
+Fabric can automatically select a model for a pattern based on a user-defined mapping file.
+
+## Configuration
+
+Create `~/.config/fabric/pattern_models.yaml` with entries mapping pattern names to models:
+
+```yaml
+summarize: openai/gpt-4o-mini
+ai: anthropic/claude-3-opus
+```
+
+The key is the pattern name. The value is the model identifier. If the value includes a vendor prefix (e.g. `openai/`), Fabric sets both the vendor and model accordingly.
+
+When you run a pattern without specifying `--model`, Fabric consults this file to determine the model to use.
+
+## Helper Command
+
+You can manage this mapping from the command line:
+
+```bash
+fabric pattern-model set <pattern> <model>
+```
+
+This updates the mapping file, creating it if necessary.

--- a/docs/Pattern-Models.md
+++ b/docs/Pattern-Models.md
@@ -4,7 +4,7 @@ Fabric can automatically select a model for a pattern based on a user-defined ma
 
 ## Configuration
 
-Create `~/.config/fabric/pattern_models.yaml` with entries mapping pattern names to models:
+Create a `pattern_models.yaml` file in your user configuration directory (for example, `~/.config/fabric/pattern_models.yaml`) with entries mapping pattern names to models:
 
 ```yaml
 summarize: openai/gpt-4o-mini

--- a/docs/Pattern-Models.md
+++ b/docs/Pattern-Models.md
@@ -20,7 +20,10 @@ When you run a pattern without specifying `--model`, Fabric consults this file t
 You can manage this mapping from the command line:
 
 ```bash
+
+fabric pattern-model list
 fabric pattern-model set <pattern> <model>
+fabric pattern-model unset <pattern>
 ```
 
-This updates the mapping file, creating it if necessary.
+`set` updates the mapping file, creating it if necessary. `unset` removes a mapping. `list` shows all current mappings.

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -26,7 +26,6 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 		} else {
 
 			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
-
 				parts := strings.SplitN(modelSpec, "/", 2)
 				if len(parts) == 2 {
 					currentFlags.Vendor = parts[0]

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -20,13 +20,13 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 	}
 
 	if currentFlags.Pattern != "" && currentFlags.Model == "" {
-
 		mapping, err2 := loadPatternModelMapping()
 		if err2 != nil {
 			fmt.Fprintf(os.Stderr, "Failed to load pattern-model mapping: %v. Please check your mapping file.\n", err2)
 		} else {
 
 			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
+
 				parts := strings.SplitN(modelSpec, "/", 2)
 				if len(parts) == 2 {
 					currentFlags.Vendor = parts[0]

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -20,7 +20,10 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 	}
 
 	if currentFlags.Pattern != "" && currentFlags.Model == "" {
-		if mapping, err2 := loadPatternModelMapping(); err2 == nil {
+		mapping, err2 := loadPatternModelMapping()
+		if err2 != nil {
+			fmt.Fprintf(os.Stderr, "Failed to load pattern-model mapping: %v. Please check your mapping file.\n", err2)
+		} else {
 			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
 				parts := strings.SplitN(modelSpec, "/", 2)
 				if len(parts) == 2 {

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -25,7 +25,7 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 			fmt.Fprintf(os.Stderr, "Failed to load pattern-model mapping: %v. Please check your mapping file.\n", err2)
 		} else {
 
-			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
+			if modelSpec, ok := mapping[strings.ToLower(currentFlags.Pattern)]; ok {
 				parts := strings.SplitN(modelSpec, "/", 2)
 				if len(parts) == 2 {
 					currentFlags.Vendor = parts[0]

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -20,6 +20,7 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 	}
 
 	if currentFlags.Pattern != "" && currentFlags.Model == "" {
+
 		mapping, err2 := loadPatternModelMapping()
 		if err2 != nil {
 			fmt.Fprintf(os.Stderr, "Failed to load pattern-model mapping: %v. Please check your mapping file.\n", err2)

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -19,6 +19,20 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 		currentFlags.AppendMessage(messageTools)
 	}
 
+	if currentFlags.Pattern != "" && currentFlags.Model == "" {
+		if mapping, err2 := loadPatternModelMapping(); err2 == nil {
+			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
+				parts := strings.SplitN(modelSpec, "/", 2)
+				if len(parts) == 2 {
+					currentFlags.Vendor = parts[0]
+					currentFlags.Model = parts[1]
+				} else {
+					currentFlags.Model = modelSpec
+				}
+			}
+		}
+	}
+
 	var chatter *core.Chatter
 	if chatter, err = registry.GetChatter(currentFlags.Model, currentFlags.ModelContextLength,
 		currentFlags.Vendor, currentFlags.Strategy, currentFlags.Stream, currentFlags.DryRun); err != nil {

--- a/internal/cli/chat.go
+++ b/internal/cli/chat.go
@@ -24,6 +24,7 @@ func handleChatProcessing(currentFlags *Flags, registry *core.PluginRegistry, me
 		if err2 != nil {
 			fmt.Fprintf(os.Stderr, "Failed to load pattern-model mapping: %v. Please check your mapping file.\n", err2)
 		} else {
+
 			if modelSpec, ok := mapping[currentFlags.Pattern]; ok {
 				parts := strings.SplitN(modelSpec, "/", 2)
 				if len(parts) == 2 {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -14,6 +14,16 @@ import (
 
 // Cli Controls the cli. It takes in the flags and runs the appropriate functions
 func Cli(version string) (err error) {
+	if len(os.Args) > 1 && os.Args[1] == "pattern-model" {
+		if len(os.Args) == 5 && os.Args[2] == "set" {
+			if err = setPatternModel(os.Args[3], os.Args[4]); err == nil {
+				fmt.Printf("pattern '%s' mapped to model '%s'\n", os.Args[3], os.Args[4])
+			}
+			return
+		}
+		return fmt.Errorf("usage: fabric pattern-model set <pattern> <model>")
+	}
+
 	var currentFlags *Flags
 	if currentFlags, err = Init(); err != nil {
 		return

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -14,15 +14,28 @@ import (
 
 // Cli Controls the cli. It takes in the flags and runs the appropriate functions
 func Cli(version string) (err error) {
-	if len(os.Args) > 1 && os.Args[1] == "pattern-model" {
-		if len(os.Args) == 5 && os.Args[2] == "set" {
-			if err = setPatternModel(os.Args[3], os.Args[4]); err == nil {
-				fmt.Printf("pattern '%s' mapped to model '%s'\n", os.Args[3], os.Args[4])
-			}
-			return
-		}
-		return fmt.Errorf("usage: fabric pattern-model set <pattern> <model>")
-	}
+  if len(os.Args) > 1 && os.Args[1] == "pattern-model" {
+      switch {
+      case len(os.Args) == 5 && os.Args[2] == "set":
+          if err = setPatternModel(os.Args[3], os.Args[4]); err == nil {
+              fmt.Printf("pattern '%s' mapped to model '%s'\n", os.Args[3], os.Args[4])
+          }
+          return err
+
+      case len(os.Args) == 4 && os.Args[2] == "unset":
+          if err = unsetPatternModel(os.Args[3]); err == nil {
+              fmt.Printf("pattern '%s' mapping removed\n", os.Args[3])
+          }
+          return err
+
+      case len(os.Args) == 3 && os.Args[2] == "list":
+          err = listPatternModels()
+          return err
+
+      default:
+          return fmt.Errorf("usage: fabric pattern-model [set <pattern> <model>|unset <pattern>|list]")
+      }
+  }
 
 	var currentFlags *Flags
 	if currentFlags, err = Init(); err != nil {

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -1,0 +1,63 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"gopkg.in/yaml.v3"
+)
+
+// getPatternModelFile returns the path to the pattern models mapping file
+func getPatternModelFile() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("could not determine user home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "fabric", "pattern_models.yaml"), nil
+}
+
+// loadPatternModelMapping loads the pattern->model mapping from disk. It returns
+// an empty map if the file does not exist.
+func loadPatternModelMapping() (map[string]string, error) {
+	path, err := getPatternModelFile()
+	if err != nil {
+		return nil, err
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return map[string]string{}, nil
+		}
+		return nil, err
+	}
+	mapping := make(map[string]string)
+	if err := yaml.Unmarshal(data, &mapping); err != nil {
+		return nil, err
+	}
+	return mapping, nil
+}
+
+// setPatternModel updates the mapping file with the provided pattern and model.
+func setPatternModel(pattern, model string) error {
+	path, err := getPatternModelFile()
+	if err != nil {
+		return err
+	}
+	mapping, err := loadPatternModelMapping()
+	if err != nil {
+		return err
+	}
+	if mapping == nil {
+		mapping = make(map[string]string)
+	}
+	mapping[pattern] = model
+	data, err := yaml.Marshal(mapping)
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0o644)
+}

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
-
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -128,3 +127,4 @@ func printPatternModelMapping(mapping map[string]string) {
         fmt.Printf("%s: %s\n", k, mapping[k])
     }
 }
+

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -10,11 +10,11 @@ import (
 
 // getPatternModelFile returns the path to the pattern models mapping file
 func getPatternModelFile() (string, error) {
-	home, err := os.UserHomeDir()
+	configDir, err := os.UserConfigDir()
 	if err != nil {
-		return "", fmt.Errorf("could not determine user home directory: %w", err)
+		return "", fmt.Errorf("could not determine user config directory: %w", err)
 	}
-	return filepath.Join(home, ".config", "fabric", "pattern_models.yaml"), nil
+	return filepath.Join(configDir, "fabric", "pattern_models.yaml"), nil
 }
 
 // loadPatternModelMapping loads the pattern->model mapping from disk. It returns

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 
 	"gopkg.in/yaml.v3"
 )
@@ -60,4 +61,21 @@ func setPatternModel(pattern, model string) error {
 		return err
 	}
 	return os.WriteFile(path, data, 0o644)
+}
+
+// printPatternModelMapping prints the current pattern->model mapping in a
+// deterministic order. Since Go maps iterate in random order, we first collect
+// the keys, sort them, and then print each mapping.
+func printPatternModelMapping(mapping map[string]string) {
+	if len(mapping) == 0 {
+		return
+	}
+	keys := make([]string, 0, len(mapping))
+	for k := range mapping {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		fmt.Printf("%s: %s\n", k, mapping[k])
+	}
 }

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -76,7 +76,7 @@ func unsetPatternModel(pattern string) error {
         return err
     }
 
-    delete(mapping, pattern)
+    delete(mapping, strings.ToLower(pattern))
 
     if len(mapping) == 0 {
         // Remove the mapping file if empty

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -63,19 +63,39 @@ func setPatternModel(pattern, model string) error {
 	return os.WriteFile(path, data, 0o644)
 }
 
-// printPatternModelMapping prints the current pattern->model mapping in a
-// deterministic order. Since Go maps iterate in random order, we first collect
-// the keys, sort them, and then print each mapping.
-func printPatternModelMapping(mapping map[string]string) {
-	if len(mapping) == 0 {
-		return
-	}
-	keys := make([]string, 0, len(mapping))
-	for k := range mapping {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		fmt.Printf("%s: %s\n", k, mapping[k])
-	}
+// unsetPatternModel removes a pattern from the mapping file.
+func unsetPatternModel(pattern string) error {
+    path, err := getPatternModelFile()
+    if err != nil {
+        return err
+    }
+
+    mapping, err := loadPatternModelMapping()
+    if err != nil {
+        return err
+    }
+
+    delete(mapping, pattern)
+
+    if len(mapping) == 0 {
+        // Remove the mapping file if empty
+        if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+            return err
+        }
+        return nil
+    }
+
+    data, err := yaml.Marshal(mapping)
+    if err != nil {
+        return err
+    }
+
+    if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+        return err
+    }
+    return os.WriteFile(path, data, 0o644)
+}
+
+// listPatternModels prints all pa
+
 }

--- a/internal/cli/pattern_models.go
+++ b/internal/cli/pattern_models.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"sort"
 
+	"strings"
+
 	"gopkg.in/yaml.v3"
 )
 
@@ -52,7 +54,7 @@ func setPatternModel(pattern, model string) error {
 	if mapping == nil {
 		mapping = make(map[string]string)
 	}
-	mapping[pattern] = model
+	mapping[strings.ToLower(pattern)] = model
 	data, err := yaml.Marshal(mapping)
 	if err != nil {
 		return err
@@ -96,6 +98,33 @@ func unsetPatternModel(pattern string) error {
     return os.WriteFile(path, data, 0o644)
 }
 
-// listPatternModels prints all pa
+// listPatternModels prints all pattern->model mappings to stdout.
+func listPatternModels() error {
+    mapping, err := loadPatternModelMapping()
+    if err != nil {
+        return err
+    }
+    if len(mapping) == 0 {
+        fmt.Println("no pattern model mappings found")
+        return nil
+    }
+    printPatternModelMapping(mapping)
+    return nil
+}
 
+// printPatternModelMapping prints the current pattern->model mapping in a
+// deterministic order. Since Go maps iterate in random order, we first collect
+// the keys, sort them, and then print each mapping.
+func printPatternModelMapping(mapping map[string]string) {
+    if len(mapping) == 0 {
+        return
+    }
+    keys := make([]string, 0, len(mapping))
+    for k := range mapping {
+        keys = append(keys, k)
+    }
+    sort.Strings(keys)
+    for _, k := range keys {
+        fmt.Printf("%s: %s\n", k, mapping[k])
+    }
 }

--- a/internal/cli/pattern_models_test.go
+++ b/internal/cli/pattern_models_test.go
@@ -1,0 +1,19 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestGetPatternModelFile(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", tmp)
+	path, err := getPatternModelFile()
+	if err != nil {
+		t.Fatalf("getPatternModelFile returned error: %v", err)
+	}
+	expected := filepath.Join(tmp, "fabric", "pattern_models.yaml")
+	if path != expected {
+		t.Fatalf("expected %s, got %s", expected, path)
+	}
+}


### PR DESCRIPTION
- Introduce helper functions to load, set, unset, and list pattern→model mappings in a user config file (pattern_models.yaml)
- Add a fabric pattern-model CLI subcommand supporting set, unset, and list operations for managing these mappings
- Automatically select vendor and model based on the mapping when running a pattern without an explicit model
- Document pattern-model mapping in a new guide and cross-link from the README
- Add tests verifying the correct config path for pattern-model files

Testing

⚠️ No automated tests were executed; review is based on static analysis only. Works for creator.

**Note**: I can barely spell golang.  All code entirely built by vibish coding.  First PR.