### PR TITLE
Make YouTube API key optional in setup

### DIFF
--- a/cmd/generate_changelog/incoming/1827.txt
+++ b/cmd/generate_changelog/incoming/1827.txt
@@ -1,0 +1,6 @@
+### PR [#1827](https://github.com/danielmiessler/Fabric/pull/1827) by [ksylvan](https://github.com/ksylvan): Make YouTube API key optional in setup
+
+- Make YouTube API key optional in setup process
+- Change API key setup question to optional configuration
+- Add test for optional API key behavior
+- Ensure plugin configuration works without API key

--- a/internal/tools/youtube/youtube.go
+++ b/internal/tools/youtube/youtube.go
@@ -69,7 +69,7 @@ func NewYouTube() (ret *YouTube) {
 		EnvNamePrefix:    plugins.BuildEnvVariablePrefix(label),
 	}
 
-	ret.ApiKey = ret.AddSetupQuestion("API key", true)
+	ret.ApiKey = ret.AddSetupQuestion("API key", false)
 
 	return
 }

--- a/internal/tools/youtube/youtube_optional_test.go
+++ b/internal/tools/youtube/youtube_optional_test.go
@@ -1,0 +1,19 @@
+package youtube
+
+import "testing"
+
+func TestNewYouTubeApiKeyOptional(t *testing.T) {
+	yt := NewYouTube()
+
+	if yt.ApiKey == nil {
+		t.Fatal("expected API key setup question to be initialized")
+	}
+
+	if yt.ApiKey.Required {
+		t.Fatalf("expected YouTube API key to be optional, but it is marked as required")
+	}
+
+	if !yt.IsConfigured() {
+		t.Fatalf("expected YouTube plugin to be considered configured without an API key")
+	}
+}


### PR DESCRIPTION
# Make YouTube API Key Optional in Setup

## Summary

This PR makes the YouTube API key optional during plugin setup, allowing the YouTube plugin to be configured and used without providing an API key upfront.

## Related Issues

Closes #1820

## Files Changed

### `internal/tools/youtube/youtube.go`
Modified the YouTube plugin initialization to mark the API key setup question as optional rather than required.

### `internal/tools/youtube/youtube_optional_test.go` (New file)
Added a new test file to verify that the YouTube API key is properly configured as optional and that the plugin is considered configured even without an API key.

## Code Changes

### internal/tools/youtube/youtube.go

Changed line 72 from:
```go
ret.ApiKey = ret.AddSetupQuestion("API key", true)
```

To:
```go
ret.ApiKey = ret.AddSetupQuestion("API key", false)
```

The second parameter to `AddSetupQuestion` controls whether the field is required. This change switches it from `true` (required) to `false` (optional).

### internal/tools/youtube/youtube_optional_test.go

Added a test with three key assertions:

1. Verifies the API key setup question is initialized
2. Confirms the `Required` field is set to `false`
3. Validates that `IsConfigured()` returns `true` even without an API key

## Reason for Changes

The YouTube API key is being made optional to improve the plugin's flexibility and user experience. This change supports scenarios where:

- Users want to use the YouTube plugin initially without having an API key ready
- The plugin has fallback functionality that doesn't require API authentication
- Configuration can be completed in stages, with the API key added later when needed

## Impact of Changes

**Positive impacts:**
- Improved user experience by reducing barriers to initial configuration
- More flexible plugin setup workflow
- Maintains backward compatibility (existing configurations with API keys continue to work)

**Potential concerns:**
- Runtime behavior when the API key is missing: Code that depends on the API key will need proper error handling when the key is not provided
- If API operations are attempted without a key, ensure graceful error messages guide users to add the key

## Test Plan

Added a unit test `TestNewYouTubeApiKeyOptional` that verifies:
1. The API key setup question is properly initialized
2. The `Required` field is explicitly set to `false`
3. The plugin is considered configured (`IsConfigured()` returns `true`) without an API key

The test should be run with:
```bash
go test ./internal/tools/youtube/...
```

## Additional Notes

**Potential bugs to watch for:**
- Silent failures or cryptic errors when YouTube API operations are attempted without a key
