### PR TITLE
 CI: Fix Release Description Update

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Update Release Description
-        run: go run ./cmd/generate_changelog --release ${{ github.ref_name }}
+        run: go run ./cmd/generate_changelog --release ${{ github.event.client_payload.tag || github.ref_name }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/cmd/generate_changelog/incoming/1741.txt
+++ b/cmd/generate_changelog/incoming/1741.txt
@@ -1,0 +1,6 @@
+### PR [#1741](https://github.com/danielmiessler/Fabric/pull/1741) by [ksylvan](https://github.com/ksylvan): CI: Fix Release Description Update
+
+- Fix: update release workflow to support manual dispatch with custom tag
+- Support custom tag from client payload in workflow
+- Fallback to github.ref_name when no custom tag provided
+- Enable manual release triggers with specified tag parameter


### PR DESCRIPTION
# CI: Fix Release Description Update

## Summary

This PR updates the GitHub Actions release workflow to support both manual and automated release triggers by making the changelog generation more flexible in how it determines the release tag.

## Files Changed

- `.github/workflows/release.yml` - Modified the changelog generation step to handle different trigger scenarios

## Code Changes

The key change is in the "Update Release Description" step:

```yaml
# Before
run: go run ./cmd/generate_changelog --release ${{ github.ref_name }}

# After  
run: go run ./cmd/generate_changelog --release ${{ github.event.client_payload.tag || github.ref_name }}
```

This change uses GitHub's logical OR operator (`||`) to first check for `github.event.client_payload.tag` and fall back to `github.ref_name` if the payload tag is not available.

## Reason for Changes

This modification enables the release workflow to work correctly in multiple scenarios:

1. **Repository dispatch events** - When triggered via API calls or external automation that includes a custom tag in the client payload
2. **Manual/tag-based triggers** - When triggered by standard GitHub events where the tag is available in `github.ref_name`

The fallback mechanism ensures backward compatibility while adding support for programmatic release triggering.

## Impact of Changes

- **Improved flexibility**: The workflow can now handle releases triggered through different mechanisms
- **Backward compatibility**: Existing manual release processes continue to work unchanged
- **Enhanced automation support**: External systems can now trigger releases with custom tag specifications
- **No breaking changes**: The fallback ensures existing functionality remains intact

## Test Plan

To test these changes:

1. **Manual trigger test**: Create a new tag and verify the release workflow uses `github.ref_name` correctly
2. **Repository dispatch test**: Trigger the workflow via repository dispatch with a `client_payload.tag` and verify it uses the provided tag
3. **Fallback test**: Trigger without client payload to confirm fallback to `github.ref_name` works

## Additional Notes

- The change is minimal and low-risk, using GitHub Actions' built-in logical operators
- This pattern is commonly used in GitHub workflows for handling multiple trigger scenarios
- The `GITHUB_TOKEN` environment variable remains unchanged and continues to provide necessary permissions for changelog generation

## Potential Considerations

- Ensure that any external systems triggering this workflow provide valid tag names in the `client_payload.tag` field
- Monitor the first few releases after deployment to confirm both trigger methods work as expected
- Consider adding validation to ensure the tag format is consistent regardless of the source