### PR TITLE
Add Claude Opus 4.7 model support and bump Anthropic SDK to v1.37.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Below are the **new features and capabilities** we've added (newest first):
 
 ### Recent Major Features
 
+- [v1.4.447](https://github.com/danielmiessler/fabric/releases/tag/v1.4.447) (April 16, 2026) — **Claude Opus 4.7**: Updates the Anthropic SDK to v1.37.0 and adds the new [Claude Opus 4.7](https://www.anthropic.com/news/claude-opus-4-7) to the available models, including 1M-token context window support.
 - [v1.4.437](https://github.com/danielmiessler/fabric/releases/tag/v1.4.437) (March 16, 2026) — **OpenAI Codex PLugin**: Fabric now supports using OpenAI Codex (with your OpenAI subscription) as a backend!
 - [v1.4.417](https://github.com/danielmiessler/fabric/releases/tag/v1.4.417) (Feb 21, 2026) — **Azure AI Gateway Plugin**: Added Azure AI Gateway plugin supporting multiple backends (AWS Bedrock, Azure OpenAI, Google Vertex AI) through a unified Azure APIM Gateway with shared subscription key authentication.
 - [v1.4.416](https://github.com/danielmiessler/fabric/releases/tag/v1.4.416) (Feb 21, 2026) — **Azure Entra ID Authentication**: Added Azure Entra ID authentication plugin with shared Azure utilities, Entra ID/MSAL support, and extracted common Azure logic into a reusable `azurecommon` package.

--- a/cmd/generate_changelog/incoming/2097.txt
+++ b/cmd/generate_changelog/incoming/2097.txt
@@ -1,0 +1,7 @@
+### PR [#2097](https://github.com/danielmiessler/Fabric/pull/2097) by [ksylvan](https://github.com/ksylvan): Add Claude Opus 4.7 model support and bump Anthropic SDK to v1.37.0
+
+- Added Claude Opus 4.7 model support and bumped the Anthropic SDK to v1.37.0.
+- Upgraded the `anthropic-sdk-go` dependency from v1.34.0 to v1.37.0.
+- Added `claude-opus-4-7` to the supported models list.
+- Enabled the 1M context window beta feature for Opus 4.7.
+- Updated model beta comments to reflect Opus 4.7 support.

--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.1
 
 require (
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
-	github.com/anthropics/anthropic-sdk-go v1.34.0
+	github.com/anthropics/anthropic-sdk-go v1.37.0
 	github.com/atotto/clipboard v0.1.4
 	github.com/aws/aws-sdk-go-v2 v1.41.5
 	github.com/aws/aws-sdk-go-v2/config v1.32.14

--- a/go.sum
+++ b/go.sum
@@ -43,6 +43,8 @@ github.com/anthropics/anthropic-sdk-go v1.27.1 h1:7DgMZ2Ng3C2mPzJGHA30NXQTZolcF0
 github.com/anthropics/anthropic-sdk-go v1.27.1/go.mod h1:qUKmaW+uuPB64iy1l+4kOSvaLqPXnHTTBKH6RVZ7q5Q=
 github.com/anthropics/anthropic-sdk-go v1.34.0 h1:IV+Wwxkwypit9Md8dr48zc626NS4o9PoQieESoNE0TE=
 github.com/anthropics/anthropic-sdk-go v1.34.0/go.mod h1:dSIO7kSrOI7MA4fE6RRVaw8tyWP7HNQU5/H/KS4cax8=
+github.com/anthropics/anthropic-sdk-go v1.37.0 h1:yBKUaBG3TCRb6das/Q5qNB9Fsafon09gu2yYVgvapKE=
+github.com/anthropics/anthropic-sdk-go v1.37.0/go.mod h1:dSIO7kSrOI7MA4fE6RRVaw8tyWP7HNQU5/H/KS4cax8=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de h1:FxWPpzIjnTlhPwqqXc4/vE0f7GvRjuAsbW+HOIe8KnA=
 github.com/araddon/dateparse v0.0.0-20210429162001-6b43995a97de/go.mod h1:DCaWoUhZrYW9p1lxo/cm8EmUOOzAPSEZNGF2DK1dJgw=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPdPJAN/hZIm0C4OItdklCFmMRWYpio=

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -38,6 +38,7 @@ func NewClient() (ret *Client) {
 	ret.defaultRequiredUserMessage = "Hi"
 	ret.models = []string{
 		// The following are the current supported models
+		string(anthropic.ModelClaudeOpus4_7),
 		string(anthropic.ModelClaudeSonnet4_6),
 		string(anthropic.ModelClaudeOpus4_6),
 		string(anthropic.ModelClaudeOpus4_5_20251101),
@@ -55,7 +56,7 @@ func NewClient() (ret *Client) {
 
 	ret.modelBetas = map[string][]string{
 		// See https://platform.claude.com/docs/en/build-with-claude/context-windows#1-m-token-context-window
-		// Claude Opus 4.6, Sonnet 4.6, Sonnet 4.5, and Sonnet 4 support a 1-million token context window.
+		// Claude Opus 4.7, Opus 4.6, Sonnet 4.6, Sonnet 4.5, and Sonnet 4 support a 1-million token context window.
 
 		// This list can change over time as Anthropic updates their models and beta features, so we maintain it separately from the main model list
 		// for easier updates.
@@ -71,9 +72,10 @@ func NewClient() (ret *Client) {
 		// Claude Sonnet 4.6 (1M context support)
 		string(anthropic.ModelClaudeSonnet4_6): {"context-1m-2025-08-07"},
 
-		// Claude Opus 4.5 and 4.6 variants (1M context support)
+		// Claude Opus 4.5, 4.6, and 4.7 variants (1M context support)
 		string(anthropic.ModelClaudeOpus4_5):          {"context-1m-2025-08-07"},
 		string(anthropic.ModelClaudeOpus4_6):          {"context-1m-2025-08-07"},
+		string(anthropic.ModelClaudeOpus4_7):          {"context-1m-2025-08-07"},
 		string(anthropic.ModelClaudeOpus4_5_20251101): {"context-1m-2025-08-07"},
 	}
 


### PR DESCRIPTION
# Add Claude Opus 4.7 model support and bump Anthropic SDK to v1.37.0

## Summary

Bumps the `anthropic-sdk-go` dependency from `v1.34.0` to `v1.37.0` and registers the newly available **Claude Opus 4.7** model in the Anthropic plugin, including its support for the 1M-token context window beta.

See [Introducing Claude Opus 4.7,](https://www.anthropic.com/news/claude-opus-4-7) published today.

## Files Changed

- **`go.mod`** — Upgraded `github.com/anthropics/anthropic-sdk-go` from `v1.34.0` to `v1.37.0` to pick up the new model constant `ModelClaudeOpus4_7`.
- **`go.sum`** — Added checksum entries for the new SDK version.
- **`internal/plugins/ai/anthropic/anthropic.go`** — Added Claude Opus 4.7 to the supported models list and to the `modelBetas` map for the 1M-token context window. Updated the comment to reflect the expanded model coverage.

## Code Changes

Added the new model to the supported models list:

```go
ret.models = []string{
    // The following are the current supported models
    string(anthropic.ModelClaudeOpus4_7),
    string(anthropic.ModelClaudeSonnet4_6),
    string(anthropic.ModelClaudeOpus4_6),
    ...
}
```

Registered the 1M-token context window beta for Opus 4.7:

```go
// Claude Opus 4.5, 4.6, and 4.7 variants (1M context support)
string(anthropic.ModelClaudeOpus4_5):          {"context-1m-2025-08-07"},
string(anthropic.ModelClaudeOpus4_6):          {"context-1m-2025-08-07"},
string(anthropic.ModelClaudeOpus4_7):          {"context-1m-2025-08-07"},
string(anthropic.ModelClaudeOpus4_5_20251101): {"context-1m-2025-08-07"},
```

Updated the descriptive comment:

```go
// Claude Opus 4.7, Opus 4.6, Sonnet 4.6, Sonnet 4.5, and Sonnet 4 support a 1-million token context window.
```

## Reason for Changes

Anthropic released Claude Opus 4.7, which is exposed via the new `ModelClaudeOpus4_7` constant in `anthropic-sdk-go` v1.37.0. This change makes the new model selectable through the Anthropic plugin and enables its 1M-token context window beta header so users can take immediate advantage of the larger context.

## Impact of Changes

- Users can now select Claude Opus 4.7 as a model through the Anthropic plugin.
- Requests targeting Opus 4.7 will automatically include the `context-1m-2025-08-07` beta header, unlocking the 1M-token context window.
- Opus 4.7 is listed first in the `models` slice, which may affect any UI/CLI surface that uses ordering (e.g., default selection, picker order) — worth confirming that this is the desired default position.
- No breaking changes are expected from the SDK bump (patch/minor version increase, same module path and `go.mod` line).

## Test Plan

- [x] Run `go build ./...` to verify the SDK upgrade compiles cleanly.
- [x] Run the existing test suite (`go test ./...`), particularly any tests under `internal/plugins/ai/anthropic/`.
- [x] Manually issue a request against Claude Opus 4.7 and confirm the response succeeds.
- [x] Verify the `context-1m-2025-08-07` beta header is sent for Opus 4.7 requests (e.g., via debug logging or proxy capture).
- [x] Confirm model listing endpoints/UI surface the new model.

## Additional Notes

- The SDK bump skips from `v1.34.0` directly to `v1.37.0`; reviewing the upstream changelog for any unrelated behavioral changes between those versions is recommended.
- Stale `v1.27.1` and `v1.34.0` entries remain in `go.sum`; if no other module references them, a `go mod tidy` pass would clean these up.
- Consider whether Opus 4.7 should also be added to any model alias maps, defaults, or documentation outside of this plugin file.
