### PR TITLE
feat: add --readpattern flag to print pattern contents to terminal

### DIFF
--- a/cmd/generate_changelog/incoming/2093.txt
+++ b/cmd/generate_changelog/incoming/2093.txt
@@ -1,11 +1,4 @@
 ### PR [#2093](https://github.com/danielmiessler/Fabric/pull/2093) by [alecjmckanna](https://github.com/alecjmckanna): feat: add --readpattern flag to print pattern contents to terminal
 
-- Feat: add --readpattern flag to print pattern contents to terminal
-Adds a new `--readpattern <name>` CLI flag that prints the raw contents
-of a named pattern's system.md file to stdout. This makes it easy to
-inspect what instructions a pattern sends to the model without having
-to navigate the filesystem manually.
-The implementation respects custom patterns directories: it checks the
-user's custom patterns directory first before falling back to the main
-patterns directory, consistent with how all other pattern lookups work.
-- Chore: incoming 2093 changelog entry
+- Adds a new `--readpattern <name>` CLI flag that prints the raw contents of a named pattern's `system.md` file to stdout, making it easy to inspect a pattern's instructions without navigating the filesystem manually.
+- Custom pattern directories are respected: the user's custom patterns directory is checked first before falling back to the main patterns directory, consistent with all other pattern lookups.

--- a/cmd/generate_changelog/incoming/2093.txt
+++ b/cmd/generate_changelog/incoming/2093.txt
@@ -1,0 +1,4 @@
+### PR [#2093](https://github.com/danielmiessler/Fabric/pull/2093) by [alecjmckanna](https://github.com/alecjmckanna): feat: add --readpattern flag to print pattern contents to terminal
+
+- Added `--readpattern <name>` CLI flag to print the raw contents of a pattern's system.md file to stdout for easy inspection of pattern instructions
+- Implementation respects custom patterns directories by checking the user's custom patterns directory first before falling back to the main patterns directory

--- a/cmd/generate_changelog/incoming/2093.txt
+++ b/cmd/generate_changelog/incoming/2093.txt
@@ -1,4 +1,11 @@
 ### PR [#2093](https://github.com/danielmiessler/Fabric/pull/2093) by [alecjmckanna](https://github.com/alecjmckanna): feat: add --readpattern flag to print pattern contents to terminal
 
-- Added `--readpattern <name>` CLI flag to print the raw contents of a pattern's system.md file to stdout for easy inspection of pattern instructions
-- Implementation respects custom patterns directories by checking the user's custom patterns directory first before falling back to the main patterns directory
+- Feat: add --readpattern flag to print pattern contents to terminal
+Adds a new `--readpattern <name>` CLI flag that prints the raw contents
+of a named pattern's system.md file to stdout. This makes it easy to
+inspect what instructions a pattern sends to the model without having
+to navigate the filesystem manually.
+The implementation respects custom patterns directories: it checks the
+user's custom patterns directory first before falling back to the main
+patterns directory, consistent with how all other pattern lookups work.
+- Chore: incoming 2093 changelog entry

