### PR TITLE
Web UI: Fix streaming chat: tokens now accumulate in order into a single message

### DIFF
--- a/cmd/generate_changelog/incoming/2029.txt
+++ b/cmd/generate_changelog/incoming/2029.txt
@@ -1,0 +1,6 @@
+### PR [#2029](https://github.com/danielmiessler/Fabric/pull/2029) by [ksylvan](https://github.com/ksylvan): Web UI: Fix streaming chat: tokens now accumulate in order into a single message
+
+- Feat: improve streaming message handling and SSE buffer parsing
+- Append content to existing assistant messages instead of replacing, and fix loading message removal to search by index rather than position
+- Refactor SSE buffer splitting to always retain incomplete segments, and trim segments before parsing to handle whitespace edge cases
+- Consolidate duplicate message update logic across chat components and process remaining buffer after stream completion more reliably

--- a/web/src/lib/components/chat/ChatInput.svelte
+++ b/web/src/lib/components/chat/ChatInput.svelte
@@ -329,15 +329,22 @@ async function readFileContent(file: File): Promise<string> {
                   messageStore.update(messages => {
                       const newMessages = [...messages];
                       // Replace the processing message with actual content
-                      const lastMessage = newMessages[newMessages.length - 1];
-                      if (lastMessage?.format === 'loading') {
-                          newMessages.pop();
+                      const loadingIndex = newMessages.findIndex(m => m.format === 'loading');
+                      if (loadingIndex !== -1) {
+                          newMessages.splice(loadingIndex, 1);
                       }
-                      newMessages.push({
-                          role: 'assistant',
-                          content,
-                          format: response?.format
-                      });
+
+                      const lastMessage = newMessages[newMessages.length - 1];
+                      if (lastMessage?.role === 'assistant') {
+                          lastMessage.content += content;
+                          lastMessage.format = response?.format;
+                      } else {
+                          newMessages.push({
+                              role: 'assistant',
+                              content,
+                              format: response?.format
+                          });
+                      }
                       return newMessages;
                   });
               },
@@ -442,13 +449,18 @@ async function readFileContent(file: File): Promise<string> {
             if (loadingIndex !== -1) {
               newMessages.splice(loadingIndex, 1);
             }
-            
-            // Always append a new assistant message
-            newMessages.push({
-              role: 'assistant',
-              content,
-              format: response?.format
-            });
+
+            const lastMessage = newMessages[newMessages.length - 1];
+            if (lastMessage?.role === 'assistant') {
+              lastMessage.content += content;
+              lastMessage.format = response?.format;
+            } else {
+              newMessages.push({
+                role: 'assistant',
+                content,
+                format: response?.format
+              });
+            }
             return newMessages;
           });
         },

--- a/web/src/lib/store/chat-store.ts
+++ b/web/src/lib/store/chat-store.ts
@@ -132,7 +132,7 @@ export async function sendMessage(
 						const lastMessage = newMessages[newMessages.length - 1];
 
 						if (lastMessage?.role === "assistant") {
-							lastMessage.content = content;
+							lastMessage.content += content;
 							lastMessage.format = response?.format;
 							console.log("Message updated:", {
 								role: "assistant",


### PR DESCRIPTION
# Web UI: Fix streaming chat: tokens now accumulate in order into a single message

Closes #2028 

## Summary

Fixes broken streaming chat where each LLM token rendered as a separate "AI" message bubble with garbled, out-of-order text. Two independent bugs were identified and fixed.

## Problem

When sending a chat message through the web UI, the response was completely unusable:
- Each token appeared as its own "AI" message (150-200 bubbles per response)
- Tokens were out of order, producing garbled text like: "The of Earth's atmosphere. is made colors wavelengths..."

## Root Causes and Fixes

**1. SSE parser dropped and reordered tokens** (`ChatService.ts`)

The `createMessageStream` SSE parser used `split("\n\n")` then `filter(startsWith("data: "))` then `pop()`. The `filter` removed empty strings from trailing `\n\n` delimiters *before* `pop()`, so `pop()` grabbed a complete data message as the "incomplete buffer" instead of the actual trailing segment. This held back tokens and mixed them with subsequent chunks.

Verified with a counting test: old parser produced 6 of 20 tokens as `"1 6 8 "`, fixed parser produces all 20 as `"1 2 3 4 5 6 7 8 9 10"`.

**Fix:** Changed to `split → pop → iterate` — pop the raw last segment first (the actual potentially-incomplete piece), then iterate remaining segments with inline filtering.

**2. Stream callbacks created a new message per token** (`ChatInput.svelte`)

`handleSubmit()` has its own stream processing that bypasses `sendMessage()` in `chat-store.ts`. The callback unconditionally pushed a new assistant message object for every incoming token instead of checking if the last message was already an assistant message and appending to it.

**Fix:** Check if the last message is an assistant message; if so, append the token (`+=`). Otherwise create a new message. Applied to both the main chat flow and the YouTube transcript flow.

**3. Delta handling in `chat-store.ts`** (secondary)

`sendMessage()` used `lastMessage.content = content` (replace) instead of `+= content` (append) for token deltas. While this code path isn't reached from the current UI submit flow, it was corrected for consistency.

## Files Changed

| File | Change |
|------|--------|
| `web/src/lib/services/ChatService.ts` | Fixed SSE parser: `split → pop → iterate` instead of `split → filter → pop` |
| `web/src/lib/components/chat/ChatInput.svelte` | Fixed both chat and YouTube stream callbacks to accumulate tokens into single message |
| `web/src/lib/store/chat-store.ts` | Changed `=` to `+=` for delta token accumulation |

## Testing

- Verified backend sends tokens in correct order via direct `curl` to `/chat` endpoint
- Programmatic SSE parser test: all 20 tokens received in correct order
- End-to-end browser test: single coherent AI message bubble with properly ordered text
- DOM inspection confirms 2 messages (1 user, 1 assistant) instead of 177
