### PR TITLE
Highlight default vendor/model in model listing

### DIFF
--- a/cmd/generate_changelog/incoming/1717.txt
+++ b/cmd/generate_changelog/incoming/1717.txt
@@ -1,0 +1,7 @@
+### PR [#1717](https://github.com/danielmiessler/Fabric/pull/1717) by [ksylvan](https://github.com/ksylvan): Highlight default vendor/model in model listing
+
+- Update PrintWithVendor signature to accept default vendor and model
+- Mark default vendor/model with asterisk in non-shell output
+- Compare vendor and model case-insensitively when marking
+- Pass registry defaults to PrintWithVendor from CLI
+- Add test ensuring default selection appears with asterisk

--- a/internal/cli/listing.go
+++ b/internal/cli/listing.go
@@ -41,7 +41,7 @@ func handleListingCommands(currentFlags *Flags, fabricDb *fsdb.Db, registry *cor
 		if currentFlags.ShellCompleteOutput {
 			models.Print(true)
 		} else {
-			models.PrintWithVendor(false)
+			models.PrintWithVendor(false, registry.Defaults.Vendor.Value, registry.Defaults.Model.Value)
 		}
 		return true, nil
 	}

--- a/internal/plugins/ai/models.go
+++ b/internal/plugins/ai/models.go
@@ -18,7 +18,8 @@ type VendorsModels struct {
 
 // PrintWithVendor prints models including their vendor on each line.
 // When shellCompleteList is true, output is suitable for shell completion.
-func (o *VendorsModels) PrintWithVendor(shellCompleteList bool) {
+// Default vendor and model are highlighted with an asterisk.
+func (o *VendorsModels) PrintWithVendor(shellCompleteList bool, defaultVendor, defaultModel string) {
 	if !shellCompleteList {
 		fmt.Printf("\n%v:\n", o.SelectionLabel)
 	}
@@ -42,7 +43,11 @@ func (o *VendorsModels) PrintWithVendor(shellCompleteList bool) {
 			if shellCompleteList {
 				fmt.Printf("%s|%s\n", groupItems.Group, item)
 			} else {
-				fmt.Printf("\t[%d]\t%s|%s\n", currentItemIndex, groupItems.Group, item)
+				mark := "       "
+				if strings.EqualFold(groupItems.Group, defaultVendor) && strings.EqualFold(item, defaultModel) {
+					mark = "      *"
+				}
+				fmt.Printf("%s\t[%d]\t%s|%s\n", mark, currentItemIndex, groupItems.Group, item)
 			}
 		}
 	}

--- a/internal/plugins/ai/models_test.go
+++ b/internal/plugins/ai/models_test.go
@@ -1,6 +1,9 @@
 package ai
 
 import (
+	"io"
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -29,5 +32,25 @@ func TestFindVendorsByModel(t *testing.T) {
 	foundVendors := vendors.FindGroupsByItem("model1")
 	if len(foundVendors) != 1 || foundVendors[0] != "vendor1" {
 		t.Fatalf("FindVendorsByModel() = %v, want %v", foundVendors, []string{"vendor1"})
+	}
+}
+
+func TestPrintWithVendorMarksDefault(t *testing.T) {
+	vendors := NewVendorsModels()
+	vendors.AddGroupItems("vendor1", []string{"model1"}...)
+	vendors.AddGroupItems("vendor2", []string{"model2"}...)
+
+	r, w, _ := os.Pipe()
+	oldStdout := os.Stdout
+	os.Stdout = w
+
+	vendors.PrintWithVendor(false, "vendor2", "model2")
+
+	w.Close()
+	os.Stdout = oldStdout
+	out, _ := io.ReadAll(r)
+
+	if !strings.Contains(string(out), "      *\t[2]\tvendor2|model2") {
+		t.Fatalf("default model not marked: %s", out)
 	}
 }


### PR DESCRIPTION
# Highlight default vendor/model in model listing

## Summary

Highlight default AI vendor/model in the interactive models listing and wire the CLI to pass configured defaults into the listing. Introduces a subtle formatting change to the non-shell-completion output and adds a unit test to verify default model highlighting.

## Related Issues

Closes #446 

## Files Changed

- internal/cli/listing.go
  - Passes configured default vendor and model to the models listing for interactive display.
- internal/plugins/ai/models.go
  - Changes the signature of PrintWithVendor to accept default vendor/model and visually marks the default in interactive listings.
  - Adds case-insensitive matching for defaults.
- internal/plugins/ai/models_test.go
  - Adds a unit test to ensure the default vendor/model is marked in the listing output.

## Code Changes

- Signature change to include defaults and documentation update:
```go
// Default vendor and model are highlighted with an asterisk.
func (o *VendorsModels) PrintWithVendor(shellCompleteList bool, defaultVendor, defaultModel string)
```

- Interactive listing now marks the configured default with an asterisk (prefix column):
```go
mark := "       "
if strings.EqualFold(groupItems.Group, defaultVendor) && strings.EqualFold(item, defaultModel) {
    mark = "      *"
}
fmt.Printf("%s\t[%d]\t%s|%s\n", mark, currentItemIndex, groupItems.Group, item)
```

- CLI now supplies defaults from registry for non-shell-completion outputs:
```go
if currentFlags.ShellCompleteOutput {
    models.Print(true)
} else {
    models.PrintWithVendor(false, registry.Defaults.Vendor.Value, registry.Defaults.Model.Value)
}
```

- Unit test captures stdout and checks that the default is marked:
```go
vendors.PrintWithVendor(false, "vendor2", "model2")
...
if !strings.Contains(string(out), "vendor2|model2 *") {
    t.Fatalf("default model not marked: %s", out)
}
```

## Reason for Changes

- Improve UX: Users can quickly identify the configured default AI model in the interactive listing.
- Make defaults visible in the CLI without affecting shell-completion output.
- Ensure behavior is test-covered.

## Impact of Changes

- Behavioral/formatting change in interactive (non-shell completion) output only:
  - An asterisk is rendered to indicate the default entry. The star currently appears in a leading “mark” column, before the index.
- Shell completion remains unchanged (no markers, same format).
- API change: PrintWithVendor now requires defaultVendor and defaultModel parameters.
  - Any other call sites must be updated accordingly to avoid compile errors.
- Case-insensitive matching for defaults improves robustness with varying config inputs.

## Test Plan

- Unit:
  - internal/plugins/ai/models_test.go: TestPrintWithVendorMarksDefault
- Manual:
  - Run the CLI command that lists models without shell completion (e.g., fabric list models) and confirm:
    - One entry has an asterisk indicating the default vendor/model.
    - Non-default entries are unmarked.
  - Run the same with shell completion mode enabled; ensure no asterisks are shown and the output remains “vendor|model”.
  - Verify behavior when defaults are unset or do not match any listed entries: no asterisk should appear.

## Additional Notes

- Potential test mismatch: The test currently searches for the substring "vendor2|model2 *", which implies the asterisk appears after the model. The implementation places the asterisk in a prefix column before the index (e.g., "      *\t[2]\tvendor2|model2"). As written, the test will fail against the current implementation. We should either:
  - Update the test to look for the prefix asterisk (e.g., check for "*\t[", along with "vendor2|model2"), or
  - Move the asterisk to a suffix position (after "vendor|model") to match the test’s expectation. This may be more intuitive and less disruptive to existing consumers parsing the listing.

- Ensure the "strings" package is imported in models.go (required for strings.EqualFold). If it is not already imported in the file, compilation will fail.

- This is a breaking change to the PrintWithVendor signature; please verify and update any other usages outside of listing.go.