### PR TITLE
docs: update README with Venice AI provider and Windows install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Below are the **new features and capabilities** we've added (newest first):
 
 ### Recent Major Features
 
+- [v1.4.294](https://github.com/danielmiessler/fabric/releases/tag/v1.4.294) (Aug 20, 2025) — **Venice AI Support**: Added the Venice AI provider. Venice is a Privacy-First, Open-Source AI provider. See their ["About Venice"](https://docs.venice.ai/overview/about-venice) page for details.
 - [v1.4.291](https://github.com/danielmiessler/fabric/releases/tag/v1.4.291) (Aug 18, 2025) — **Speech To Text**: Add OpenAI speech-to-text support with `--transcribe-file`, `--transcribe-model`, and `--split-media-file` flags.
 - [v1.4.287](https://github.com/danielmiessler/fabric/releases/tag/v1.4.287) (Aug 16, 2025) — **AI Reasoning**: Add Thinking to Gemini models and introduce `readme_updates` python script
 - [v1.4.286](https://github.com/danielmiessler/fabric/releases/tag/v1.4.286) (Aug 14, 2025) — **AI Reasoning**: Introduce Thinking Config Across Anthropic and OpenAI Providers
@@ -139,6 +140,7 @@ Keep in mind that many of these were recorded when Fabric was Python-based, so r
       - [Bash Completion](#bash-completion)
       - [Fish Completion](#fish-completion)
   - [Usage](#usage)
+    - [Debug Levels](#debug-levels)
   - [Our approach to prompting](#our-approach-to-prompting)
   - [Examples](#examples)
   - [Just use the Patterns](#just-use-the-patterns)
@@ -208,6 +210,17 @@ To install Fabric, you can use the latest release binaries or install it from th
 #### Windows
 
 `https://github.com/danielmiessler/fabric/releases/latest/download/fabric-windows-amd64.exe`
+
+Or via PowerShell, just copy and paste and run the following snippet to install the binary into `{HOME}\.local\bin`. Please make sure that directory is included in your `PATH`.
+
+```powershell
+$ErrorActionPreference = "Stop"
+$LATEST="https://github.com/danielmiessler/fabric/releases/latest/download/fabric-windows-amd64.exe"
+$DIR="${HOME}\.local\bin"
+New-Item -Path $DIR -ItemType Directory -Force
+Invoke-WebRequest -URI  "${LATEST}" -outfile "${DIR}\fabric.exe"
+& "${DIR}\fabric.exe" /version
+```
 
 #### macOS (arm64)
 

--- a/cmd/generate_changelog/incoming/1723.txt
+++ b/cmd/generate_changelog/incoming/1723.txt
@@ -1,0 +1,7 @@
+### PR [#1723](https://github.com/danielmiessler/Fabric/pull/1723) by [ksylvan](https://github.com/ksylvan): docs: update README with Venice AI provider and Windows install script
+
+- Add Venice AI provider configuration with API endpoint
+- Document Venice AI as privacy-first open-source provider
+- Include PowerShell installation script for Windows users
+- Add debug levels section to table of contents
+- Update recent major features with v1.4.294 release notes

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -102,6 +102,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "https://api.together.xyz/v1",
 		ImplementsResponses: false,
 	},
+	"Venice AI": {
+		Name:                "Venice AI",
+		BaseURL:             "https://api.venice.ai/api/v1",
+		ImplementsResponses: false,
+	},
 }
 
 // GetProviderByName returns the provider configuration for a given name with O(1) lookup


### PR DESCRIPTION

## Summary

Add native support for the Venice AI provider (OpenAI-compatible) and update documentation:
- Introduce Venice AI to the OpenAI-compatible provider map with its API base URL.
- Update README with a new “Recent Major Feature” entry for Venice AI support.
- Add a Windows PowerShell one-liner for installing Fabric.
- Add “Debug Levels” to the README table of contents.
- Include a changelog stub for PR #1723.

## Related Issues

Closes #610 
Closes #1187 

## Files Changed

- internal/plugins/ai/openai_compatible/providers_config.go
  - Added Venice AI provider configuration.
- README.md
  - Added v1.4.294 feature note for Venice AI.
  - Added PowerShell install snippet for Windows.
  - Added “Debug Levels” entry to the Usage section of the Table of Contents.
- cmd/generate_changelog/incoming/1723.txt
  - New changelog entry describing the above updates.

## Code Changes

- internal/plugins/ai/openai_compatible/providers_config.go
  - Add Venice AI to the provider map:
    ```go
    "Venice AI": {
        Name:                "Venice AI",
        BaseURL:             "https://api.venice.ai/api/v1",
        ImplementsResponses: false,
    },
    ```
  - Rationale:
    - BaseURL points to Venice’s OpenAI-compatible v1 API root.
    - ImplementsResponses=false indicates we’ll use the Chat Completions flow rather than OpenAI’s Responses API for this provider.

- README.md
  - Recent Major Features:
    ```md
    - [v1.4.294](https://github.com/danielmiessler/fabric/releases/tag/v1.4.294) (Aug 20, 2025) — **Venice AI Support**: Added the Venice AI provider. Venice is a Privacy-First, Open-Source AI provider. See their ["About Venice"](https://docs.venice.ai/overview/about-venice) page for details.
    ```
  - Table of Contents:
    ```md
    - [Usage](#usage)
      - [Debug Levels](#debug-levels)
    ```
  - Windows install snippet:
    ```powershell
    $ErrorActionPreference = "Stop"
    $LATEST="https://github.com/danielmiessler/fabric/releases/latest/download/fabric-windows-amd64.exe"
    $DIR="${HOME}\.local\bin"
    New-Item -Path $DIR -ItemType Directory -Force
    Invoke-Webrequest -URI  "${LATEST}" -outfile "${DIR}\fabric.exe"
    & "${DIR}\fabric.exe" /version
    ```

- cmd/generate_changelog/incoming/1723.txt
  - Adds the changelog notes for this PR, including the Venice AI provider, Windows install script, debug levels ToC update, and the v1.4.294 release note.

## Reason for Changes

- Feature addition: Enable users to select Venice AI as a provider via our OpenAI-compatible integration.
- Documentation improvements: Make it easier for Windows users to install Fabric and surface debugging information in the README’s ToC.
- Transparency: Update Recent Major Features and include a structured changelog entry for release automation.

## Impact of Changes

- New functionality: Users can now target Venice AI using the OpenAI-compatible path with the configured base URL.
- No breaking changes: Existing providers and defaults are unchanged.
- Documentation: Easier onboarding for Windows and better discoverability for debugging guidance.
- Release communication: The README’s feature list and the changelog entry align with the upcoming v1.4.294 release.

## Test Plan

- Provider config:
  - Build and run Fabric.
  - Verify that “Venice AI” appears in any provider listing (if available) and can be selected.
  - Used the `--listmodels` subcommand and verified that Venice models show up.
  - Executed a simple prompt using the Venice AI provider and a valid API key.
