### PR TITLE
modernize Go code with TypeFor and range loops

### DIFF
--- a/cmd/generate_changelog/incoming/1876.txt
+++ b/cmd/generate_changelog/incoming/1876.txt
@@ -1,0 +1,7 @@
+### PR [#1876](https://github.com/danielmiessler/Fabric/pull/1876) by [ksylvan](https://github.com/ksylvan): modernize Go code with TypeFor and range loops
+
+- Replace reflect.TypeOf with TypeFor generic syntax for improved type handling
+- Convert traditional for loops to range-based iterations for better code readability
+- Simplify reflection usage in CLI flag handling to reduce complexity
+- Update test loops to use range over integers for cleaner test code
+- Refactor string processing loops in template plugin to use modern Go patterns

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -115,7 +115,7 @@ func Init() (ret *Flags, err error) {
 
 	// Create mapping from flag names (both short and long) to yaml tag names
 	flagToYamlTag := make(map[string]string)
-	t := reflect.TypeOf(Flags{})
+	t := reflect.TypeFor[Flags]()
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 		yamlTag := field.Tag.Get("yaml")
@@ -224,7 +224,7 @@ func Init() (ret *Flags, err error) {
 }
 
 func parseDebugLevel(args []string) int {
-	for i := 0; i < len(args); i++ {
+	for i := range args {
 		arg := args[i]
 		if arg == "--debug" && i+1 < len(args) {
 			if lvl, err := strconv.Atoi(args[i+1]); err == nil {

--- a/internal/cli/help.go
+++ b/internal/cli/help.go
@@ -137,8 +137,7 @@ func (h *TranslatedHelpWriter) getTranslatedDescription(flagName string) string 
 
 // getOriginalDescription retrieves the original description from struct tags
 func (h *TranslatedHelpWriter) getOriginalDescription(flagName string) string {
-	flags := &Flags{}
-	flagsType := reflect.TypeOf(flags).Elem()
+	flagsType := reflect.TypeFor[Flags]()
 
 	for i := 0; i < flagsType.NumField(); i++ {
 		field := flagsType.Field(i)
@@ -218,8 +217,7 @@ func detectLanguageFromEnv() string {
 // writeAllFlags writes all flags with translated descriptions
 func (h *TranslatedHelpWriter) writeAllFlags() {
 	// Use direct reflection on the Flags struct to get all flag definitions
-	flags := &Flags{}
-	flagsType := reflect.TypeOf(flags).Elem()
+	flagsType := reflect.TypeFor[Flags]()
 
 	for i := 0; i < flagsType.NumField(); i++ {
 		field := flagsType.Field(i)

--- a/internal/plugins/ai/openai/openai_test.go
+++ b/internal/plugins/ai/openai/openai_test.go
@@ -16,7 +16,7 @@ func TestBuildResponseRequestWithMaxTokens(t *testing.T) {
 
 	var msgs []*chat.ChatCompletionMessage
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		msgs = append(msgs, &chat.ChatCompletionMessage{
 			Role:    "User",
 			Content: "My msg",
@@ -42,7 +42,7 @@ func TestBuildResponseRequestNoMaxTokens(t *testing.T) {
 
 	var msgs []*chat.ChatCompletionMessage
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		msgs = append(msgs, &chat.ChatCompletionMessage{
 			Role:    "User",
 			Content: "My msg",

--- a/internal/plugins/template/text.go
+++ b/internal/plugins/template/text.go
@@ -16,7 +16,7 @@ func toTitle(s string) string {
 	lower := strings.ToLower(s)
 	runes := []rune(lower)
 
-	for i := 0; i < len(runes); i++ {
+	for i := range runes {
 		// Capitalize if previous char is non-letter AND
 		// (we're at the end OR next char is not space)
 		if i == 0 || !unicode.IsLetter(runes[i-1]) {


### PR DESCRIPTION
# modernize Go code with TypeFor and range loops

## Summary

This PR introduces minor code quality improvements by adopting modern Go idioms and syntax. The changes replace older reflection patterns with the newer `reflect.TypeFor` generic function and simplify loop iterations where the index variable is unused.

This is part 3 of incorporating `modernize` into Fabric.

## Related Issues

See #1873 for the bigger context.

## Files Changed

### `internal/cli/flags.go`
- **Line 118**: Replaced `reflect.TypeOf(Flags{})` with `reflect.TypeFor[Flags]()`
- **Line 227**: Simplified loop from `for i := 0; i < len(args); i++` to `for i := range args`

### `internal/cli/help.go`
- **Lines 140-141**: Replaced pointer creation and `reflect.TypeOf(flags).Elem()` with `reflect.TypeFor[Flags]()`
- **Lines 220-221**: Same reflection pattern update as above

### `internal/plugins/ai/openai/openai_test.go`
- **Line 19**: Changed `for i := 0; i < 2; i++` to `for range 2` (index unused)
- **Line 45**: Same loop simplification as above

### `internal/plugins/template/text.go`
- **Line 19**: Simplified loop from `for i := 0; i < len(runes); i++` to `for i := range runes`

## Code Changes

#### Reflection API Modernization

**Before:**
```go
t := reflect.TypeOf(Flags{})
```

**After:**
```go
t := reflect.TypeFor[Flags]()
```

**Before:**
```go
flags := &Flags{}
flagsType := reflect.TypeOf(flags).Elem()
```

**After:**
```go
flagsType := reflect.TypeFor[Flags]()
```

#### Loop Simplification

**Before:**
```go
for i := 0; i < len(args); i++ {
    arg := args[i]
    // ...
}
```

**After:**
```go
for i := range args {
    arg := args[i]
    // ...
}
```

**Before:**
```go
for i := 0; i < 2; i++ {
    // loop body doesn't use i
}
```

**After:**
```go
for range 2 {
    // cleaner when index is unused
}
```

## Reason for Changes

These changes modernize the codebase to use Go 1.22+ idioms:

1. **`reflect.TypeFor`**: This generic function (introduced in Go 1.22) is the preferred way to obtain type information. It's more type-safe and eliminates the need to instantiate structs or use `.Elem()` on pointer types.

2. **Range-over-integer**: The `for range N` syntax (Go 1.22+) clearly expresses intent when a loop counter isn't needed.

3. **Simplified range**: Using `for i := range slice` instead of `for i := 0; i < len(slice); i++` is more idiomatic and slightly more efficient (avoids bounds checking).

## Impact of Changes

**Positive impacts:**
- Improved code readability and maintainability
- Adopts modern Go best practices
- Slightly better performance due to eliminated allocations (no temporary `Flags{}` structs)
- More type-safe reflection code

**Potential concerns:**
- **Go version requirement**: These changes require Go 1.22 or later. If the project supports earlier Go versions, this will break compatibility.
- No functional changes to behavior—all changes are refactoring only

## Test Plan

The changes are purely refactoring with no behavioral modifications:

1. Existing unit tests should pass without modification (verified in `openai_test.go`)
2. The reflection changes maintain identical runtime behavior—the same type information is obtained
3. Loop simplifications preserve exact iteration semantics

**Recommended testing:**
```bash
go test ./...
```

Verify that all existing tests pass, particularly:
- Flag parsing and initialization tests
- Help text generation tests
- Template processing tests

## Additional Notes

- These changes assume the project has migrated to Go 1.22 or later
- No breaking changes to public APIs
- This is consistent with a broader codebase modernization effort
- All changes follow official Go style guidelines and recommendations from the Go team
