### PR TITLE
Improve model name matching for NeedsRaw in Ollama plugin

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -24,6 +24,7 @@
 		"compadd",
 		"compdef",
 		"compinit",
+		"conceptmap",
 		"creatordate",
 		"curcontext",
 		"custompatterns",

--- a/cmd/generate_changelog/incoming/1847.txt
+++ b/cmd/generate_changelog/incoming/1847.txt
@@ -1,0 +1,7 @@
+### PR [#1847](https://github.com/danielmiessler/Fabric/pull/1847) by [ksylvan](https://github.com/ksylvan): Improve model name matching for NeedsRaw in Ollama plugin
+
+- Improved model name matching in Ollama plugin by replacing prefix-based matching with substring matching
+- Enhanced NeedsRaw functionality to support more flexible model name detection
+- Renamed `ollamaPrefixes` variable to `ollamaSearchStrings` for better code clarity
+- Replaced `HasPrefix` function with `Contains` for more comprehensive model matching
+- Added "conceptmap" to VSCode dictionary settings

--- a/internal/plugins/ai/ollama/ollama.go
+++ b/internal/plugins/ai/ollama/ollama.go
@@ -163,13 +163,13 @@ func (o *Client) createChatRequest(msgs []*chat.ChatCompletionMessage, opts *dom
 }
 
 func (o *Client) NeedsRawMode(modelName string) bool {
-	ollamaPrefixes := []string{
+	ollamaSearchStrings := []string{
 		"llama3",
 		"llama2",
 		"mistral",
 	}
-	for _, prefix := range ollamaPrefixes {
-		if strings.HasPrefix(modelName, prefix) {
+	for _, searchString := range ollamaSearchStrings {
+		if strings.Contains(modelName, searchString) {
 			return true
 		}
 	}


### PR DESCRIPTION
# Improve model name matching for NeedsRaw in Ollama plugin

## Summary

This PR makes two minor improvements: it adds a word to the VSCode spell-checker dictionary and fixes a model name matching bug in the Ollama AI plugin by changing from prefix-based matching to substring-based matching.

## Related Issues

Closes #1801

## Files Changed

### `.vscode/settings.json`
- Added `"conceptmap"` to the `cSpell.words` dictionary to prevent false-positive spell-check warnings.

### `internal/plugins/ai/ollama/ollama.go`
- Modified the `NeedsRawMode` function to use substring matching instead of prefix matching for model name detection.

## Code Changes

### `.vscode/settings.json`
Added a new word to the spell-checker dictionary:
```json
"conceptmap",
```

### `internal/plugins/ai/ollama/ollama.go`
The core logic change in the `NeedsRawMode` function:

**Before:**
```go
ollamaPrefixes := []string{
    "llama3",
    "llama2", 
    "mistral",
}
for _, prefix := range ollamaPrefixes {
    if strings.HasPrefix(modelName, prefix) {
        return true
    }
}
```

**After:**
```go
ollamaSearchStrings := []string{
    "llama3",
    "llama2",
    "mistral",
}
for _, searchString := range ollamaSearchStrings {
    if strings.Contains(modelName, searchString) {
        return true
    }
}
```

## Reason for Changes

### Spell-checker Dictionary Update
Adding "conceptmap" to the dictionary eliminates unnecessary spell-check warnings for what appears to be a legitimate term used in the codebase.

### Model Name Matching Logic
The original implementation used `strings.HasPrefix()` which only matched model names that started with the specified strings. This approach would fail to identify models with organizational prefixes or other naming conventions. For example:
- ❌ `HasPrefix` would miss: `"vendor/llama3"`, `"custom-mistral-7b"`, `"org/llama2-chat"`
- ✅ `Contains` catches: Any model name with these strings anywhere in the name

The change to `strings.Contains()` provides more flexible matching, ensuring that models with these names in any position will be correctly identified as needing raw mode.

## Impact of Changes

### VSCode Settings
- **Impact**: Minimal - improves developer experience by reducing noise from spell-checker
- **Risk**: None

### Ollama Plugin
- **Impact**: Improves model detection reliability for the `NeedsRawMode` function
- **Benefit**: Models with non-standard naming conventions (prefixed or suffixed) will now be correctly identified
- **Risk**: **Potential false positives** - if a model name coincidentally contains "llama2", "llama3", or "mistral" as a substring but isn't actually one of these model families, it will incorrectly return `true`
  - Example: A hypothetical model named `"anthropic-llamabert3"` would match on "llama3"
  - Example: A model named `"mistral-killer-v2"` would match on "mistral"

## Test Plan

### Manual Testing Recommended:
1. Test with standard model names: `"llama3"`, `"llama2"`, `"mistral"`
2. Test with prefixed model names: `"ollama/llama3"`, `"custom/mistral-7b"`
3. Test with suffixed model names: `"llama3-instruct"`, `"mistral-chat"`
4. Test with models that should NOT match to ensure no false positives

### Unit Test Suggestion:
Consider adding unit tests for the `NeedsRawMode` function with various model name patterns:
```go
testCases := []struct {
    modelName string
    expected  bool
}{
    {"llama3", true},
    {"ollama/llama3", true},
    {"llama3-instruct", true},
    {"gpt-4", false},
    {"claude-3", false},
}
```

## Additional Notes

### Potential Issues to Watch:
1. **False Positives**: The substring matching is more permissive and could match unintended model names. Consider whether this is acceptable or if a more sophisticated matching strategy (e.g., regex patterns or exact model name registry) would be better.

2. **Alternative Approach**: If false positives become an issue, consider:
   - Using regex patterns for more precise matching
   - Maintaining a whitelist of exact model names
   - Adding namespace/vendor prefixes to the search strings (e.g., `"ollama/llama3"`)

3. **Documentation**: It may be helpful to document which model naming conventions are expected to trigger raw mode, especially if users are configuring custom model names.

The variable renaming from `ollamaPrefixes` to `ollamaSearchStrings` appropriately reflects the changed behavior and improves code readability.
