### PR TITLE
Remove garble from the build process for Windows

### DIFF
--- a/.github/workflows/update-version-and-create-tag.yml
+++ b/.github/workflows/update-version-and-create-tag.yml
@@ -95,6 +95,7 @@ jobs:
         run: |
           go run ./cmd/generate_changelog --process-prs ${{ steps.increment_version.outputs.new_tag }}
           go run ./cmd/generate_changelog --sync-db
+          git add ./cmd/generate_changelog/changelog.db
       - name: Commit changes
         run: |
           # These files are modified by the version bump process

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -5,10 +5,7 @@ version: 2
 project_name: fabric
 before:
   hooks:
-    # You may remove this if you don't use go modules.
     - go mod tidy
-    # you may remove this if you don't need go generate
-    # - go generate ./...
 
 builds:
   - id: default
@@ -19,19 +16,28 @@ builds:
       - linux
     main: ./cmd/fabric
     binary: fabric
-  - id: windows-garbled
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+      - -X main.builtBy=goreleaser
+      - -X main.tag={{.Tag}}
+
+  - id: windows-build
     env:
       - CGO_ENABLED=0
     goos:
       - windows
     main: ./cmd/fabric
     binary: fabric
-    tool: garble
-    # From https://github.com/eyevanovich/garble-goreleaser-example/blob/main/.goreleaser.yaml
-    # command is a single string.
-    command: "-tiny"
-    flags: [ "-seed=random", "build" ]
-    ldflags: [ "-s", "-w" ]
+    ldflags:
+      - -s -w
+      - -X main.version={{.Version}}
+      - -X main.commit={{.ShortCommit}}
+      - -X main.date={{.Date}}
+      - -X main.builtBy=goreleaser
+      - -X main.tag={{.Tag}}
 
 archives:
   - formats: [tar.gz]


### PR DESCRIPTION
# Remove garble from the build process for Windows

## Summary

This PR updates the CI/CD pipeline and build configuration for the Fabric project. The main changes include adding the changelog database to git tracking during the release process and simplifying the Windows build configuration by removing the Garble obfuscation tool in favor of standard build flags with version information injection.

The original idea of adding `garble` was to make it pass virus scanning during version upgrades for Winget, and this was a failed experiment. 

## Files Changed

- **`.github/workflows/update-version-and-create-tag.yml`**: Added a step to track the changelog database file in git after generation
- **`.goreleaser.yaml`**: Refactored the Windows build configuration and added comprehensive version information to all builds

## Code Changes

### `.github/workflows/update-version-and-create-tag.yml`
```yaml
@@ -95,6 +95,7 @@ jobs:
         run: |
           go run ./cmd/generate_changelog --process-prs ${{ steps.increment_version.outputs.new_tag }}
           go run ./cmd/generate_changelog --sync-db
+          git add ./cmd/generate_changelog/changelog.db
```
Added `git add` command to stage the changelog database file after it's synchronized, ensuring it's included in the version bump commit.

### `.goreleaser.yaml`
```yaml
- id: windows-garbled
+ id: windows-build
```
Renamed the Windows build configuration from `windows-garbled` to `windows-build` for clarity.

```yaml
- tool: garble
- command: "-tiny"
- flags: [ "-seed=random", "build" ]
- ldflags: [ "-s", "-w" ]
+ ldflags:
+   - -s -w
+   - -X main.version={{.Version}}
+   - -X main.commit={{.ShortCommit}}
+   - -X main.date={{.Date}}
+   - -X main.builtBy=goreleaser
+   - -X main.tag={{.Tag}}
```
Removed Garble obfuscation tool configuration and replaced it with standard ldflags that inject version metadata into the binary at build time. These same ldflags were also added to the default build configuration.

## Reason for Changes

1. **Changelog Database Tracking**: The changelog database needs to be committed to the repository to maintain a persistent record of changelog data across releases
2. **Build Simplification**: Removing Garble reduces build complexity and potential compatibility issues while maintaining binary optimization through standard `-s -w` flags
3. **Version Information**: Adding version metadata injection allows the application to report its version, commit hash, build date, and tag information at runtime, improving debugging and support capabilities

## Impact of Changes

- **Positive Impact**: 
  - Changelog generation will now persist properly across releases
  - Binaries will contain embedded version information for better traceability
  - Build process is simplified and more maintainable
  - Both Linux and Windows builds now use consistent configuration patterns

- **Potential Considerations**:
  - Windows binaries will no longer be obfuscated, which may slightly increase reverse-engineering risk if that was a concern
  - Binary sizes might be slightly different without Garble's tiny mode optimization

## Test Plan

1. Verify the GitHub Actions workflow successfully commits the changelog database during version bumps
2. Build binaries for all platforms and confirm version information is correctly embedded
3. Test that the application can report its version information at runtime
4. Validate that Windows builds complete successfully without Garble

## Additional Notes

The removal of Garble suggests a shift towards prioritizing build reliability and maintainability over code obfuscation. The addition of comprehensive version metadata will significantly improve the ability to track and debug issues in production deployments.
