### PR TITLE
Standardize Anthropic Beta Failure Logging

### DIFF
--- a/cmd/generate_changelog/incoming/1727.txt
+++ b/cmd/generate_changelog/incoming/1727.txt
@@ -1,0 +1,7 @@
+### PR [#1727](https://github.com/danielmiessler/Fabric/pull/1727) by [ksylvan](https://github.com/ksylvan): Standardize Anthropic Beta Failure Logging
+
+- Refactor: route Anthropic beta failure logs through internal debug logger
+- Replace fmt.Fprintf stderr with debuglog.Debug for beta failures
+- Import internal log package and remove os dependency
+- Standardize logging level to debuglog.Basic for beta errors
+- Preserve fallback stream behavior when beta features fail

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-	"os"
 	"strconv"
 	"strings"
 
@@ -12,6 +11,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/option"
 	"github.com/danielmiessler/fabric/internal/chat"
 	"github.com/danielmiessler/fabric/internal/domain"
+	debuglog "github.com/danielmiessler/fabric/internal/log"
 	"github.com/danielmiessler/fabric/internal/plugins"
 	"github.com/danielmiessler/fabric/internal/util"
 )
@@ -195,7 +195,7 @@ func (an *Client) SendStream(
 	}
 	stream := an.client.Messages.NewStreaming(ctx, params, reqOpts...)
 	if stream.Err() != nil && len(betas) > 0 {
-		fmt.Fprintf(os.Stderr, "Anthropic beta feature %s failed: %v\n", strings.Join(betas, ","), stream.Err())
+		debuglog.Debug(debuglog.Basic, "Anthropic beta feature %s failed: %v\n", strings.Join(betas, ","), stream.Err())
 		stream = an.client.Messages.NewStreaming(ctx, params)
 	}
 
@@ -289,7 +289,7 @@ func (an *Client) Send(ctx context.Context, msgs []*chat.ChatCompletionMessage, 
 	}
 	if message, err = an.client.Messages.New(ctx, params, reqOpts...); err != nil {
 		if len(betas) > 0 {
-			fmt.Fprintf(os.Stderr, "Anthropic beta feature %s failed: %v\n", strings.Join(betas, ","), err)
+			debuglog.Debug(debuglog.Basic, "Anthropic beta feature %s failed: %v\n", strings.Join(betas, ","), err)
 			if message, err = an.client.Messages.New(ctx, params); err != nil {
 				return
 			}


### PR DESCRIPTION
# Standardize Anthropic Beta Failure Logging

## Summary

This PR replaces direct stderr output with structured debug logging for Anthropic API beta feature failures, improving the consistency of error handling and debug output across the codebase.

## Related Issues

Closes #1724 

You can still see the warning when using the `--debug` flag

```text
fabric -m $MODEL_CLAUDE --debug 1 test
DEBUG: Anthropic beta feature context-1m-2025-08-07 failed: POST "https://api.anthropic.com/v1/messages": 400 Bad Request (Request-ID: req_011CST94aNKdnaLbUmGY7Mjf) {"type":"error","error":{"type":"invalid_request_error","message":"The long context beta is not yet available for this subscription."},"request_id":"req_011CST94aNKdnaLbUmGY7Mjf"}
I understand you want me to execute instructions using your input "test" and respond only in en-US English.
```

## Files Changed

- **internal/plugins/ai/anthropic/anthropic.go**: Modified error reporting mechanism from using `fmt.Fprintf(os.Stderr, ...)` to using the internal debug logging system `debuglog.Debug()`.

## Code Changes

### internal/plugins/ai/anthropic/anthropic.go

**Import changes:**
```go
- "os"
+ debuglog "github.com/danielmiessler/fabric/internal/log"
```

**SendStream method (line ~198):**
```go
- fmt.Fprintf(os.Stderr, "Anthropic beta feature %s failed: %v\n", strings.Join(betas, ","), stream.Err())
+ debuglog.Debug(debuglog.Basic, "Anthropic beta feature %s failed: %v\n", strings.Join(betas, ","), stream.Err())
```

**Send method (line ~292):**
```go
- fmt.Fprintf(os.Stderr, "Anthropic beta feature %s failed: %v\n", strings.Join(betas, ","), err)
+ debuglog.Debug(debuglog.Basic, "Anthropic beta feature %s failed: %v\n", strings.Join(betas, ","), err)
```

## Reason for Changes

The changes standardize error reporting throughout the application by utilizing the internal debug logging system instead of writing directly to stderr. This provides:
- Centralized control over debug output visibility
- Consistent logging format across the application
- Better control over log levels and filtering

## Impact of Changes

- **Logging Consistency**: Debug messages for Anthropic beta feature failures now follow the same logging patterns as the rest of the application
- **No Functional Changes**: The error handling logic remains unchanged - beta features that fail still fall back to standard API calls
- **Debug Control**: These messages can now be controlled via the application's debug logging configuration rather than always appearing in stderr

## Test Plan

1. Test with Anthropic API calls that use beta features
2. Verify that when beta features fail, the debug messages appear when debug logging is enabled
3. Confirm fallback to standard API calls still works correctly
4. Ensure no debug output appears in stderr when debug logging is disabled

## Additional Notes

- The `debuglog.Basic` level was chosen for these messages as they represent non-critical fallback scenarios
- The message format and content remain identical to preserve any existing log parsing or monitoring
- No changes to the actual error handling flow - this is purely a logging improvement