### PR TITLE
Bundle yt-dlp with fabric in Nix flake, introduce slim variant

### DIFF
--- a/cmd/generate_changelog/incoming/1890.txt
+++ b/cmd/generate_changelog/incoming/1890.txt
@@ -1,0 +1,7 @@
+### PR [#1890](https://github.com/danielmiessler/Fabric/pull/1890) by [ksylvan](https://github.com/ksylvan): Bundle yt-dlp with fabric in Nix flake, introduce slim variant
+
+- Added yt-dlp bundling with fabric package and introduced fabric-slim variant
+- Renamed original fabric package to fabricSlim and created new fabric package as symlinkJoin of fabricSlim and yt-dlp
+- Added fabric-slim output for the slim variant and updated default package to point to bundled fabric
+- Enhanced fabric meta description to note yt-dlp inclusion and set mainProgram to fabric in bundled package
+- Added wrapper for fabric binary to include PATH in execution environment


### PR DESCRIPTION
# Bundle yt-dlp with fabric in Nix flake, introduce slim variant

## Summary

This pull request updates the Nix flake configuration to bundle `yt-dlp` with the `fabric` package by default. It introduces a new `fabric-slim` variant for users who wish to provide their own dependencies, while the standard `fabric` package now ensures `yt-dlp` is available in its execution environment via a wrapper.

## Related issues

Closes #1862 

## Screenshots

<img width="881" height="325" alt="image" src="https://github.com/user-attachments/assets/8224b107-e24e-4602-845b-a4b8c4dd9702" />

## Files Changed

- **cmd/generate_changelog/incoming/1890.txt**: Added a new changelog entry describing the bundling of `yt-dlp` and the introduction of the slim variant.
- **flake.nix**: Refactored the package definitions to create a base `fabricSlim` package and a bundled `fabric` package using `symlinkJoin`.

## Code Changes

### flake.nix

The core logic was updated to split the package into two variants. The original build logic is now assigned to `fabricSlim`:

```nix
          fabricSlim = pkgs.callPackage ./nix/pkgs/fabric {
            go = goVersion;
            inherit self;
            inherit (gomod2nix.legacyPackages.${system}) buildGoApplication;
          };
```

A new `fabric` package is created by joining `fabricSlim` and `yt-dlp`, and then wrapping the binary to ensure `yt-dlp` is in the `PATH`:

```nix
          fabric = pkgs.symlinkJoin {
            name = "fabric-${fabricSlim.version}";
            inherit (fabricSlim) version;
            paths = [
              fabricSlim
              pkgs.yt-dlp
            ];
            nativeBuildInputs = [ pkgs.makeWrapper ];
            postBuild = ''
              wrapProgram $out/bin/fabric \
                --prefix PATH : $out/bin
            '';
            meta = fabricSlim.meta // {
              description = "${fabricSlim.meta.description} (includes yt-dlp)";
              mainProgram = "fabric";
            };
          };
```

The flake outputs were updated to export both versions:

```nix
        {
          default = fabric;
          inherit fabric;
          "fabric-slim" = fabricSlim;
          inherit (gomod2nix.legacyPackages.${system}) gomod2nix;
        }
```

## Reason for Changes

Fabric utilizes `yt-dlp` for features involving YouTube content processing. Previously, Nix users had to install `yt-dlp` separately and ensure it was in their environment's `PATH`. By bundling it using `symlinkJoin` and `wrapProgram`, we provide a "batteries-included" experience that works out of the box, while still offering the `fabric-slim` version for users who prefer a minimal installation or manage their own dependencies.

## Impact of Changes

- **User Experience**: Users installing the default `fabric` package via Nix will now automatically have `yt-dlp` available to the application.
- **Package Size**: The default package size will increase as it now includes `yt-dlp` and its dependencies.
- **Flexibility**: Users who require a minimal footprint can switch to the `fabric-slim` output.
- **Maintainability**: The use of `symlinkJoin` keeps the Go build logic separate from the environment wrapping logic.

## Test Plan

1. **Verify Default Build**: Run `nix build .#fabric` (or just `nix build`) and verify that the resulting `fabric` binary can successfully locate and execute `yt-dlp`.
2. **Verify Slim Build**: Run `nix build .#fabric-slim` and verify that `yt-dlp` is not included in the resulting store path.
3. **Path Check**: Inspect the wrapper script in `result/bin/fabric` to ensure the `PATH` is correctly prefixed with the bundled `yt-dlp` location.

```text
$ nix run .#fabric -- -y https://youtube.com/watch?v=dQw4w9WgXcQ -p summarize

## ONE SENTENCE SUMMARY:
A narrator professes enduring love and commitment, promising loyalty, honesty, and never abandoning a long-known partner.

## MAIN POINTS:
1. The speaker insists both people understand love’s “rules” and expectations.
2. A deep commitment is expressed as something uniquely offered by the narrator.
3. The narrator wants their feelings clearly understood by the partner.
4. Repeated vows emphasize never giving up on the relationship.
5. Assurance is given against letting the partner down.
6. The speaker rejects the idea of deserting or running around.
7. Promises include not making the partner cry or say goodbye.
8. Honesty is stressed through refusing to tell lies or intentionally hurt.
9. Their long shared history is highlighted as the foundation of trust.
10. The partner’s unspoken pain and shyness are acknowledged as already understood.

## TAKEAWAYS:
1. Loyalty is portrayed as the central proof of love.
2. Clear communication of emotions is framed as necessary for reassurance.
3. Long-term relationships rely on mutual awareness of each other’s feelings.
4. Consistency and repetition reinforce sincerity in commitments.
5. Honesty and avoiding harm are presented as non-negotiable relationship standards.
```

And. running the slim package:

```text
$  nix run .#fabric-slim -- -y https://youtube.com/watch?v=dQw4w9WgXcQ -p summarize
yt-dlp not found in PATH. Please install yt-dlp to use YouTube transcript functionality
```

## Additional Notes

The `mainProgram` meta attribute was explicitly set on the bundled package to ensure compatibility with `nix run`. This change follows standard Nixpkgs patterns for wrapping binaries with runtime dependencies.

