### PR TITLE
fix(youtube): preserve ffmpeg frame timing in visual OCR cues

### DIFF
--- a/cmd/generate_changelog/incoming/2101.txt
+++ b/cmd/generate_changelog/incoming/2101.txt
@@ -1,0 +1,17 @@
+### PR [#2101](https://github.com/danielmiessler/Fabric/pull/2101) by [shaun0927](https://github.com/shaun0927): fix(youtube): preserve ffmpeg frame timing in visual OCR cues
+
+- Preserve real visual OCR timing in YouTube frame cues
+The visual OCR path emitted subtitle-style cues using the OCR result index
+instead of the underlying ffmpeg frame time, which made the output look more
+precise than it was. This change parses ffmpeg showinfo timestamps, formats
+cue ranges from real frame times, and adds regression coverage for the timing
+helpers and the end-to-end visual extraction path.
+Constraint: Preserve existing OCR extraction flow and output shape while fixing cue timing
+Rejected: Leave timestamps index-based and document the limitation | still produces misleading time cues
+Confidence: high
+Scope-risk: narrow
+Reversibility: clean
+Directive: Keep ffmpeg-derived frame timing wired through any future visual extraction refactors
+Tested: go test ./internal/tools/youtube -v
+Not-tested: Live yt-dlp/ffmpeg/tesseract execution against a real YouTube video
+Related: #2099

--- a/cmd/generate_changelog/incoming/2101.txt
+++ b/cmd/generate_changelog/incoming/2101.txt
@@ -1,17 +1,5 @@
 ### PR [#2101](https://github.com/danielmiessler/Fabric/pull/2101) by [shaun0927](https://github.com/shaun0927): fix(youtube): preserve ffmpeg frame timing in visual OCR cues
 
-- Preserve real visual OCR timing in YouTube frame cues
-The visual OCR path emitted subtitle-style cues using the OCR result index
-instead of the underlying ffmpeg frame time, which made the output look more
-precise than it was. This change parses ffmpeg showinfo timestamps, formats
-cue ranges from real frame times, and adds regression coverage for the timing
-helpers and the end-to-end visual extraction path.
-Constraint: Preserve existing OCR extraction flow and output shape while fixing cue timing
-Rejected: Leave timestamps index-based and document the limitation | still produces misleading time cues
-Confidence: high
-Scope-risk: narrow
-Reversibility: clean
-Directive: Keep ffmpeg-derived frame timing wired through any future visual extraction refactors
-Tested: go test ./internal/tools/youtube -v
-Not-tested: Live yt-dlp/ffmpeg/tesseract execution against a real YouTube video
-Related: #2099
+- Fixes YouTube visual OCR cues so timestamps come from real ffmpeg frame timing instead of the OCR result index.
+- Parses `pts_time` from ffmpeg `showinfo` output and formats cue ranges from actual frame times, with a safe fallback.
+- Adds regression coverage for the timestamp parser, cue-range helper, and the end-to-end visual extraction path.

--- a/internal/tools/youtube/timestamp_test.go
+++ b/internal/tools/youtube/timestamp_test.go
@@ -59,3 +59,33 @@ func TestShouldIncludeRepeat(t *testing.T) {
 		}
 	}
 }
+
+func TestParseFFmpegFrameTimes(t *testing.T) {
+	logOutput := `
+[Parsed_showinfo_1 @ 0x1] n:   0 pts:      0 pts_time:0
+[Parsed_showinfo_1 @ 0x1] n:   1 pts:    500 pts_time:0.5
+[Parsed_showinfo_1 @ 0x1] n:   2 pts:   2500 pts_time:2.5
+`
+
+	frameTimes := parseFFmpegFrameTimes(logOutput)
+	if len(frameTimes) != 3 {
+		t.Fatalf("expected 3 frame times, got %d", len(frameTimes))
+	}
+	if frameTimes[0] != 0 || frameTimes[1] != 0.5 || frameTimes[2] != 2.5 {
+		t.Fatalf("unexpected frame times: %#v", frameTimes)
+	}
+}
+
+func TestVisualCueRange_UsesActualFrameTimes(t *testing.T) {
+	frameTimes := []float64{0, 0.5, 2.5}
+
+	start0, end0 := visualCueRange(frameTimes, 0)
+	if start0 != "00:00:00.000" || end0 != "00:00:00.499" {
+		t.Fatalf("unexpected first cue range: %s --> %s", start0, end0)
+	}
+
+	start1, end1 := visualCueRange(frameTimes, 1)
+	if start1 != "00:00:00.500" || end1 != "00:00:02.499" {
+		t.Fatalf("unexpected second cue range: %s --> %s", start1, end1)
+	}
+}

