### PR TITLE
fix: propagate caller context in Ollama SendStream and ListModels

### DIFF
--- a/internal/plugins/ai/ollama/ollama.go
+++ b/internal/plugins/ai/ollama/ollama.go
@@ -90,8 +90,7 @@ func (o *Client) configure() (err error) {
 	return
 }
 
-func (o *Client) ListModels(_ context.Context) (ret []string, err error) {
-	ctx := context.Background()
+func (o *Client) ListModels(ctx context.Context) (ret []string, err error) {
 
 	var listResp *ollamaapi.ListResponse
 	if listResp, err = o.client.List(ctx); err != nil {
@@ -104,8 +103,7 @@ func (o *Client) ListModels(_ context.Context) (ret []string, err error) {
 	return
 }
 
-func (o *Client) SendStream(_ context.Context, msgs []*chat.ChatCompletionMessage, opts *domain.ChatOptions, channel chan domain.StreamUpdate) (err error) {
-	ctx := context.Background()
+func (o *Client) SendStream(ctx context.Context, msgs []*chat.ChatCompletionMessage, opts *domain.ChatOptions, channel chan domain.StreamUpdate) (err error) {
 
 	var req ollamaapi.ChatRequest
 	if req, err = o.createChatRequest(ctx, msgs, opts); err != nil {


### PR DESCRIPTION
## What this Pull Request (PR) does

Fixes #2083

`SendStream()` and `ListModels()` in the Ollama plugin were ignoring the caller's `context.Context` (parameter named `_`) and creating a fresh `context.Background()` instead. This meant HTTP requests to a remote Ollama server had no deadline or cancellation — if the server hangs or the connection resets (ECONNRESET), the goroutine blocks forever.

The fix uses the caller's context directly. `Send()` at line 142 already does this correctly, and the OpenAI plugin's `SendStream()` does too, so this just makes the Ollama plugin consistent.

4-line change: 2 parameter renames (`_ context.Context` → `ctx context.Context`) and 2 removed `ctx := context.Background()` lines.

## Related issues

Closes #2083

## Screenshots

N/A — no UI changes.