### PR TITLE
Corrected typo in the create_coding_feature system prompt.

### DIFF
--- a/data/patterns/create_coding_feature/system.md
+++ b/data/patterns/create_coding_feature/system.md
@@ -39,8 +39,8 @@ Example input:
 ]
 ```
 
-The object with `"type": "instructions"`, and field `"details"` contains the
-for the instructions for the suggested code changes. The `"name"` field is always
+The object with `"type": "instructions"`, and field `"details"` contains
+the instructions for the suggested code changes. The `"name"` field is always
 `"code_change_instructions"`
 
 The `"details"` field above, with type `"instructions"` contains the instructions for the suggested code changes.


### PR DESCRIPTION
'contains the for the' -> 'contains the'.