--- a/internal/tools/youtube/visual_timestamp_test.go
+++ b/internal/tools/youtube/visual_timestamp_test.go
@@ -1,0 +1,39 @@
+package youtube
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeExecutable(t *testing.T, dir, name, contents string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(contents), 0o755); err != nil {
+		t.Fatalf("failed to write %s: %v", name, err)
+	}
+	return path
+}
+
+func TestGrabVisual_UsesFrameTimesFromFFmpeg(t *testing.T) {
+	binDir := t.TempDir()
+	writeExecutable(t, binDir, "yt-dlp", "#!/usr/bin/env bash\necho 'http://example.invalid/video'\n")
+	writeExecutable(t, binDir, "ffmpeg", "#!/usr/bin/env bash\nout=\"${@: -1}\"\ntouch \"${out//%04d/0001}\"\ntouch \"${out//%04d/0002}\"\necho '[Parsed_showinfo_1 @ 0x1] n:   0 pts:      0 pts_time:0' >&2\necho '[Parsed_showinfo_1 @ 0x1] n:   1 pts:    500 pts_time:0.5' >&2\n")
+	writeExecutable(t, binDir, "tesseract", "#!/usr/bin/env bash\ncase \"$1\" in\n  *0001.jpg) echo 'First frame text' ;;\n  *0002.jpg) echo 'Second frame text' ;;\n  *) echo 'Unknown frame text' ;;\nesac\n")
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	yt := NewYouTube()
+	got, err := yt.GrabVisual("video123", "en", "", 0.4, 2)
+	if err != nil {
+		t.Fatalf("GrabVisual returned error: %v", err)
+	}
+
+	if !strings.Contains(got, "00:00:00.500 --> 00:00:01.499") {
+		t.Fatalf("expected second frame to use ffmpeg-derived timing, got %q", got)
+	}
+	if !strings.Contains(got, "Second frame text") {
+		t.Fatalf("expected second frame OCR text in output, got %q", got)
+	}
+}

--- a/internal/tools/youtube/youtube.go
+++ b/internal/tools/youtube/youtube.go
@@ -44,6 +44,7 @@ var videoPatternRegex *regexp.Regexp
 var playlistPatternRegex *regexp.Regexp
 var vttTagRegex *regexp.Regexp
 var durationRegex *regexp.Regexp
+var ffmpegPtsTimeRegex *regexp.Regexp
 
 const TimeGapForRepeats = 10 // seconds
 
