### PR TITLE
Update Dockerfile for best practices and critical CVE fixes

### DIFF
--- a/cmd/generate_changelog/incoming/2091.txt
+++ b/cmd/generate_changelog/incoming/2091.txt
@@ -1,4 +1,4 @@
-### PR [#2091](https://github.com/danielmiessler/Fabric/pull/2091) by [jimscard](https://github.com/jimscard): Update Dockerfile for best practices and critical CVE fixes
+### PR [#2091](https://github.com/danielmiessler/Fabric/pull/2091) by [jimscard](https://github.com/jimscard) and [ksylvan](https://github.com/ksylvan): Update Dockerfile for best practices and critical CVE fixes
 
 - Pins Alpine 3.21 and Go 1.25.9 explicitly for reproducible, auditable builds.
 - Installs the Go toolchain directly in the builder stage, removing the dependency on an unavailable upstream `golang` tag.

--- a/cmd/generate_changelog/incoming/2091.txt
+++ b/cmd/generate_changelog/incoming/2091.txt
@@ -1,0 +1,7 @@
+### PR [#2091](https://github.com/danielmiessler/Fabric/pull/2091) by [jimscard](https://github.com/jimscard): Update Dockerfile for best practices and critical CVE fixes
+
+- Pins Alpine 3.21 and Go 1.25.9 explicitly for reproducible, auditable builds.
+- Installs the Go toolchain directly in the builder stage, removing the dependency on an unavailable upstream `golang` tag.
+- Upgrades `setuptools` to remediate the critical vulnerability CVE-2025-47273.
+- Refreshes the `yt-dlp` installation path to align with current packaging conventions.
+- Configures the final image to run as a non-root user, reducing the container's attack surface.

--- a/internal/plugins/ai/copilot/copilot.go
+++ b/internal/plugins/ai/copilot/copilot.go
@@ -20,6 +20,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"time"
 
