### PR TITLE
fix: resolve WebUI tooltips not rendering due to overflow clipping

### DIFF
--- a/cmd/generate_changelog/incoming/1904.txt
+++ b/cmd/generate_changelog/incoming/1904.txt
@@ -1,0 +1,7 @@
+### PR [#1904](https://github.com/danielmiessler/Fabric/pull/1904) by [majiayu000](https://github.com/majiayu000): fix: resolve WebUI tooltips not rendering due to overflow clipping
+
+- Fix: resolve WebUI tooltips not rendering due to overflow clipping by using position: fixed and getBoundingClientRect() to calculate tooltip position dynamically, preventing tooltips from being clipped by parent containers with overflow: hidden
+- Refactor: extract tooltip positioning logic into separate positioning.ts module for better code organization and maintainability
+- Improve accessibility with aria-describedby attributes and unique IDs for better screen reader support
+- Add reactive tooltip position updates on scroll and resize events for dynamic positioning
+- Add SSR safety with isBrowser flag check and comprehensive unit test coverage for the positioning functions

--- a/web/src/lib/components/ui/tooltip/Tooltip.test.ts
+++ b/web/src/lib/components/ui/tooltip/Tooltip.test.ts
@@ -1,67 +1,56 @@
-import { describe, it, expect } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import { calculateTooltipPosition, formatPositionStyle, TOOLTIP_GAP } from './positioning';
 
 describe('Tooltip positioning logic', () => {
-  const gap = 8;
-
-  function calculatePosition(
-    rect: { top: number; bottom: number; left: number; right: number; width: number; height: number },
-    position: 'top' | 'bottom' | 'left' | 'right'
-  ) {
-    let top = 0;
-    let left = 0;
-
-    switch (position) {
-      case 'top':
-        top = rect.top - gap;
-        left = rect.left + rect.width / 2;
-        break;
-      case 'bottom':
-        top = rect.bottom + gap;
-        left = rect.left + rect.width / 2;
-        break;
-      case 'left':
-        top = rect.top + rect.height / 2;
-        left = rect.left - gap;
-        break;
-      case 'right':
-        top = rect.top + rect.height / 2;
-        left = rect.right + gap;
-        break;
-    }
-
-    return { top, left };
-  }
-
   const mockRect = {
     top: 100,
     bottom: 130,
     left: 200,
     right: 300,
     width: 100,
-    height: 30
-  };
+    height: 30,
+    x: 200,
+    y: 100,
+    toJSON: () => ({})
+  } as DOMRect;
 
   it('calculates top position correctly', () => {
-    const result = calculatePosition(mockRect, 'top');
+    const result = calculateTooltipPosition(mockRect, 'top');
     expect(result.top).toBe(92); // 100 - 8
     expect(result.left).toBe(250); // 200 + 100/2
   });
 
   it('calculates bottom position correctly', () => {
-    const result = calculatePosition(mockRect, 'bottom');
+    const result = calculateTooltipPosition(mockRect, 'bottom');
     expect(result.top).toBe(138); // 130 + 8
     expect(result.left).toBe(250); // 200 + 100/2
   });
 
   it('calculates left position correctly', () => {
-    const result = calculatePosition(mockRect, 'left');
+    const result = calculateTooltipPosition(mockRect, 'left');
     expect(result.top).toBe(115); // 100 + 30/2
     expect(result.left).toBe(192); // 200 - 8
   });
 
   it('calculates right position correctly', () => {
-    const result = calculatePosition(mockRect, 'right');
+    const result = calculateTooltipPosition(mockRect, 'right');
     expect(result.top).toBe(115); // 100 + 30/2
     expect(result.left).toBe(308); // 300 + 8
+  });
+
+  it('uses the correct gap value', () => {
+    expect(TOOLTIP_GAP).toBe(8);
+  });
+
+  it('formats position style correctly', () => {
+    const position = { top: 100, left: 200 };
+    const style = formatPositionStyle(position);
+    expect(style).toBe('top: 100px; left: 200px;');
+  });
+
+  it('respects custom gap parameter', () => {
+    const customGap = 16;
+    const result = calculateTooltipPosition(mockRect, 'top', customGap);
+    expect(result.top).toBe(84); // 100 - 16
   });
 });

--- a/web/src/lib/components/ui/tooltip/positioning.ts
+++ b/web/src/lib/components/ui/tooltip/positioning.ts
@@ -1,0 +1,27 @@
+export const TOOLTIP_GAP = 8;
+
+export type TooltipPosition = 'top' | 'bottom' | 'left' | 'right';
+
+export interface Position {
+  top: number;
+  left: number;
+}
+
+export function calculateTooltipPosition(
+  rect: DOMRect,
+  position: TooltipPosition,
+  gap: number = TOOLTIP_GAP
+): Position {
+  const positions: Record<TooltipPosition, Position> = {
+    top: { top: rect.top - gap, left: rect.left + rect.width / 2 },
+    bottom: { top: rect.bottom + gap, left: rect.left + rect.width / 2 },
+    left: { top: rect.top + rect.height / 2, left: rect.left - gap },
+    right: { top: rect.top + rect.height / 2, left: rect.right + gap }
+  };
+
+  return positions[position];
+}
+
+export function formatPositionStyle(position: Position): string {
+  return `top: ${position.top}px; left: ${position.left}px;`;
+}


### PR DESCRIPTION
## What this Pull Request (PR) does

Fixes tooltip visibility issue in WebUI Model Controls by using `position: fixed` positioning instead of `position: absolute`.

**Problem**: Tooltips were being clipped by parent containers with `overflow: hidden` (caused by Svelte slide transitions).

**Solution**: Calculate tooltip position using `getBoundingClientRect()` and apply fixed positioning to escape overflow constraints.

## Related issues

Closes #1790

## Screenshots

The tooltip now correctly renders above the parent container boundaries.