@@ -60,6 +61,7 @@ func init() {
 	vttTagRegex = regexp.MustCompile(`<[^>]*>`)
 	// YouTube duration format PT1H2M3S
 	durationRegex = regexp.MustCompile(`(?i)PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?`)
+	ffmpegPtsTimeRegex = regexp.MustCompile(`pts_time:([0-9]+(?:\.[0-9]+)?)`)
 }
 
 func NewYouTube() (ret *YouTube) {
@@ -501,6 +503,48 @@ func parseSeconds(secondsStr string) (int, error) {
 	return seconds, nil
 }
 
+func parseFFmpegFrameTimes(logOutput string) []float64 {
+	matches := ffmpegPtsTimeRegex.FindAllStringSubmatch(logOutput, -1)
+	frameTimes := make([]float64, 0, len(matches))
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		frameTime, err := strconv.ParseFloat(match[1], 64)
+		if err != nil {
+			continue
+		}
+		frameTimes = append(frameTimes, frameTime)
+	}
+	return frameTimes
+}
+
+func formatCueTimestamp(seconds float64) string {
+	if seconds < 0 {
+		seconds = 0
+	}
+	totalMilliseconds := int(seconds*1000 + 0.5)
+	hours := totalMilliseconds / 3_600_000
+	minutes := (totalMilliseconds % 3_600_000) / 60_000
+	secs := (totalMilliseconds % 60_000) / 1000
+	milliseconds := totalMilliseconds % 1000
+	return fmt.Sprintf("%02d:%02d:%02d.%03d", hours, minutes, secs, milliseconds)
+}
+
+func visualCueRange(frameTimes []float64, index int) (string, string) {
+	start := float64(index)
+	if index < len(frameTimes) {
+		start = frameTimes[index]
+	}
+
+	end := start + 0.999
+	if index+1 < len(frameTimes) && frameTimes[index+1] > start {
+		end = frameTimes[index+1] - 0.001
+	}
+
+	return formatCueTimestamp(start), formatCueTimestamp(end)
+}
+
 func (o *YouTube) GrabComments(videoId string) (ret []string, err error) {
 	if err = o.initService(); err != nil {
 		return
@@ -911,16 +955,18 @@ func (o *YouTube) GrabVisual(videoId string, language string, additionalArgs str
 
 	var filter string
 	if fps > 0 {
-		filter = fmt.Sprintf("fps=%d", fps)
+		filter = fmt.Sprintf("fps=%d,showinfo", fps)
 	} else {
-		filter = fmt.Sprintf("select='gt(scene,%f)'", sensitivity)
+		filter = fmt.Sprintf("select='gt(scene,%f)',showinfo", sensitivity)
 	}
 
 	framePattern := filepath.Join(tempDir, "frame_%04d.jpg")
 	cmdFfmpeg := exec.CommandContext(ctx, "ffmpeg", "-i", streamUrl, "-vf", filter, "-fps_mode", "vfr", framePattern)
-	if out, err := cmdFfmpeg.CombinedOutput(); err != nil {
-		return "", fmt.Errorf(i18n.T("youtube_ffmpeg_frame_extraction_failed"), err, string(out))
+	ffmpegOutput, err := cmdFfmpeg.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf(i18n.T("youtube_ffmpeg_frame_extraction_failed"), err, string(ffmpegOutput))
 	}
+	frameTimes := parseFFmpegFrameTimes(string(ffmpegOutput))
 
 	files, err := filepath.Glob(filepath.Join(tempDir, "frame_*.jpg"))
 	if err != nil {
@@ -967,11 +1013,8 @@ func (o *YouTube) GrabVisual(videoId string, language string, additionalArgs str
 	var sb strings.Builder
 	for i, text := range results {
 		if text != "" {
-			secs := i
-			hours := secs / 3600
-			mins := (secs % 3600) / 60
-			sec := secs % 60
-			sb.WriteString(fmt.Sprintf("\n%02d:%02d:%02d.000 --> %02d:%02d:%02d.999\n", hours, mins, sec, hours, mins, sec))
+			start, end := visualCueRange(frameTimes, i)
+			sb.WriteString(fmt.Sprintf("\n%s --> %s\n", start, end))
 			sb.WriteString(i18n.T("youtube_visual_frame_cue"))
 			sb.WriteString("\n")
 			sb.WriteString(text)


### PR DESCRIPTION
## Summary

This PR fixes the YouTube visual OCR path so its cue timestamps are derived from ffmpeg frame timing instead of the OCR result index.

## Problem

`GrabVisual()` currently extracts frames using either `fps=%d` or `select='gt(scene,%f)'`, but later formats subtitle-like cues from:

```go
secs := i
```

So the nth OCR result is labeled as second `n` regardless of when that frame actually occurred in the source video.

## Fix

- append `showinfo` to the ffmpeg filter used for visual extraction
- parse `pts_time` values from ffmpeg output
- format cue ranges from actual frame timestamps (falling back cleanly if timestamps are unavailable)
- add regression coverage for the timestamp parser, cue-range helper, and end-to-end visual extraction path

## Files changed

- `internal/tools/youtube/youtube.go`
- `internal/tools/youtube/timestamp_test.go`
- `internal/tools/youtube/visual_timestamp_test.go`

## Tests

```bash
go test ./internal/tools/youtube -v
```

## Related issues

Closes #2099
