### PR TITLE
Fix Codex Empty Response bug

### DIFF
--- a/internal/plugins/ai/codex/codex.go
+++ b/internal/plugins/ai/codex/codex.go
@@ -242,11 +242,14 @@ func (c *Client) Send(ctx context.Context, msgs []*chat.ChatCompletionMessage, o
 	if err := c.mapRequestError(stream.Err()); err != nil {
 		return "", err
 	}
+	streamedText := builder.String()
 	if completedResp != nil {
-		return c.ExtractText(completedResp), nil
+		if extractedText := c.ExtractText(completedResp); strings.TrimSpace(extractedText) != "" {
+			return extractedText, nil
+		}
 	}
 
-	return builder.String(), nil
+	return streamedText, nil
 }
 
 // SendStream sends a request to Codex and streams the response text updates.

--- a/internal/plugins/ai/codex/codex_test.go
+++ b/internal/plugins/ai/codex/codex_test.go
@@ -429,6 +429,61 @@ func TestSendIncludesSourcesFromAnnotatedResponse(t *testing.T) {
 	}
 }
 
+func TestSendFallsBackToDeltaWhenCompletedResponseHasNoText(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/responses" {
+			http.NotFound(w, r)
+			return
+		}
+
+		w.Header().Set("Content-Type", "text/event-stream")
+		flusher, ok := w.(http.Flusher)
+		if !ok {
+			t.Fatalf("response writer does not implement http.Flusher")
+		}
+		fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, map[string]any{
+			"type":  string(constant.ResponseOutputTextDelta("").Default()),
+			"delta": "hello from delta",
+		}))
+		flusher.Flush()
+		fmt.Fprintf(w, "data: %s\n\n", marshalJSON(t, map[string]any{
+			"type": "response.completed",
+			"response": map[string]any{
+				"output": []any{
+					map[string]any{
+						"type": "message",
+						"content": []any{
+							map[string]any{
+								"type": "output_text",
+								"text": "",
+							},
+						},
+					},
+				},
+			},
+		}))
+		flusher.Flush()
+		fmt.Fprint(w, "data: [DONE]\n\n")
+	}))
+	defer apiServer.Close()
+
+	client := newConfiguredTestClient(t, apiServer.URL, "acct_delta_fallback", testJWT("acct_delta_fallback", time.Now().Add(time.Hour)))
+
+	message, err := client.Send(context.Background(), []*chat.ChatCompletionMessage{
+		{Role: chat.ChatMessageRoleUser, Content: "Hello"},
+	}, &domain.ChatOptions{
+		Model:       "gpt-5.4",
+		Temperature: 0.7,
+	})
+	if err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	if message != "hello from delta" {
+		t.Fatalf("Send() = %q, want %q", message, "hello from delta")
+	}
+}
+
 func TestSendStreamReadsCodexSSE(t *testing.T) {
 	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/responses" {


### PR DESCRIPTION
# Fix Codex Empty Response bug

## Summary

Closes #2096 

This PR fixes a response handling edge case in the Codex AI client where `Send()` could return an empty string when the final `response.completed` payload contained no usable text, even though text had already been received through streamed deltas.

The change updates the fallback behavior so that streamed delta text is preserved and returned when the completed response does not contain meaningful text. A regression test has also been added to cover this scenario.

## Files Changed

### `internal/plugins/ai/codex/codex.go`
Updated `Client.Send()` to prefer extracted text from the completed response only when it is non-empty after trimming whitespace. Otherwise, it now falls back to the accumulated streamed delta text.

### `internal/plugins/ai/codex/codex_test.go`
Added a test case to verify that `Send()` returns streamed delta content when the final completed response includes an empty `output_text` value.

## Code Changes

### `internal/plugins/ai/codex/codex.go`

The method now stores the accumulated streamed output before inspecting the completed response:

```go
streamedText := builder.String()
if completedResp != nil {
	if extractedText := c.ExtractText(completedResp); strings.TrimSpace(extractedText) != "" {
		return extractedText, nil
	}
}

return streamedText, nil
```

Previously, the code returned `c.ExtractText(completedResp)` whenever a completed response existed, even if that extracted text was empty. That behavior could discard valid streamed content already collected from delta events.

### `internal/plugins/ai/codex/codex_test.go`

Added a regression test that simulates an SSE stream with:
1. A `response.output_text.delta` event containing text
2. A `response.completed` event whose `output_text.text` is empty
3. A `[DONE]` marker

Relevant test behavior:

```go
if message != "hello from delta" {
	t.Fatalf("Send() = %q, want %q", message, "hello from delta")
}
```

This confirms that the client now correctly falls back to delta text instead of returning an empty final response.

## Reason for Changes

The previous implementation assumed that the completed response payload was always the best source of truth. In practice, that payload can be present but contain empty text. When that happened, `Send()` returned an empty string and ignored the valid text already received from streamed deltas.

This change fixes that bug by treating the completed response as authoritative only when it contains meaningful text.

## Impact of Changes

- Fixes a user-facing bug where Codex responses could appear blank despite streamed content being received.
- Improves resilience of the Codex client against incomplete or inconsistent final SSE payloads.
- Preserves existing behavior when the completed response does contain valid text.
- Reduces the risk of losing generated output in edge cases involving empty final response bodies.

Potential considerations:
- The fallback now depends on accumulated streamed text, so any future changes to delta assembly should continue to preserve compatibility with this logic.
- Whitespace-only completed responses are now treated as empty, which is appropriate here but worth noting if whitespace ever becomes semantically meaningful.

## Test Plan

- Added automated coverage for the regression scenario in `codex_test.go`.
- The new test verifies that:
  - streamed delta text is collected correctly
  - an empty completed response does not override valid streamed output
  - `Send()` returns the expected fallback text

Suggested additional validation:
- Confirm existing tests still pass for normal completed responses with non-empty text.
- Verify behavior when no completed response is received and only deltas are available.
- Verify behavior when both deltas and completed response contain text, ensuring completed response still takes precedence.

## Additional Notes

This is a narrowly scoped fix with low risk. The behavior change is limited to cases where the completed response text is empty or whitespace-only. In all other cases, response handling remains unchanged.
