### PR TITLE
Implement Configurable Debug Logging Levels

### DIFF
--- a/README.md
+++ b/README.md
@@ -636,9 +636,19 @@ Application Options:
       --yt-dlp-args=                Additional arguments to pass to yt-dlp (e.g. '--cookies-from-browser brave')
       --thinking=                   Set reasoning/thinking level (e.g., off, low, medium, high, or
                                     numeric tokens for Anthropic or Google Gemini)
+      --debug=                     Set debug level (0: off, 1: basic, 2: detailed, 3: trace)
 Help Options:
   -h, --help                        Show this help message
 ```
+
+### Debug Levels
+
+Use the `--debug` flag to control runtime logging:
+
+- `0`: off (default)
+- `1`: basic debug info
+- `2`: detailed debugging
+- `3`: trace level
 
 ## Our approach to prompting
 

--- a/cmd/generate_changelog/incoming/1718.txt
+++ b/cmd/generate_changelog/incoming/1718.txt
@@ -1,0 +1,7 @@
+### PR [#1718](https://github.com/danielmiessler/Fabric/pull/1718) by [ksylvan](https://github.com/ksylvan): Implement Configurable Debug Logging Levels
+
+- Add --debug flag controlling runtime logging verbosity levels
+- Introduce internal/log package with Off, Basic, Detailed, Trace
+- Replace ad-hoc Debugf and globals with centralized debug logger
+- Wire debug level during early CLI argument parsing
+- Add bash, zsh, fish completions for --debug levels

--- a/completions/_fabric
+++ b/completions/_fabric
@@ -145,6 +145,7 @@ _fabric() {
     '(--transcribe-file)--transcribe-file[Audio or video file to transcribe]:audio file:_files -g "*.mp3 *.mp4 *.mpeg *.mpga *.m4a *.wav *.webm"' \
     '(--transcribe-model)--transcribe-model[Model to use for transcription (separate from chat model)]:transcribe model:_fabric_transcription_models' \
     '(--split-media-file)--split-media-file[Split audio/video files larger than 25MB using ffmpeg]' \
+    '(--debug)--debug[Set debug level (0=off, 1=basic, 2=detailed, 3=trace)]:debug level:(0 1 2 3)' \
     '(--notification)--notification[Send desktop notification when command completes]' \
     '(--notification-command)--notification-command[Custom command to run for notifications]:notification command:' \
     '(-h --help)'{-h,--help}'[Show this help message]' \

--- a/completions/fabric.bash
+++ b/completions/fabric.bash
@@ -13,7 +13,7 @@ _fabric() {
   _get_comp_words_by_ref -n : cur prev words cword
 
   # Define all possible options/flags
-  local opts="--pattern -p --variable -v --context -C --session --attachment -a --setup -S --temperature -t --topp -T --stream -s --presencepenalty -P --raw -r --frequencypenalty -F --listpatterns -l --listmodels -L --listcontexts -x --listsessions -X --updatepatterns -U --copy -c --model -m --vendor -V --modelContextLength --output -o --output-session --latest -n --changeDefaultModel -d --youtube -y --playlist --transcript --transcript-with-timestamps --comments --metadata --yt-dlp-args --language -g --scrape_url -u --scrape_question -q --seed -e --thinking --wipecontext -w --wipesession -W --printcontext --printsession --readability --input-has-vars --no-variable-replacement --dry-run --serve --serveOllama --address --api-key --config --search --search-location --image-file --image-size --image-quality --image-compression --image-background --suppress-think --think-start-tag --think-end-tag --disable-responses-api --transcribe-file --transcribe-model --split-media-file --voice --list-gemini-voices --notification --notification-command --version --listextensions --addextension --rmextension --strategy --liststrategies --listvendors --shell-complete-list --help -h"
+  local opts="--pattern -p --variable -v --context -C --session --attachment -a --setup -S --temperature -t --topp -T --stream -s --presencepenalty -P --raw -r --frequencypenalty -F --listpatterns -l --listmodels -L --listcontexts -x --listsessions -X --updatepatterns -U --copy -c --model -m --vendor -V --modelContextLength --output -o --output-session --latest -n --changeDefaultModel -d --youtube -y --playlist --transcript --transcript-with-timestamps --comments --metadata --yt-dlp-args --language -g --scrape_url -u --scrape_question -q --seed -e --thinking --wipecontext -w --wipesession -W --printcontext --printsession --readability --input-has-vars --no-variable-replacement --dry-run --serve --serveOllama --address --api-key --config --search --search-location --image-file --image-size --image-quality --image-compression --image-background --suppress-think --think-start-tag --think-end-tag --disable-responses-api --transcribe-file --transcribe-model --split-media-file --voice --list-gemini-voices --notification --notification-command --debug --version --listextensions --addextension --rmextension --strategy --liststrategies --listvendors --shell-complete-list --help -h"
 
   # Helper function for dynamic completions
   _fabric_get_list() {
@@ -76,6 +76,10 @@ _fabric() {
     ;;
   --transcribe-model)
     COMPREPLY=($(compgen -W "$(_fabric_get_list --list-transcription-models)" -- "${cur}"))
+    return 0
+    ;;
+  --debug)
+    COMPREPLY=($(compgen -W "0 1 2 3" -- "${cur}"))
     return 0
     ;;
   # Options requiring file/directory paths

--- a/completions/fabric.fish
+++ b/completions/fabric.fish
@@ -99,6 +99,7 @@ function __fabric_register_completions
         complete -c $cmd -l voice -d "TTS voice name for supported models (e.g., Kore, Charon, Puck)" -a "(__fabric_get_gemini_voices)"
         complete -c $cmd -l transcribe-file -d "Audio or video file to transcribe" -r -a "*.mp3 *.mp4 *.mpeg *.mpga *.m4a *.wav *.webm"
         complete -c $cmd -l transcribe-model -d "Model to use for transcription (separate from chat model)" -a "(__fabric_get_transcription_models)"
+        complete -c $cmd -l debug -d "Set debug level (0=off, 1=basic, 2=detailed, 3=trace)" -a "0 1 2 3"
         complete -c $cmd -l notification-command -d "Custom command to run for notifications (overrides built-in notifications)"
 
         # Boolean flags (no arguments)

--- a/docs/Using-Speech-To-Text.md
+++ b/docs/Using-Speech-To-Text.md
@@ -1,0 +1,139 @@
+# Using Speech-To-Text (STT) with Fabric
+
+Fabric supports speech-to-text transcription of audio and video files using OpenAI's transcription models. This feature allows you to convert spoken content into text that can then be processed through Fabric's patterns.
+
+## Overview
+
+The STT feature integrates OpenAI's Whisper and GPT-4o transcription models to convert audio/video files into text. The transcribed text is automatically passed as input to your chosen pattern or chat session.
+
+## Requirements
+
+- OpenAI API key configured in Fabric
+- For files larger than 25MB: `ffmpeg` installed on your system
+- Supported audio/video formats: `.mp3`, `.mp4`, `.mpeg`, `.mpga`, `.m4a`, `.wav`, `.webm`
+
+## Basic Usage
+
+### Simple Transcription
+
+To transcribe an audio file and send the result to a pattern:
+
+```bash
+fabric --transcribe-file /path/to/audio.mp3 --transcribe-model whisper-1 --pattern summarize
+```
+
+### Transcription Only
+
+To just transcribe a file without applying a pattern:
+
+```bash
+fabric --transcribe-file /path/to/audio.mp3 --transcribe-model whisper-1
+```
+
+## Command Line Flags
+
+### Required Flags
+
+- `--transcribe-file`: Path to the audio or video file to transcribe
+- `--transcribe-model`: Model to use for transcription (required when using transcription)
+
+### Optional Flags
+
+- `--split-media-file`: Automatically split files larger than 25MB into chunks using ffmpeg
+
+## Available Models
+
+You can list all available transcription models with:
+
+```bash
+fabric --list-transcription-models
+```
+
+Currently supported models:
+
+- `whisper-1`: OpenAI's Whisper model
+- `gpt-4o-mini-transcribe`: GPT-4o Mini transcription model
+- `gpt-4o-transcribe`: GPT-4o transcription model
+
+## File Size Handling
+
+### Files Under 25MB
+
+Files under the 25MB limit are processed directly without any special handling.
+
+### Files Over 25MB
+
+For files exceeding OpenAI's 25MB limit, you have two options:
+
+1. **Manual handling**: The command will fail with an error message suggesting to use `--split-media-file`
+2. **Automatic splitting**: Use the `--split-media-file` flag to automatically split the file into chunks
+
+```bash
+fabric --transcribe-file large_recording.mp4 --transcribe-model whisper-1 --split-media-file --pattern summarize
+```
+
+When splitting is enabled:
+
+- Fabric uses `ffmpeg` to split the file into 10-minute segments initially
+- If segments are still too large, it reduces the segment time by half repeatedly
+- All segments are transcribed and the results are concatenated
+- Temporary files are automatically cleaned up after processing
+
+## Integration with Patterns
+
+The transcribed text is seamlessly integrated into Fabric's workflow:
+
+1. File is transcribed using the specified model
+2. Transcribed text becomes the input message
+3. Text is sent to the specified pattern or chat session
+
+### Example Workflows
+
+**Meeting transcription and summarization:**
+
+```bash
+fabric --transcribe-file meeting.mp4 --transcribe-model gpt-4o-transcribe --pattern summarize
+```
+
+**Interview analysis:**
+
+```bash
+fabric --transcribe-file interview.mp3 --transcribe-model whisper-1 --pattern extract_insights
+```
+
+**Large video file processing:**
+
+```bash
+fabric --transcribe-file presentation.mp4 --transcribe-model gpt-4o-transcribe --split-media-file --pattern create_summary
+```
+
+## Error Handling
+
+Common error scenarios:
+
+- **Unsupported format**: Only the listed audio/video formats are supported
+- **File too large**: Use `--split-media-file` for files over 25MB
+- **Missing ffmpeg**: Install ffmpeg for automatic file splitting
+- **Invalid model**: Use `--list-transcription-models` to see available models
+- **Missing model**: The `--transcribe-model` flag is required when using `--transcribe-file`
+
+## Technical Details
+
+### Implementation
+
+- Transcription is handled in `internal/cli/transcribe.go:14`
+- OpenAI-specific implementation in `internal/plugins/ai/openai/openai_audio.go:41`
+- File splitting uses ffmpeg with configurable segment duration
+- Supports any vendor that implements the `transcriber` interface
+
+### Processing Pipeline
+
+1. CLI validates file format and size
+2. If file > 25MB and splitting enabled, file is split using ffmpeg
+3. Each file/segment is sent to OpenAI's transcription API
+4. Results are concatenated with spaces between segments
+5. Transcribed text is passed as input to the main Fabric pipeline
+
+### Vendor Support
+
+Currently, only OpenAI is supported for transcription, but the interface allows for future expansion to other vendors that provide transcription capabilities.

--- a/internal/log/log.go
+++ b/internal/log/log.go
@@ -1,0 +1,69 @@
+package log
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sync"
+)
+
+// Level represents the debug verbosity.
+type Level int
+
+const (
+	// Off disables all debug output.
+	Off Level = iota
+	// Basic provides minimal debugging information.
+	Basic
+	// Detailed provides more verbose debugging.
+	Detailed
+	// Trace is the most verbose level.
+	Trace
+)
+
+var (
+	mu     sync.RWMutex
+	level  Level     = Off
+	output io.Writer = os.Stderr
+)
+
+// SetLevel sets the global debug level.
+func SetLevel(l Level) {
+	mu.Lock()
+	level = l
+	mu.Unlock()
+}
+
+// LevelFromInt converts an int to a Level.
+func LevelFromInt(i int) Level {
+	switch {
+	case i <= 0:
+		return Off
+	case i == 1:
+		return Basic
+	case i == 2:
+		return Detailed
+	case i >= 3:
+		return Trace
+	default:
+		return Off
+	}
+}
+
+// Debug writes a debug message if the global level permits.
+func Debug(l Level, format string, a ...interface{}) {
+	mu.RLock()
+	current := level
+	w := output
+	mu.RUnlock()
+	if current >= l {
+		fmt.Fprintf(w, "DEBUG: "+format, a...)
+	}
+}
+
+// SetOutput allows overriding the output destination for debug logs.
+func SetOutput(w io.Writer) {
+	mu.Lock()
+	output = w
+	mu.Unlock()
+}

--- a/internal/plugins/ai/openai/openai_audio.go
+++ b/internal/plugins/ai/openai/openai_audio.go
@@ -11,6 +11,8 @@ import (
 	"sort"
 	"strings"
 
+	debuglog "github.com/danielmiessler/fabric/internal/log"
+
 	openai "github.com/openai/openai-go"
 )
 
@@ -56,18 +58,14 @@ func (o *Client) TranscribeFile(ctx context.Context, filePath, model string, spl
 		return "", err
 	}
 
-	debug := os.Getenv("FABRIC_STT_DEBUG") != ""
-
 	var files []string
 	var cleanup func()
 	if info.Size() > MaxAudioFileSize {
 		if !split {
 			return "", fmt.Errorf("file %s exceeds 25MB limit; use --split-media-file to enable automatic splitting", filePath)
 		}
-		if debug {
-			fmt.Fprintf(os.Stderr, "File %s is larger than the size limit... breaking it up into chunks...\n", filePath)
-		}
-		if files, cleanup, err = splitAudioFile(filePath, ext, MaxAudioFileSize, debug); err != nil {
+		debuglog.Debug(debuglog.Basic, "File %s is larger than the size limit... breaking it up into chunks...\n", filePath)
+		if files, cleanup, err = splitAudioFile(filePath, ext, MaxAudioFileSize); err != nil {
 			return "", err
 		}
 		defer cleanup()
@@ -77,9 +75,7 @@ func (o *Client) TranscribeFile(ctx context.Context, filePath, model string, spl
 
 	var builder strings.Builder
 	for i, f := range files {
-		if debug {
-			fmt.Fprintf(os.Stderr, "Using model %s to transcribe part %d (file name: %s)...\n", model, i+1, f)
-		}
+		debuglog.Debug(debuglog.Basic, "Using model %s to transcribe part %d (file name: %s)...\n", model, i+1, f)
 		var chunk *os.File
 		if chunk, err = os.Open(f); err != nil {
 			return "", err
@@ -105,7 +101,7 @@ func (o *Client) TranscribeFile(ctx context.Context, filePath, model string, spl
 
 // splitAudioFile splits the source file into chunks smaller than maxSize using ffmpeg.
 // It returns the list of chunk file paths and a cleanup function.
-func splitAudioFile(src, ext string, maxSize int64, debug bool) (files []string, cleanup func(), err error) {
+func splitAudioFile(src, ext string, maxSize int64) (files []string, cleanup func(), err error) {
 	if _, err = exec.LookPath("ffmpeg"); err != nil {
 		return nil, nil, fmt.Errorf("ffmpeg not found: please install it")
 	}
@@ -119,9 +115,7 @@ func splitAudioFile(src, ext string, maxSize int64, debug bool) (files []string,
 	segmentTime := 600 // start with 10 minutes
 	for {
 		pattern := filepath.Join(dir, "chunk-%03d"+ext)
-		if debug {
-			fmt.Fprintf(os.Stderr, "Running ffmpeg to split audio into %d-second chunks...\n", segmentTime)
-		}
+		debuglog.Debug(debuglog.Basic, "Running ffmpeg to split audio into %d-second chunks...\n", segmentTime)
 		cmd := exec.Command("ffmpeg", "-y", "-i", src, "-f", "segment", "-segment_time", fmt.Sprintf("%d", segmentTime), "-c", "copy", pattern)
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr

--- a/internal/plugins/ai/vendors.go
+++ b/internal/plugins/ai/vendors.go
@@ -148,7 +148,6 @@ func (o *VendorsManager) setupVendorTo(vendor Vendor, configuredVendors map[stri
 		delete(configuredVendors, vendor.GetName())
 		fmt.Printf("[%v] skipped\n", vendor.GetName())
 	}
-	return
 }
 
 type modelResult struct {

--- a/internal/plugins/template/extension_registry.go
+++ b/internal/plugins/template/extension_registry.go
@@ -10,8 +10,9 @@ import (
 	"strings"
 	"time"
 
+	debuglog "github.com/danielmiessler/fabric/internal/log"
+
 	"gopkg.in/yaml.v3"
-	// Add this import
 )
 
 // ExtensionDefinition represents a single extension configuration
@@ -87,9 +88,7 @@ func NewExtensionRegistry(configDir string) *ExtensionRegistry {
 	r.ensureConfigDir()
 
 	if err := r.loadRegistry(); err != nil {
-		if Debug {
-			fmt.Printf("Warning: could not load extension registry: %v\n", err)
-		}
+		debuglog.Debug(debuglog.Basic, "Warning: could not load extension registry: %v\n", err)
 	}
 
 	return r

--- a/internal/plugins/template/template.go
+++ b/internal/plugins/template/template.go
@@ -6,6 +6,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	debuglog "github.com/danielmiessler/fabric/internal/log"
 )
 
 var (
@@ -14,7 +16,6 @@ var (
 	filePlugin     = &FilePlugin{}
 	fetchPlugin    = &FetchPlugin{}
 	sysPlugin      = &SysPlugin{}
-	Debug          = false // Debug flag
 )
 
 var extensionManager *ExtensionManager
@@ -33,9 +34,7 @@ var pluginPattern = regexp.MustCompile(`\{\{plugin:([^:]+):([^:]+)(?::([^}]+))?\
 var extensionPattern = regexp.MustCompile(`\{\{ext:([^:]+):([^:]+)(?::([^}]+))?\}\}`)
 
 func debugf(format string, a ...interface{}) {
-	if Debug {
-		fmt.Printf(format, a...)
-	}
+	debuglog.Debug(debuglog.Trace, format, a...)
 }
 
 func ApplyTemplate(content string, variables map[string]string, input string) (string, error) {


### PR DESCRIPTION
# Implement Configurable Debug Logging Levels

## Summary

Introduce configurable, leveled debug logging across the CLI and key subsystems, replace ad-hoc/debug globals with a unified internal logging package, and expand Speech-To-Text (STT) documentation. Adds a `--debug` flag with four levels (off, basic, detailed, trace), integrates logging into transcription workflows (including ffmpeg chunking), updates shell completions, and removes the `FABRIC_STT_DEBUG` environment variable.

## Related Issues

Closes #1220 

## Files Changed

- README.md
  - Documented `--debug` flag and the available debug levels.
- cmd/generate_changelog/incoming/1718.txt
  - Changelog entry for this PR.
- completions/_fabric
  - zsh completion for `--debug` with supported values.
- completions/fabric.bash
  - bash completion: added `--debug` flag to options and value suggestions.
- completions/fabric.fish
  - fish completion for `--debug` with supported values.
- docs/Using-Speech-To-Text.md
  - New comprehensive STT documentation (usage, models, splitting workflow, error handling, and implementation details).
- internal/cli/flags.go
  - Added `--debug` flag to `Flags`.
  - Early parse of `--debug` from raw args to set logging level prior to full flag parsing.
  - Replaced local `Debugf`/globals with centralized `internal/log` usage.
- internal/log/log.go
  - New unified logging package with leveled debug output and thread-safe configuration.
- internal/plugins/ai/openai/openai_audio.go
  - Integrated leveled logging into STT flow (file size checks, chunking, and per-chunk transcription).
  - Removed `FABRIC_STT_DEBUG` env var and simplified `splitAudioFile` signature.
- internal/plugins/ai/vendors.go
  - Minor cleanup (removed redundant return).
- internal/plugins/template/extension_registry.go
  - Replaced package-level Debug usage with centralized logging.
- internal/plugins/template/template.go
  - Removed `Debug` global; switched internal debug function to use trace-level logging.

## Code Changes

- Add `--debug` flag and early initialization:
```go
// internal/cli/flags.go
type Flags struct {
    ...
    Debug int `long:"debug" description:"Set debug level (0=off, 1=basic, 2=detailed, 3=trace)" default:"0"`
}

func Init() (ret *Flags, err error) {
    debuglog.SetLevel(debuglog.LevelFromInt(parseDebugLevel(os.Args[1:])))
    ...
    if args, err = parser.Parse(); err != nil {
        return
    }
    debuglog.SetLevel(debuglog.LevelFromInt(ret.Debug))
    ...
}
```

- Early `--debug` parsing helper:
```go
// internal/cli/flags.go
func parseDebugLevel(args []string) int {
    for i := 0; i < len(args); i++ {
        arg := args[i]
        if arg == "--debug" && i+1 < len(args) {
            if lvl, err := strconv.Atoi(args[i+1]); err == nil {
                return lvl
            }
        } else if strings.HasPrefix(arg, "--debug=") {
            if lvl, err := strconv.Atoi(strings.TrimPrefix(arg, "--debug=")); err == nil {
                return lvl
            }
        }
    }
    return 0
}
```

- Unified logging package:
```go
// internal/log/log.go
type Level int

const (
    Off Level = iota
    Basic
    Detailed
    Trace
)

func Debug(l Level, format string, a ...interface{}) {
    mu.RLock(); current := level; w := output; mu.RUnlock()
    if current >= l {
        fmt.Fprintf(w, "DEBUG: "+format, a...)
    }
}
```

- STT integration and removal of env-based debug:
```go
// internal/plugins/ai/openai/openai_audio.go
if info.Size() > MaxAudioFileSize {
    if !split {
        return "", fmt.Errorf("file %s exceeds 25MB limit; use --split-media-file ...", filePath)
    }
    debuglog.Debug(debuglog.Basic, "File %s is larger than the size limit... breaking it up into chunks...\n", filePath)
    if files, cleanup, err = splitAudioFile(filePath, ext, MaxAudioFileSize); err != nil {
        return "", err
    }
}

for i, f := range files {
    debuglog.Debug(debuglog.Basic, "Using model %s to transcribe part %d (file name: %s)...\n", model, i+1, f)
    ...
}
```

- ffmpeg splitting logs:
```go
// internal/plugins/ai/openai/openai_audio.go
debuglog.Debug(debuglog.Basic, "Running ffmpeg to split audio into %d-second chunks...\n", segmentTime)
```

- Template/extension logging normalization:
```go
// internal/plugins/template/template.go
func debugf(format string, a ...interface{}) {
    debuglog.Debug(debuglog.Trace, format, a...)
}

// internal/plugins/template/extension_registry.go
debuglog.Debug(debuglog.Basic, "Warning: could not load extension registry: %v\n", err)
```

- README debug flag documentation:
```md
--debug=                     Set debug level (0: off, 1: basic, 2: detailed, 3: trace)

### Debug Levels
- 0: off (default)
- 1: basic debug info
- 2: detailed debugging
- 3: trace level
```

## Reason for Changes

- Provide a consistent, configurable logging experience across the CLI and internal modules.
- Replace scattered, ad-hoc debug handling (including global variables and env-specific toggles) with a centralized, thread-safe logging API.
- Improve transparency and diagnostics for STT flows (especially chunking behavior for large files).
- Offer better user documentation for STT usage and debugging.
- Keep default behavior unchanged while enabling optional verbosity for troubleshooting.

## Impact of Changes

- Default behavior remains unchanged (debug level 0/off).
- Users can now enable richer diagnostics with `--debug {0..3}`.
- STT workflows output actionable logs when debug is enabled (file size checks, ffmpeg chunking progress, per-chunk transcription).
- Shell completion updates ensure discoverability and ease-of-use for the `--debug` flag.
- Removal of `FABRIC_STT_DEBUG` consolidates configuration into the CLI flag.
- Internal codebase gains a unified logging approach that is thread-safe and extensible.

## Test Plan

- CLI parsing and precedence:
  - Run with no `--debug`: confirm no debug output.
  - Run with `--debug 1`, `--debug=2`, `--debug 3`: confirm appropriate verbosity.
  - Confirm early logs (e.g., YAML mapping messages) are emitted when `--debug` is provided before parsing.
- STT flows:
  - Transcribe a <25MB file; confirm expected output and no chunking logs unless debug enabled.
  - Transcribe a >25MB file without `--split-media-file`; confirm error message suggests enabling splitting.
  - Transcribe a >25MB file with `--split-media-file`; confirm ffmpeg logs and per-chunk logs at basic level.
- Shell completions:
  - Verify `--debug` values are suggested (zsh, bash, fish).
- Template/extensions:
  - Trigger scenarios that load extension registry; confirm warning logged only when debug level permits.
- Regression:
  - Run common patterns and chat sessions across vendors to confirm no behavior changes when debug=0.

## Additional Notes

- Breaking change: `FABRIC_STT_DEBUG` is removed. Use `--debug` instead.
- Current scope: `--debug` is a CLI-only setting. There is no YAML tag for `debug` in the Flags struct; if we want config-file support, we can add `yaml:"debug"` in a follow-up.
- Follow-ups to consider:
  - Input validation for `--debug` range within flag parsing.
  - Timestamped logging and/or log levels in output prefix.
  - Pluggable log output formatters (JSON/structured logs) if needed.