### PR TITLE
fix: add all positional arguments to message

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -213,7 +213,9 @@ func Init() (ret *Flags, err error) {
 
 	// Append positional arguments to the message (custom message)
 	if len(args) > 0 {
-		ret.Message = AppendMessage(ret.Message, args[len(args)-1])
+		argMessage := strings.TrimSpace(strings.Join(args, " "))
+		ret.Message = AppendMessage(ret.Message, argMessage)
+
 	}
 
 	if pipedToStdin {


### PR DESCRIPTION
## What this Pull Request (PR) does

This PR changes behvior of fabric cli to include all positional arguments to the message (prompt).

E.g. 

```
fabric -p <my-pattern> How do I use fabric to list available models
```

now correctly appends full sentence to the message prompt rather than the last positional argument. 

## Related issues

closes #1958.