@@ -401,9 +402,7 @@ func (c *Client) parseSSEStream(reader io.Reader, channel chan domain.StreamUpda
 // extractResponseText extracts the assistant's response from messages.
 func (c *Client) extractResponseText(messages []responseMessage) string {
 	// Find the last assistant message (Copilot's response)
-	for i := len(messages) - 1; i >= 0; i-- {
-		msg := messages[i]
-		// Response messages from Copilot have the copilotConversationResponseMessage type
+	for _, msg := range slices.Backward(messages) {
 		if msg.ODataType == "#microsoft.graph.copilotConversationResponseMessage" {
 			if msg.Text != "" {
 				return msg.Text

--- a/internal/plugins/ai/gemini/gemini.go
+++ b/internal/plugins/ai/gemini/gemini.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -290,9 +291,9 @@ func (o *Client) isTTSModel(modelName string) bool {
 
 // extractTextForTTS extracts text content from chat messages for TTS generation
 func (o *Client) extractTextForTTS(msgs []*chat.ChatCompletionMessage) (string, error) {
-	for i := len(msgs) - 1; i >= 0; i-- {
-		if msgs[i].Role == chat.ChatMessageRoleUser && msgs[i].Content != "" {
-			return msgs[i].Content, nil
+	for _, msg := range slices.Backward(msgs) {
+		if msg.Role == chat.ChatMessageRoleUser && msg.Content != "" {
+			return msg.Content, nil
 		}
 	}
 	return "", errors.New(i18n.T("gemini_no_text_for_tts"))

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,11 +1,28 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.25-alpine AS builder
+ARG GO_VERSION=1.25.9
+ARG ALPINE_VERSION=3.21
+
+FROM alpine:${ALPINE_VERSION} AS builder
+
+ARG GO_VERSION
+ARG TARGETARCH
+ENV GOROOT=/usr/local/go
+ENV PATH=${GOROOT}/bin:${PATH}
 
 WORKDIR /src
 
-# Install build dependencies
-RUN apk add --no-cache git
+# Install build dependencies and the pinned Go toolchain.
+RUN apk add --no-cache ca-certificates curl git tar \
+    && case "${TARGETARCH:-$(apk --print-arch)}" in \
+        amd64|x86_64) go_arch='amd64' ;; \
+        arm64|aarch64) go_arch='arm64' ;; \
+        *) echo "Unsupported TARGETARCH: ${TARGETARCH:-$(apk --print-arch)}" >&2; exit 1 ;; \
+    esac \
+    && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" -o /tmp/go.tgz \
+    && rm -rf "${GOROOT}" \
+    && tar -C /usr/local -xzf /tmp/go.tgz \
+    && rm -f /tmp/go.tgz
 
 COPY go.mod go.sum ./
 RUN go mod download
@@ -14,15 +31,22 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o /fabric ./cmd/fabric
 
-FROM alpine:latest
+FROM alpine:${ALPINE_VERSION}
 
 LABEL org.opencontainers.image.description="A Docker image for running the Fabric CLI. See https://github.com/danielmiessler/Fabric/tree/main/scripts/docker for details."
 
-RUN apk add --no-cache ca-certificates yt-dlp \
-    && mkdir -p /root/.config/fabric
+RUN apk add --no-cache ca-certificates python3 py3-pip \
+    && pip3 install --no-cache-dir --break-system-packages 'setuptools>=78.1.1' \
+    && pip3 install --no-cache-dir --break-system-packages 'yt-dlp>=2026.02.21' \
+    && mkdir -p /root/.config/fabric \
+    && apk upgrade --no-cache
 
 COPY --from=builder /fabric /usr/local/bin/fabric
 
 EXPOSE 8080
+
+# Run as non-root user
+RUN adduser -D appuser
+USER appuser
 
 ENTRYPOINT ["fabric"]

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,11 +1,15 @@
 # syntax=docker/dockerfile:1
 
 ARG GO_VERSION=1.25.9
+ARG GO_SHA256_AMD64=00859d7bd6defe8bf84d9db9e57b9a4467b2887c18cd93ae7460e713db774bc1
+ARG GO_SHA256_ARM64=ec342e7389b7f489564ed5463c63b16cf8040023dabc7861256677165a8c0e2b
 ARG ALPINE_VERSION=3.21
 
 FROM alpine:${ALPINE_VERSION} AS builder
 
 ARG GO_VERSION
+ARG GO_SHA256_AMD64
+ARG GO_SHA256_ARM64
 ARG TARGETARCH
 ENV GOROOT=/usr/local/go
 ENV PATH=${GOROOT}/bin:${PATH}
@@ -15,11 +19,12 @@ WORKDIR /src
 # Install build dependencies and the pinned Go toolchain.
 RUN apk add --no-cache ca-certificates curl git tar \
     && case "${TARGETARCH:-$(apk --print-arch)}" in \
-        amd64|x86_64) go_arch='amd64' ;; \
-        arm64|aarch64) go_arch='arm64' ;; \
+        amd64|x86_64) go_arch='amd64'; expected_sha256="${GO_SHA256_AMD64}" ;; \
+        arm64|aarch64) go_arch='arm64'; expected_sha256="${GO_SHA256_ARM64}" ;; \
         *) echo "Unsupported TARGETARCH: ${TARGETARCH:-$(apk --print-arch)}" >&2; exit 1 ;; \
     esac \
     && curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${go_arch}.tar.gz" -o /tmp/go.tgz \
+    && echo "${expected_sha256}  /tmp/go.tgz" | sha256sum -c - \
     && rm -rf "${GOROOT}" \
     && tar -C /usr/local -xzf /tmp/go.tgz \
     && rm -f /tmp/go.tgz
@@ -38,7 +43,6 @@ LABEL org.opencontainers.image.description="A Docker image for running the Fabri
 RUN apk add --no-cache ca-certificates python3 py3-pip \
     && pip3 install --no-cache-dir --break-system-packages 'setuptools>=78.1.1' \
     && pip3 install --no-cache-dir --break-system-packages 'yt-dlp>=2026.02.21' \
-    && mkdir -p /root/.config/fabric \
     && apk upgrade --no-cache
 
 COPY --from=builder /fabric /usr/local/bin/fabric
@@ -46,7 +50,9 @@ COPY --from=builder /fabric /usr/local/bin/fabric
 EXPOSE 8080
 
 # Run as non-root user
-RUN adduser -D appuser
+RUN adduser -D appuser \
+    && mkdir -p /home/appuser/.config/fabric \
+    && chown -R appuser:appuser /home/appuser/.config
 USER appuser
 
 ENTRYPOINT ["fabric"]


### PR DESCRIPTION
## Summary
- update `scripts/docker/Dockerfile` to align the container build with current industry best practices
- pin Alpine 3.21 and Go 1.25.9 explicitly and install Go directly in the builder stage
- fix multiple critical CVEs, including the `setuptools` fix for CVE-2025-47273, and run the final image as a non-root user

## Testing
- docker build -t fabric-pr-check -f scripts/docker/Dockerfile .