### PR TITLE
Update anthropic-sdk-go and add claude-sonnet-4-5

### DIFF
--- a/cmd/generate_changelog/incoming/1783.txt
+++ b/cmd/generate_changelog/incoming/1783.txt
@@ -1,0 +1,5 @@
+### PR [#1783](https://github.com/danielmiessler/Fabric/pull/1783) by [ksylvan](https://github.com/ksylvan): Update anthropic-sdk-go and add claude-sonnet-4-5
+
+- Feat: update `anthropic-sdk-go` to v1.13.0 and add new model
+- Upgrade `anthropic-sdk-go` to version 1.13.0
+- Add `ModelClaudeSonnet4_5` to supported models list

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/danielmiessler/fabric
 go 1.25.1
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.12.0
+	github.com/anthropics/anthropic-sdk-go v1.13.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/aws/aws-sdk-go-v2 v1.39.0
 	github.com/aws/aws-sdk-go-v2/config v1.31.8

--- a/go.sum
+++ b/go.sum
@@ -29,6 +29,8 @@ github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFI
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
 github.com/anthropics/anthropic-sdk-go v1.12.0 h1:xPqlGnq7rWrTiHazIvCiumA0u7mGQnwDQtvA1M82h9U=
 github.com/anthropics/anthropic-sdk-go v1.12.0/go.mod h1:WTz31rIUHUHqai2UslPpw5CwXrQP3geYBioRV4WOLvE=
+github.com/anthropics/anthropic-sdk-go v1.13.0 h1:Bhbe8sRoDPtipttg8bQYrMCKe2b79+q6rFW1vOKEUKI=
+github.com/anthropics/anthropic-sdk-go v1.13.0/go.mod h1:WTz31rIUHUHqai2UslPpw5CwXrQP3geYBioRV4WOLvE=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -49,10 +49,12 @@ func NewClient() (ret *Client) {
 		string(anthropic.ModelClaude_3_Opus_20240229), string(anthropic.ModelClaude_3_Haiku_20240307),
 		string(anthropic.ModelClaudeOpus4_20250514), string(anthropic.ModelClaudeSonnet4_20250514),
 		string(anthropic.ModelClaudeOpus4_1_20250805),
+		string(anthropic.ModelClaudeSonnet4_5),
 	}
 
 	ret.modelBetas = map[string][]string{
 		string(anthropic.ModelClaudeSonnet4_20250514): {"context-1m-2025-08-07"},
+		string(anthropic.ModelClaudeSonnet4_5):        {"context-1m-2025-08-07"},
 	}
 
 	return


### PR DESCRIPTION
# Update anthropic-sdk-go and add claude-sonnet-4-5

## Summary

This pull request updates the Anthropic SDK dependency from version 1.12.0 to 1.13.0 and adds support for the new Claude Sonnet 4.5 model in the Fabric project's Anthropic AI plugin.

## Related Issues

Closes #1782 

## Files Changed

### `go.mod`
- **Change**: Updated `github.com/anthropics/anthropic-sdk-go` dependency from `v1.12.0` to `v1.13.0`
- **Purpose**: Upgrade to the latest version of the Anthropic SDK to access new models and potential bug fixes

### `go.sum`
- **Change**: Added checksum entries for the new SDK version `v1.13.0`
- **Purpose**: Maintain integrity verification for the updated dependency

### `internal/plugins/ai/anthropic/anthropic.go`
- **Change**: Added support for the new Claude Sonnet 4.5 model
- **Purpose**: Enable users to utilize the latest Claude Sonnet 4.5 model in the Fabric application

## Code Changes

#### Anthropic Client Configuration (`internal/plugins/ai/anthropic/anthropic.go`)

**Added model to supported models list:**
```go
string(anthropic.ModelClaudeSonnet4_5),
```

**Added beta configuration for the new model:**
```go
string(anthropic.ModelClaudeSonnet4_5): {"context-1m-2025-08-07"},
```

The new model is configured with the `context-1m-2025-08-07` beta flag, which likely enables the 1 million token context window feature, consistent with the Claude Sonnet 4 configuration.

## Reason for Changes

1. **SDK Update**: The Anthropic SDK was updated to version 1.13.0 to gain access to the newly released Claude Sonnet 4.5 model and any accompanying improvements or fixes in the SDK.

2. **Model Support**: Claude Sonnet 4.5 represents a new model offering from Anthropic, and adding support ensures that Fabric users can take advantage of the latest AI capabilities.

3. **Beta Feature Access**: The model is configured with the extended context beta flag, allowing users to leverage the 1 million token context window capability.

## Impact of Changes

**Positive Impacts:**
- Users can now select and use the Claude Sonnet 4.5 model through Fabric
- Access to improved performance and capabilities that come with the newer model
- Extended context window support (1M tokens) for Claude Sonnet 4.5
- Maintains consistency with the existing beta configuration pattern used for Claude Sonnet 4

**Potential Considerations:**
- The SDK upgrade is a minor version bump (1.12.0 → 1.13.0), which should maintain backward compatibility but may include behavior changes
- Users will need to have API access to Claude Sonnet 4.5 through their Anthropic account
- The beta flag requirement means this feature may still be evolving

## Test Plan

1. Verify the application builds successfully with the updated dependency ✅
2. Test basic functionality with existing Claude models to ensure no regressions ✅
3. Test Claude Sonnet 4.5 model selection and API calls with a valid Anthropic API key ✅
4. Verify the 1M context window beta flag is properly applied in API requests ✅
5. Confirm error handling works correctly if users don't have access to the new model ✅

## Additional Notes

- The change follows the existing pattern for adding new Claude models to the client
- Both the model identifier and beta configuration are added consistently with the Claude Sonnet 4 implementation
- No breaking changes are introduced; this is purely additive functionality
- The SDK update appears to be the primary vehicle for accessing the new model enum `ModelClaudeSonnet4_5`
- Users should ensure their Anthropic API keys have appropriate access to the new model before attempting to use it