--- a/completions/_fabric
+++ b/completions/_fabric
@@ -84,6 +84,7 @@ _fabric() {
     '(-r --raw)'{-r,--raw}'[Use the defaults of the model without sending chat options. Only affects OpenAI-compatible providers. Anthropic models always use smart parameter selection to comply with model-specific requirements.]' \
     '(-F --frequencypenalty)'{-F,--frequencypenalty}'[Set frequency penalty (default: 0.0)]:frequency penalty:' \
     '(-l --listpatterns)'{-l,--listpatterns}'[List all patterns]' \
+    '(--readpattern)--readpattern[Print the contents of the named pattern to the terminal]:pattern:_fabric_patterns' \
     '(-L --listmodels)'{-L,--listmodels}'[List all available models]' \
     '(-x --listcontexts)'{-x,--listcontexts}'[List all contexts]' \
     '(-X --listsessions)'{-X,--listsessions}'[List all sessions]' \

--- a/completions/fabric.bash
+++ b/completions/fabric.bash
@@ -17,7 +17,7 @@ _fabric() {
    fi
 
   # Define all possible options/flags
-  local opts="--pattern -p --variable -v --context -C --session --attachment -a --setup -S --temperature -t --topp -T --stream -s --presencepenalty -P --raw -r --frequencypenalty -F --listpatterns -l --listmodels -L --listcontexts -x --listsessions -X --updatepatterns -U --copy -c --model -m --vendor -V --modelContextLength --output -o --output-session --latest -n --changeDefaultModel -d --youtube -y --playlist --transcript --transcript-with-timestamps --visual --visual-sensitivity --visual-fps --comments --metadata --yt-dlp-args --language -g --scrape_url -u --scrape_question -q --seed -e --thinking --wipecontext -w --wipesession -W --printcontext --printsession --readability --input-has-vars --no-variable-replacement --dry-run --serve --serveOllama --address --api-key --config --search --search-location --image-file --image-size --image-quality --image-compression --image-background --suppress-think --think-start-tag --think-end-tag --disable-responses-api --transcribe-file --transcribe-model --split-media-file --voice --list-gemini-voices --notification --notification-command --debug --version --listextensions --addextension --rmextension --strategy --liststrategies --listvendors --shell-complete-list --help -h"
+  local opts="--pattern -p --variable -v --context -C --session --attachment -a --setup -S --temperature -t --topp -T --stream -s --presencepenalty -P --raw -r --frequencypenalty -F --listpatterns -l --readpattern --listmodels -L --listcontexts -x --listsessions -X --updatepatterns -U --copy -c --model -m --vendor -V --modelContextLength --output -o --output-session --latest -n --changeDefaultModel -d --youtube -y --playlist --transcript --transcript-with-timestamps --visual --visual-sensitivity --visual-fps --comments --metadata --yt-dlp-args --language -g --scrape_url -u --scrape_question -q --seed -e --thinking --wipecontext -w --wipesession -W --printcontext --printsession --readability --input-has-vars --no-variable-replacement --dry-run --serve --serveOllama --address --api-key --config --search --search-location --image-file --image-size --image-quality --image-compression --image-background --suppress-think --think-start-tag --think-end-tag --disable-responses-api --transcribe-file --transcribe-model --split-media-file --voice --list-gemini-voices --notification --notification-command --debug --version --listextensions --addextension --rmextension --strategy --liststrategies --listvendors --shell-complete-list --help -h"
 
   # Helper function for dynamic completions
   _fabric_get_list() {
@@ -26,7 +26,7 @@ _fabric() {
 
   # Handle completions based on the previous word
   case "${prev}" in
-  -p | --pattern)
+  -p | --pattern | --readpattern)
     COMPREPLY=($(compgen -W "$(_fabric_get_list --listpatterns)" -- "${cur}"))
     return 0
     ;;

--- a/completions/fabric.fish
+++ b/completions/fabric.fish
@@ -59,6 +59,7 @@ function __fabric_register_completions
 
         # Flag completions with arguments
         complete -c $cmd -s p -l pattern -d "Choose a pattern from the available patterns" -a "(__fabric_get_patterns)"
+        complete -c $cmd -l readpattern -d "Print the contents of the named pattern to the terminal" -a "(__fabric_get_patterns)"
         complete -c $cmd -s v -l variable -d "Values for pattern variables, e.g. -v=#role:expert -v=#points:30"
         complete -c $cmd -s C -l context -d "Choose a context from the available contexts" -a "(__fabric_get_contexts)"
         complete -c $cmd -l session -d "Choose a session from the available sessions" -a "(__fabric_get_sessions)"

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -39,6 +39,7 @@ type Flags struct {
 	Raw                             bool                 `short:"r" long:"raw" yaml:"raw" description:"Use the defaults of the model without sending chat options (temperature, top_p, etc.). Only affects OpenAI-compatible providers. Anthropic models always use smart parameter selection to comply with model-specific requirements."`
 	FrequencyPenalty                float64              `short:"F" long:"frequencypenalty" yaml:"frequencypenalty" description:"Set frequency penalty" default:"0.0"`
 	ListPatterns                    bool                 `short:"l" long:"listpatterns" description:"List all patterns"`
+	ReadPattern                     string               `long:"readpattern" description:"Print the contents of the named pattern to the terminal"`
 	ListAllModels                   bool                 `short:"L" long:"listmodels" description:"List all available models"`
 	ListAllContexts                 bool                 `short:"x" long:"listcontexts" description:"List all contexts"`
 	ListAllSessions                 bool                 `short:"X" long:"listsessions" description:"List all sessions"`

--- a/internal/cli/listing.go
+++ b/internal/cli/listing.go
@@ -29,6 +29,11 @@ func handleListingCommands(currentFlags *Flags, fabricDb *fsdb.Db, registry *cor
 		return true, nil
 	}
 
+	if currentFlags.ReadPattern != "" {
+		err = fabricDb.Patterns.PrintPattern(currentFlags.ReadPattern)
+		return true, err
+	}
+
 	if currentFlags.ListPatterns {
 		// Check if patterns exist before listing
 		var names []string

--- a/internal/plugins/db/fsdb/patterns.go
+++ b/internal/plugins/db/fsdb/patterns.go
@@ -156,6 +156,17 @@ func (o *PatternsEntity) getFromDB(name string) (ret *Pattern, err error) {
 	return
 }
 
+// PrintPattern prints the raw contents of the named pattern to the terminal.
+// It checks the custom patterns directory first, then falls back to the main directory.
+func (o *PatternsEntity) PrintPattern(name string) (err error) {
+	var pattern *Pattern
+	if pattern, err = o.GetRaw(name); err != nil {
+		return
+	}
+	fmt.Print(pattern.Pattern)
+	return
+}
+
 func (o *PatternsEntity) PrintLatestPatterns(latestNumber int) (err error) {
 	var contents []byte
 	if contents, err = os.ReadFile(o.UniquePatternsFilePath); err != nil {

--- a/internal/plugins/db/fsdb/patterns_test.go
+++ b/internal/plugins/db/fsdb/patterns_test.go
@@ -267,6 +267,71 @@ func TestPatternsEntity_CustomPatterns(t *testing.T) {
 	assert.Equal(t, "Custom pattern content", pattern.Pattern)
 }
 
+func TestPrintPattern(t *testing.T) {
+	entity, cleanup := setupTestPatternsEntity(t)
+	defer cleanup()
+
+	createTestPattern(t, entity, "test-pattern", "# IDENTITY\nYou are a test assistant.\n")
+
+	t.Run("prints pattern content to stdout", func(t *testing.T) {
+		// Capture stdout
+		oldStdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		printErr := entity.PrintPattern("test-pattern")
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf [4096]byte
+		n, _ := r.Read(buf[:])
+		output := string(buf[:n])
+
+		require.NoError(t, printErr)
+		assert.Equal(t, "# IDENTITY\nYou are a test assistant.\n", output)
+	})
+
+	t.Run("returns error for non-existent pattern", func(t *testing.T) {
+		err := entity.PrintPattern("nonexistent-pattern")
+		assert.Error(t, err)
+	})
+
+	t.Run("custom pattern directory takes precedence", func(t *testing.T) {
+		customDir, err := os.MkdirTemp("", "test-custom-*")
+		require.NoError(t, err)
+		defer os.RemoveAll(customDir)
+
+		entityWithCustom := &PatternsEntity{
+			StorageEntity:     entity.StorageEntity,
+			SystemPatternFile: entity.SystemPatternFile,
+			CustomPatternsDir: customDir,
+		}
+		createTestPattern(t, &PatternsEntity{
+			StorageEntity:     &StorageEntity{Dir: customDir, Label: "patterns", ItemIsDir: true},
+			SystemPatternFile: "system.md",
+		}, "test-pattern", "# CUSTOM\nCustom version.\n")
+
+		oldStdout := os.Stdout
+		r, w, err := os.Pipe()
+		require.NoError(t, err)
+		os.Stdout = w
+
+		printErr := entityWithCustom.PrintPattern("test-pattern")
+
+		w.Close()
+		os.Stdout = oldStdout
+
+		var buf [4096]byte
+		n, _ := r.Read(buf[:])
+		output := string(buf[:n])
+
+		require.NoError(t, printErr)
+		assert.Equal(t, "# CUSTOM\nCustom version.\n", output)
+	})
+}
+
 func TestPatternsEntity_CustomPatternsEmpty(t *testing.T) {
 	// Test behavior when custom patterns directory is empty or doesn't exist
 	mainDir, err := os.MkdirTemp("", "test-main-patterns-*")


### PR DESCRIPTION
## What this Pull Request (PR) does

Adds a new `--readpattern <name>` CLI flag that prints the raw contents of a named pattern's `system.md` file to stdout.

**Example usage:**
\`\`\`
fabric --readpattern youtube_summary
fabric --readpattern summarize
\`\`\`

Currently, inspecting a pattern's instructions requires navigating to the patterns directory and opening the file manually. This flag makes it convenient to read any pattern directly from the terminal, consistent with how `--listpatterns` works for discovery.

The implementation:
- Checks the user's **custom patterns directory first**, then falls back to the main directory — consistent with all other pattern lookups
- Returns a clear error message if the pattern name is not found (directing the user to `fabric -l`)
- Works cross-platform (Windows, Linux, macOS)
- Adds unit tests covering: stdout output, error on missing pattern, and custom directory precedence

## Related issues

None — this is a new convenience feature.

## Screenshots

```
$ fabric --readpattern summarize
# IDENTITY and PURPOSE

You are an expert content summarizer. You take content in and output a Markdown formatted summary...
```