### PR TITLE
 fix: allow resetting required settings without validation errors

### DIFF
--- a/cmd/generate_changelog/incoming/1860.txt
+++ b/cmd/generate_changelog/incoming/1860.txt
@@ -1,0 +1,7 @@
+### PR [#1860](https://github.com/danielmiessler/Fabric/pull/1860) by [ksylvan](https://github.com/ksylvan): fix: allow resetting required settings without validation errors
+
+- Fix: allow resetting required settings without validation errors
+- Update `Ask` to detect reset command and bypass validation
+- Refactor `OnAnswer` to support new `isReset` parameter logic
+- Invoke `ConfigureCustom` in `Setup` to avoid redundant re-validation
+- Add unit tests ensuring required fields can be reset


### PR DESCRIPTION
#  fix: allow resetting required settings without validation errors

## Summary

This PR refactors the plugin setup flow to properly handle the "reset" command for required configuration fields. The changes introduce a distinction between explicit value resets and missing required values, allowing users to intentionally clear configuration values without triggering validation errors during the interactive setup process.

## Related Issues

Close #1858

## Files Changed

### `internal/plugins/plugin.go`
- Modified the `Setup()` method to call `ConfigureCustom` instead of `Configure` after setup questions
- Enhanced `Ask()` method to track whether a user explicitly requested a reset
- Refactored `OnAnswer()` method to delegate to a new `OnAnswerWithReset()` method
- Added new `OnAnswerWithReset()` method that conditionally skips validation when a value is explicitly reset

### `internal/plugins/plugin_test.go`
- Added `TestSetupQuestion_Ask_Reset()` to verify that resetting a required field doesn't produce errors
- Added comprehensive `TestSetupQuestion_OnAnswerWithReset()` with multiple test cases covering reset scenarios, empty answers, and valid answers on required fields

## Code Changes

### Plugin Setup Flow (`plugin.go`)

**Modified Setup() to use ConfigureCustom:**
```go
// After Setup, run ConfigureCustom if present, but skip re-validation
// since Ask() already validated user input (or allowed explicit reset)
if o.ConfigureCustom != nil {
    err = o.ConfigureCustom()
}
```
This change calls `ConfigureCustom` instead of `Configure`, avoiding redundant validation after the user has already answered setup questions.

**Enhanced Ask() to track reset intent:**
```go
isReset := strings.ToLower(answer) == AnswerReset
// ...
err = o.OnAnswerWithReset(answer, isReset)
```
The method now captures whether the user explicitly typed "reset" and passes this context downstream.

**New OnAnswerWithReset() method:**
```go
func (o *SetupQuestion) OnAnswerWithReset(answer string, isReset bool) (err error) {
    // ... existing validation logic ...
    
    // Skip validation when explicitly resetting a value - the user intentionally
    // wants to clear the value even if it's required
    if isReset {
        return nil
    }
    err = o.IsValidErr()
    return
}
```
This new method allows validation to be bypassed when a value is explicitly reset, while maintaining validation for all other cases.

### Test Coverage (`plugin_test.go`)

Added comprehensive test coverage for the reset functionality:
- Tests that resetting a required field doesn't trigger validation errors
- Tests that empty answers (non-reset) on required fields still trigger validation errors
- Tests that valid answers continue to work as expected

## Reason for Changes

The previous implementation treated the "reset" command the same as an empty answer, causing validation errors when users tried to clear required configuration fields. This created a poor user experience where users couldn't reset values during interactive setup without encountering errors.

The changes address this by:
1. **Distinguishing intent**: Differentiating between "user wants to reset" vs "user provided no value"
2. **Skipping validation on explicit resets**: Allowing users to intentionally clear values without validation errors
3. **Maintaining validation for other cases**: Preserving the existing validation behavior for non-reset scenarios

## Impact of Changes

**Positive Impacts:**
- Improved UX: Users can now successfully reset required configuration values during interactive setup
- Clearer code semantics: The distinction between reset and empty answers is now explicit in the code
- Better separation of concerns: `ConfigureCustom` is called after setup instead of `Configure`, avoiding redundant validation

**Potential Issues to Watch:**
1. **State consistency**: If `ConfigureCustom` implementations rely on validation having already occurred, they should continue to work since `Ask()` performs validation (except on explicit resets)
2. **Plugin compatibility**: Plugins that override `OnAnswer()` will continue to work, but won't benefit from the reset-without-validation behavior unless they adopt `OnAnswerWithReset()`
3. **Empty vs reset semantics**: Downstream code that checks for empty values should be aware that empty values can now exist on required fields if explicitly reset

## Test Plan

The changes include comprehensive unit tests:
- `TestSetupQuestion_Ask_Reset()`: Verifies that typing "reset" on a required field clears the value without error
- `TestSetupQuestion_OnAnswerWithReset()`: Tests multiple scenarios including explicit resets, empty answers, and valid answers on required fields

**Manual Testing Recommendations:**
1. Run interactive setup for a plugin with required fields
2. Enter "reset" for a required field that has an existing value
3. Verify no validation error occurs and the value is cleared
4. Test that pressing Enter without typing anything on a required empty field still produces a validation error

## Additional Notes

- The change maintains backward compatibility by keeping the original `OnAnswer()` method as a wrapper that calls `OnAnswerWithReset()` with `isReset=false`
- The comment in `Setup()` explains why `ConfigureCustom` is called instead of `Configure`, helping future maintainers understand the design decision
- The validation skip logic includes a clear comment explaining that reset is an intentional user action, not an oversight
