### PR TITLE
Support code-signing windows .exe using signtool.exe

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,13 @@ jobs:
           GOARCH: ${{ matrix.arch }}
         run: |
           go build -o fabric-windows-${{ matrix.arch }}.exe ./cmd/fabric
-
+      - name: Sign Binary on Windows
+        if: false && matrix.os == 'windows-latest'
+        uses: tonymet/code-sign-action@v1.0.1
+        with:
+          file: fabric-windows-${{ matrix.arch }}.exe
+          certificate-data: ${{ secrets.WINDOWS_CERT_BASE64 }}
+          certificate-password: ${{ secrets.WINDOWS_CERT_PASSWORD }}
       - name: Upload build artifact
         if: matrix.os != 'windows-latest'
         uses: actions/upload-artifact@v4

--- a/scripts/windows/create-cert.ps1
+++ b/scripts/windows/create-cert.ps1
@@ -1,0 +1,1 @@
+New-SelfSignedCertificate -Subject "CN=Fabric Self-Signing Certificate" -Type CodeSigningCert -CertStoreLocation Cert:\CurrentUser\My -HashAlgorithm SHA256

--- a/scripts/windows/export-cert.ps1
+++ b/scripts/windows/export-cert.ps1
@@ -1,0 +1,13 @@
+# Export signing certificate into base64 encoded contents
+$cert= Get-ChildItem -Path Cert:\CurrentUser\My | where-object  {$_.Subject -like "*fabric*"}
+if ($null -eq $cert) {
+    Write-Error "Signing certificate '*fabric*' not found in CurrentUser\My store."
+    exit 1
+}
+$password = Read-Host -AsSecureString -Prompt "Enter a password for the PFX file"
+$pfxPath = [System.IO.Path]::GetTempFileName() + ".pfx"
+Export-PfxCertificate -Cert $cert -FilePath $pfxPath -Password $password
+$pfxContent = [System.IO.File]::ReadAllBytes($pfxPath)
+[System.Convert]::ToBase64String($pfxContent)
+Remove-Item $pfxPath
+Write-Output "`n`nAdd these secrets to github secrets as WINDOWS_CERT_BASE64 and WINDOWS_CERT_PASSWORD`n"


### PR DESCRIPTION
## What this Pull Request (PR) does
To support improving Windows installation and  issue     #1722 , add code-signing to fabric.exe  .   

1. self-sign binary using our own certificate ( see `scripts/windows/create-cert.ps1` ) .  This calls `tonymet/code-sign-action@v1.0.1` which signs but does not run `signtool verify` during CI since that breaks the build.
1. sign binary with timestamp signature verified by root CA (certificate authority)
2. Support for future MacOS code signing by adding MacOS builds to the build matrix ( currently disabled)

## Ongoing maintenance
1. The certificate expires in 12 months and will need re-creation and re-deployment in 11 mo

## How to Enable this Feature after merging

Code signing is disabled by default. Here's how to enable
1. create the cert and store securely with ` . .\scripts\windows\create-cert.ps1`
3. export the cert and add to github secrets with this project  .  `WINDOWS_CERT_BASE64` and `WINDOWS_CERT_PASSWORD` will be generated via `. .\scripts\windows\export-cert.ps1`
4. modify release.yaml and change `Sign Binary on Windows` if condition to `true && ...` . This will activate code signing with the next actions run. 

## Context on Code Signing & Windows Integrity 

The overall goal is to streamline windows installation .  Indications of that would be:
1. simple cli installation e.g. winget 
5. pass Windows Defender Smart Screen (avoid warnings on download from Edge / Windows Explorer )
6. avoid triggering Defender Antivirus (quarantine) or other anti-virus 

The challenge is that (2) and (3) are heuristics-based programs depending on signals including .exe hash, download path, code-signatures , user reports.   (3) Windows Defender heuristics also measure .exe activity like writing to files on disk, reading environment variables, network activity. 

Self-signing helps with (3) completely.  For (2) it will help gradually , as MS Defender Smart Screen uses the code-signature as one of the heuristics signals .  It will continue to fail Smart Screen and show warnings in MS Edge & MS Explorer

## Related issues
#1722 

## Testing Code-signed Binaries

### Download
```
$LATEST="https://github.com/tonymet/Fabric/releases/download/v1.4.294/fabric-windows-amd64.exe"
 Invoke-Webrequest -URI  "${LATEST}" -outfile (Split-Path -leaf $LATEST)
```

### Verify
Note `signTool Error: A certificate chain processed, but terminated in a root` is an expected error because we are using self-signed certificate.  The timestamp signature is valid 
```

PS C:\Users\tonymet\source\Fabric\test-release> signtool verify /debug fabric-windows-amd64.exe

Verifying: fabric-windows-amd64.exe

Signature Index: 0 (Primary Signature)
Hash of file (sha256): 9D94DD1A3C1566E14BFA1C96E22B03C5F4924499B9B36D38C47D59C106175317

Signing Certificate Chain:
    Issued to: Test Fabric Signing Certificate
    Issued by: Test Fabric Signing Certificate
    Expires:   Thu Aug 20 13:36:41 2026
    SHA1 hash: CF44CF76A52B3CDB115B243D5F0FCB0630904525

The signature is timestamped: Fri Aug 22 09:25:29 2025
Timestamp Verified by:
    Issued to: USERTrust RSA Certification Authority
    Issued by: USERTrust RSA Certification Authority
    Expires:   Mon Jan 18 16:59:59 2038
    SHA1 hash: 2B8F1B57330DBBA2D07A6C51F70EE90DDAB9AD8E

        Issued to: Sectigo Public Time Stamping Root R46
        Issued by: USERTrust RSA Certification Authority
        Expires:   Mon Jan 18 16:59:59 2038
        SHA1 hash: 853D632D938282617CD09035C491DE92C142DAC7

            Issued to: Sectigo Public Time Stamping CA R36
            Issued by: Sectigo Public Time Stamping Root R46
            Expires:   Fri Mar 21 16:59:59 2036
            SHA1 hash: C6AE54E47886F17C3D5512488C69C34A7AF9C2DD

                Issued to: Sectigo Public Time Stamping Signer R36
                Issued by: Sectigo Public Time Stamping CA R36
                Expires:   Fri Mar 21 16:59:59 2036
                SHA1 hash: 38C914811044B4DC663E93D4744B814186A9B5B1

SignTool Error: A certificate chain processed, but terminated in a root
        certificate which is not trusted by the trust provider.

Number of files successfully Verified: 0
Number of warnings: 0
Number of errors: 1
```
