### PR TITLE
Improve channel management in Gemini provider

### DIFF
--- a/cmd/generate_changelog/incoming/1832.txt
+++ b/cmd/generate_changelog/incoming/1832.txt
@@ -1,0 +1,7 @@
+### PR [#1832](https://github.com/danielmiessler/Fabric/pull/1832) by [ksylvan](https://github.com/ksylvan): Improve channel management in Gemini provider
+
+- Fix: improve channel management in Gemini streaming method
+- Add deferred channel close at function start
+- Return error immediately instead of breaking loop
+- Remove redundant channel close statements from loop
+- Ensure channel closes on all exit paths consistently


### PR DESCRIPTION
# Improve channel management in Gemini provider

## Summary

Ensure `SendStream` consistently closes the output channel and returns errors instead of sending error messages into the stream and exiting via `break`. This hardens the streaming behavior and avoids double-closing the channel.

## Related Issues

Closes #1815 

## Files Changed

- `internal/plugins/ai/gemini/gemini.go`
  - Adjusted `SendStream` to:
    - Always close the provided channel via `defer`.
    - Return errors encountered from the streaming client instead of writing them into the channel and breaking.
    - Remove multiple explicit `close(channel)` calls.

## Code Changes

### `internal/plugins/ai/gemini/gemini.go`

1. Ensure the output channel is closed exactly once:

```go
func (o *Client) SendStream(msgs []*chat.ChatCompletionMessage, opts *domain.ChatOptions, channel chan string) (err error) {
    ctx := context.Background()
    defer close(channel)
```

Previously, the channel was closed explicitly in multiple places (inside the loop on error and again at the end of the function). Now it is closed via `defer`, guaranteeing closure even on early returns and preventing double-closes.

2. Return errors from the stream loop instead of sending them on the channel:

```go
for response, err := range stream {
    if err != nil {
        channel <- fmt.Sprintf("Error: %v\n", err)
        return err
    }

    text := o.extractTextFromResponse(response)
    if text != "" {
        channel <- text
    }
}
```

Previously:

```go
for response, err := range stream {
    if err != nil {
        channel <- fmt.Sprintf("Error: %v\n", err)
        close(channel)
        break
    }

    text := o.extractTextFromResponse(response)
    if text != "" {
        channel <- text
    }
}
close(channel)
```

Key differences:

- On error, we now:
  - Keep the existing behavior of sending a human-readable error message into the channel.
  - Immediately return the error, allowing callers to handle it programmatically.
- We no longer `break` the loop and rely on trailing `close(channel)`; instead, `defer close(channel)` ensures channel closure on any return path.

3. Remove redundant explicit `close(channel)` at the end of `SendStream`, as it is now handled by `defer`.

## Reason for Changes

- Avoid potential `panic: close of closed channel` due to multiple `close(channel)` calls (in-loop on error and at the end of the function).
- Make error handling more explicit for callers:
  - Callers can now distinguish successful vs. failed streaming via the `error` return value rather than inferring errors solely from channel content.
- Ensure the channel is always closed regardless of how the function exits (normal completion, early error, or other future branches).

## Impact of Changes

- **API semantics**:
  - `SendStream` continues to stream text messages on `channel`.
  - On error, behavior is slightly richer:
    - The channel still receives a user-friendly `"Error: ..."` message.
    - The function now returns a non-nil error.
- **Resource safety**:
  - Eliminates double-close risk on the channel.
  - Guarantees channel closure in all paths via `defer`.
- **Downstream consumers**:
  - Consumers that:
    - Only read from the channel and ignore the returned error will still receive an error message and observe channel closure as before.
    - Check the returned error can now respond appropriately (logging, retries, surfacing to caller, etc.).
- No impact on other parts of the project outside this method.

## Test Plan

Tests succeed and have tested:

1. **Happy path streaming**
   - Mock `stream` to emit several responses without error.
   - Confirm:
     - All expected text chunks are sent on `channel`.
     - `SendStream` returns `nil`.
     - `channel` is closed exactly once and terminates after all chunks.

2. **Stream error mid-way**
   - Mock `stream` to emit some responses and then return an error.
   - Confirm:
     - Text chunks before the error are sent on `channel`.
     - An `"Error: ..."` message is sent on `channel` after the error occurs.
     - `SendStream` returns the same error.
     - `channel` is closed and no data is sent after closure.

3. **Immediate error (no responses)**
   - Mock `stream` to return an error immediately.
   - Confirm:
     - Only the error message is sent on `channel`.
     - `SendStream` returns the error.
     - `channel` is closed.

4. **Channel close safety**
   - Use `go test -race` with consumers that read from the channel to verify that no data races or panics occur and the channel is closed exactly once.

## Additional Notes

- The function still uses `context.Background()`. If per-request cancellation is needed, a future improvement would be to accept a `context.Context` parameter so callers can cancel streaming.