### PR TITLE
docs: fix link to example Pattern in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -640,7 +640,7 @@ Fabric _Patterns_ are different than most prompts you'll see.
 Here's an example of a Fabric Pattern.
 
 ```bash
-https://github.com/danielmiessler/fabric/blob/main/patterns/extract_wisdom/system.md
+https://github.com/danielmiessler/Fabric/blob/main/data/patterns/extract_wisdom/system.md
 ```
 
 <img width="1461" alt="pattern-example" src="https://github.com/danielmiessler/fabric/assets/50654/b910c551-9263-405f-9735-71ca69bbab6d">


### PR DESCRIPTION
I was trying to follow the link in the readme to the example Pattern only to get a 404. This change updates the link to the correct (I think) path.