### PR TITLE
Fix Docker Build Path Configuration

### DIFF
--- a/.github/workflows/docker-publish-on-tag.yml
+++ b/.github/workflows/docker-publish-on-tag.yml
@@ -101,6 +101,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ./scripts/docker/Dockerfile
           push: true
           platforms: linux/amd64,linux/arm64
           tags: ${{ steps.meta.outputs.tags }}

--- a/.github/workflows/update-version-and-create-tag.yml
+++ b/.github/workflows/update-version-and-create-tag.yml
@@ -6,7 +6,6 @@ on:
       - main # Monitor the main branch
     paths-ignore:
       - "data/patterns/**"
-      - "**/*.md"
       - "data/strategies/**"
       - "cmd/generate_changelog/*.db"
       - "cmd/generate_changelog/incoming/*.txt"

--- a/cmd/generate_changelog/incoming/1735.txt
+++ b/cmd/generate_changelog/incoming/1735.txt
@@ -1,0 +1,7 @@
+### PR [#1735](https://github.com/danielmiessler/Fabric/pull/1735) by [ksylvan](https://github.com/ksylvan): Fix Docker Build Path Configuration
+
+- Fix: update Docker workflow to use specific Dockerfile and monitor markdown file changes
+- Add explicit Dockerfile path to Docker build action
+- Remove markdown files from workflow paths-ignore filter
+- Enable CI triggers for documentation file changes
+- Specify Docker build context with custom file location


### PR DESCRIPTION
# Fix Docker Build Path Configuration

## Summary

This PR updates the Docker build configuration and modifies the version update workflow triggers. The changes ensure the Docker build process uses the correct Dockerfile location and adjusts which file changes trigger the version update and tagging workflow.

## Files Changed

- `.github/workflows/docker-publish-on-tag.yml`: Added explicit Dockerfile path for the Docker build action
- `.github/workflows/update-version-and-create-tag.yml`: Removed markdown files from the ignore list for workflow triggers

## Code Changes

### `.github/workflows/docker-publish-on-tag.yml`
Added a new `file` parameter to specify the Dockerfile location:
```yaml
@@ -101,6 +101,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
+          file: ./scripts/docker/Dockerfile
           push: true
```
This explicitly tells the Docker build action to use the Dockerfile located at `./scripts/docker/Dockerfile` instead of looking for it in the root directory.

### `.github/workflows/update-version-and-create-tag.yml`
Removed markdown files from the paths-ignore list:
```yaml
@@ -6,7 +6,6 @@ on:
       - main # Monitor the main branch
     paths-ignore:
       - "data/patterns/**"
-      - "**/*.md"
       - "data/strategies/**"
```
This means changes to markdown files will now trigger the version update and create tag workflow.

## Reason for Changes

1. **Docker Build Fix**: The Dockerfile appears to be located in a subdirectory (`./scripts/docker/`) rather than the repository root. Without specifying the file path, the Docker build action would fail to find the Dockerfile, causing build failures.

2. **Workflow Trigger Enhancement**: Removing markdown files from the ignore list ensures that documentation updates can trigger version updates, which may be desired for maintaining version consistency when important documentation changes are made.

## Impact of Changes

- **Docker Builds**: Will now successfully locate and use the correct Dockerfile, preventing build failures in the CI/CD pipeline
- **Version Management**: Documentation changes will now trigger the version update workflow, potentially increasing the frequency of version bumps but ensuring documentation updates are properly versioned

## Test Plan

1. Verify that the Docker build workflow successfully completes when a new tag is created
2. Confirm the Docker image is built using the Dockerfile at `./scripts/docker/Dockerfile`
3. Test that pushing changes to markdown files on the main branch triggers the version update workflow
4. Ensure other ignored paths (patterns, strategies, etc.) still correctly prevent workflow execution

## Additional Notes

- Consider whether triggering version updates on markdown changes aligns with your versioning strategy. If documentation changes shouldn't trigger new versions, this change should be reconsidered
- Ensure the Dockerfile at `./scripts/docker/Dockerfile` exists and is properly maintained
- Monitor the initial runs of these workflows after merging to catch any unexpected behavior early