### PR TITLE
Update `anthropic-sdk-go` to v1.16.0 and update models

### DIFF
--- a/cmd/generate_changelog/incoming/1816.txt
+++ b/cmd/generate_changelog/incoming/1816.txt
@@ -1,0 +1,7 @@
+### PR [#1816](https://github.com/danielmiessler/Fabric/pull/1816) by [ksylvan](https://github.com/ksylvan): Update `anthropic-sdk-go` to v1.16.0 and update models
+
+- Upgraded `anthropic-sdk-go` from v1.13.0 to v1.16.0
+- Removed outdated model `ModelClaude3_5SonnetLatest`
+- Added new model `ModelClaudeSonnet4_5_20250929`
+- Updated anthropic beta map to include the new model
+- Updated dependencies in `go.sum` file

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/danielmiessler/fabric
 go 1.25.1
 
 require (
-	github.com/anthropics/anthropic-sdk-go v1.13.0
+	github.com/anthropics/anthropic-sdk-go v1.16.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/aws/aws-sdk-go-v2 v1.39.0
 	github.com/aws/aws-sdk-go-v2/config v1.31.8

--- a/go.sum
+++ b/go.sum
@@ -27,8 +27,8 @@ github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kk
 github.com/andybalholm/cascadia v1.3.3/go.mod h1:xNd9bqTn98Ln4DwST8/nG+H0yuB8Hmgu1YHNnWw0GeA=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be h1:9AeTilPcZAjCFIImctFaOjnTIavg87rW78vTPkQqLI8=
 github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be/go.mod h1:ySMOLuWl6zY27l47sB3qLNK6tF2fkHG55UZxx8oIVo4=
-github.com/anthropics/anthropic-sdk-go v1.13.0 h1:Bhbe8sRoDPtipttg8bQYrMCKe2b79+q6rFW1vOKEUKI=
-github.com/anthropics/anthropic-sdk-go v1.13.0/go.mod h1:WTz31rIUHUHqai2UslPpw5CwXrQP3geYBioRV4WOLvE=
+github.com/anthropics/anthropic-sdk-go v1.16.0 h1:nRkOFDqYXsHteoIhjdJr/5dsiKbFF3rflSv8ax50y8o=
+github.com/anthropics/anthropic-sdk-go v1.16.0/go.mod h1:WTz31rIUHUHqai2UslPpw5CwXrQP3geYBioRV4WOLvE=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -44,17 +44,18 @@ func NewClient() (ret *Client) {
 	ret.models = []string{
 		string(anthropic.ModelClaude3_7SonnetLatest), string(anthropic.ModelClaude3_7Sonnet20250219),
 		string(anthropic.ModelClaude3_5HaikuLatest), string(anthropic.ModelClaude3_5Haiku20241022),
-		string(anthropic.ModelClaude3_5SonnetLatest), string(anthropic.ModelClaude3_5Sonnet20241022),
-		string(anthropic.ModelClaude_3_5_Sonnet_20240620), string(anthropic.ModelClaude3OpusLatest),
-		string(anthropic.ModelClaude_3_Opus_20240229), string(anthropic.ModelClaude_3_Haiku_20240307),
+		string(anthropic.ModelClaude3OpusLatest), string(anthropic.ModelClaude_3_Opus_20240229),
+		string(anthropic.ModelClaude_3_Haiku_20240307),
 		string(anthropic.ModelClaudeOpus4_20250514), string(anthropic.ModelClaudeSonnet4_20250514),
 		string(anthropic.ModelClaudeOpus4_1_20250805),
 		string(anthropic.ModelClaudeSonnet4_5),
+		string(anthropic.ModelClaudeSonnet4_5_20250929),
 	}
 
 	ret.modelBetas = map[string][]string{
-		string(anthropic.ModelClaudeSonnet4_20250514): {"context-1m-2025-08-07"},
-		string(anthropic.ModelClaudeSonnet4_5):        {"context-1m-2025-08-07"},
+		string(anthropic.ModelClaudeSonnet4_20250514):   {"context-1m-2025-08-07"},
+		string(anthropic.ModelClaudeSonnet4_5):          {"context-1m-2025-08-07"},
+		string(anthropic.ModelClaudeSonnet4_5_20250929): {"context-1m-2025-08-07"},
 	}
 
 	return


### PR DESCRIPTION
# Update `anthropic-sdk-go` to v1.16.0 and update models

This PR updates the Anthropic SDK dependency from version 1.13.0 to 1.16.0 and refactors the model list to include a new Claude Sonnet 4.5 dated model while reorganizing the existing model declarations for better clarity.

## Files Changed

### `go.mod`
- Updated `github.com/anthropics/anthropic-sdk-go` from version `1.13.0` to `1.16.0`

### `go.sum`
- Updated checksums for the Anthropic SDK dependency to reflect the new version `1.16.0`

### `internal/plugins/ai/anthropic/anthropic.go`
- Reorganized the model list by removing intermediate Claude 3.5 Sonnet models and adding the new dated variant
- Added beta configuration for the new Claude Sonnet 4.5 dated model

## Code Changes

#### Dependency Update
```go
// go.mod
-	github.com/anthropics/anthropic-sdk-go v1.13.0
+	github.com/anthropics/anthropic-sdk-go v1.16.0
```

#### Model List Refactoring
The model list was reorganized to remove the following models:
- `ModelClaude3_5SonnetLatest`
- `ModelClaude3_5Sonnet20241022`
- `ModelClaude_3_5_Sonnet_20240620`

And added:
```go
string(anthropic.ModelClaudeSonnet4_5_20250929)
```

#### Beta Configuration Addition
```go
ret.modelBetas = map[string][]string{
    string(anthropic.ModelClaudeSonnet4_20250514):   {"context-1m-2025-08-07"},
    string(anthropic.ModelClaudeSonnet4_5):          {"context-1m-2025-08-07"},
+   string(anthropic.ModelClaudeSonnet4_5_20250929): {"context-1m-2025-08-07"},
}
```

## Reason for Changes

1. **SDK Update**: Upgrading to Anthropic SDK v1.16.0 likely includes bug fixes, performance improvements, and support for newer models that are referenced in the code changes.

2. **Model List Simplification**: The removal of Claude 3.5 Sonnet variants suggests these models may have been deprecated or superseded by the Claude 4 series models. This cleanup reduces confusion and maintains only actively supported models.

3. **New Model Support**: Adding `ModelClaudeSonnet4_5_20250929` provides access to a newer dated version of the Claude Sonnet 4.5 model, likely with improvements or fixes over previous versions.

4. **Beta Feature Configuration**: The new model requires the same 1M context window beta feature flag as its predecessors, ensuring consistent behavior across Claude 4.5 variants.

## Impact of Changes

### Positive Impacts
- **Up-to-date Dependencies**: Users benefit from the latest SDK improvements and bug fixes
- **Access to Latest Models**: The new dated model variant provides access to the most recent Claude capabilities
- **Cleaner Codebase**: Removing deprecated models reduces maintenance burden and potential confusion

### Potential Issues
- **Breaking Changes**: Users who were explicitly using the removed Claude 3.5 Sonnet models will no longer have access to them through this client. This could break existing configurations that reference these specific model strings.
- **API Compatibility**: The SDK version bump could introduce breaking changes in the API surface, though the code suggests the changes are backward compatible in the areas being used.

## Test Plan

The changes were tested as follows:

1. **Dependency Resolution**: Verify that `go mod tidy` and `go build` complete successfully with the new SDK version
2. **Model Initialization**: Confirm that the client initializes correctly and the model list is properly populated
3. **Model Selection**: Test that the new `ModelClaudeSonnet4_5_20250929` can be selected and used for inference
4. **Beta Feature**: Verify that the 1M context window beta feature is properly applied when using the new model
5. **Backward Compatibility**: Test existing code paths that use Claude 4 models to ensure they continue to work as expected

## Additional Notes

**Deprecation Warning**: If the removed Claude 3.5 Sonnet models are still in use by consumers of this library, consider:
- Adding a migration guide in the PR description or release notes
- Implementing a deprecation warning period before removal
- Documenting which models should be used as replacements

**Version Date Pattern**: The new model follows the pattern of dated model versions (e.g., `20250929`), which appears to be Anthropic's strategy for versioning models. Future updates will likely follow this pattern.

**Beta Feature Consistency**: All Claude Sonnet 4.5 variants now require the same beta feature flag, suggesting this is a family-wide capability requirement rather than model-specific.
