### PR TITLE
fix(chat): emit SSE error and skip complete on prompt setup failures

### DIFF
--- a/cmd/generate_changelog/incoming/2102.txt
+++ b/cmd/generate_changelog/incoming/2102.txt
@@ -1,0 +1,17 @@
+### PR [#2102](https://github.com/danielmiessler/Fabric/pull/2102) by [shaun0927](https://github.com/shaun0927): fix(chat): emit SSE error and skip complete on prompt setup failures
+
+- Prevent false SSE completion after prompt setup failures
+The /chat handler previously relied on stream-originated error updates and
+still emitted a terminal complete event when chatter setup failed before any
+stream updates were sent. This change forwards a server-side error event for
+those early failures, suppresses complete after errors, and adds regression
+coverage for an invalid strategy path.
+Constraint: Keep the fix narrow to the REST SSE path
+Rejected: Broad chatter API redesign | unnecessary for a targeted contract fix
+Confidence: high
+Scope-risk: narrow
+Reversibility: clean
+Directive: Preserve the invariant that complete is emitted only for successful prompt runs
+Tested: go test ./internal/server -v
+Not-tested: End-to-end browser SSE client behavior outside package tests
+Related: #2100

--- a/cmd/generate_changelog/incoming/2102.txt
+++ b/cmd/generate_changelog/incoming/2102.txt
@@ -1,17 +1,5 @@
 ### PR [#2102](https://github.com/danielmiessler/Fabric/pull/2102) by [shaun0927](https://github.com/shaun0927): fix(chat): emit SSE error and skip complete on prompt setup failures
 
-- Prevent false SSE completion after prompt setup failures
-The /chat handler previously relied on stream-originated error updates and
-still emitted a terminal complete event when chatter setup failed before any
-stream updates were sent. This change forwards a server-side error event for
-those early failures, suppresses complete after errors, and adds regression
-coverage for an invalid strategy path.
-Constraint: Keep the fix narrow to the REST SSE path
-Rejected: Broad chatter API redesign | unnecessary for a targeted contract fix
-Confidence: high
-Scope-risk: narrow
-Reversibility: clean
-Directive: Preserve the invariant that complete is emitted only for successful prompt runs
-Tested: go test ./internal/server -v
-Not-tested: End-to-end browser SSE client behavior outside package tests
-Related: #2100
+- Fixes a REST `/chat` SSE bug where prompt setup failures could still end with a terminal `complete` event.
+- Forwards an explicit stream error when `chatter.Send()` fails before any stream update has been emitted, and suppresses the terminal `complete` afterward.
+- Adds regression coverage for the invalid-strategy path.

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -6,6 +6,7 @@ import (
 	"log"
 	"net/http"
 	"strings"
+	"sync/atomic"
 
 	"github.com/danielmiessler/fabric/internal/chat"
 
@@ -100,6 +101,7 @@ func (h *ChatHandler) HandleChat(c *gin.Context) {
 				i+1, prompt.Model, prompt.PatternName, prompt.ContextName)
 
 			streamChan := make(chan domain.StreamUpdate)
+			var sawError atomic.Bool
 
 			go func(p PromptRequest) {
 				defer close(streamChan)
@@ -118,6 +120,18 @@ func (h *ChatHandler) HandleChat(c *gin.Context) {
 				}
 
 				chatReq := buildPromptChatRequest(p, request.Language)
+				vendorUpdates := make(chan domain.StreamUpdate)
+				var forwardedError atomic.Bool
+				forwardDone := make(chan struct{})
+				go func() {
+					defer close(forwardDone)
+					for update := range vendorUpdates {
+						if update.Type == domain.StreamTypeError {
+							forwardedError.Store(true)
+						}
+						streamChan <- update
+					}
+				}()
 
 				opts := &domain.ChatOptions{
 					Model:            p.Model,
@@ -128,14 +142,21 @@ func (h *ChatHandler) HandleChat(c *gin.Context) {
 					Thinking:         request.Thinking,
 					Search:           request.Search,
 					SearchLocation:   request.SearchLocation,
-					UpdateChan:       streamChan,
+					UpdateChan:       vendorUpdates,
 					Quiet:            true,
 				}
 
 				_, err = chatter.Send(c.Request.Context(), chatReq, opts)
+				close(vendorUpdates)
+				<-forwardDone
 				if err != nil {
 					log.Printf("Error from chatter.Send: %v", err)
-					// Error already sent to streamChan via domain.StreamTypeError if occurred in Send loop
+					if !forwardedError.Load() {
+						streamChan <- domain.StreamUpdate{
+							Type:    domain.StreamTypeError,
+							Content: fmt.Sprintf(i18n.T("server_chat_error"), err),
+						}
+					}
 					return
 				}
 			}(prompt)
@@ -159,6 +180,7 @@ func (h *ChatHandler) HandleChat(c *gin.Context) {
 							Usage: update.Usage,
 						}
 					case domain.StreamTypeError:
+						sawError.Store(true)
 						response = StreamResponse{
 							Type:    "error",
 							Format:  "plain",
@@ -173,14 +195,16 @@ func (h *ChatHandler) HandleChat(c *gin.Context) {
 				}
 			}
 
-			completeResponse := StreamResponse{
-				Type:    "complete",
-				Format:  "plain",
-				Content: "",
-			}
-			if err := writeSSEResponse(c.Writer, completeResponse); err != nil {
-				log.Printf("Error writing completion response: %v", err)
-				return
+			if !sawError.Load() {
+				completeResponse := StreamResponse{
+					Type:    "complete",
+					Format:  "plain",
+					Content: "",
+				}
+				if err := writeSSEResponse(c.Writer, completeResponse); err != nil {
+					log.Printf("Error writing completion response: %v", err)
+					return
+				}
 			}
 		}
 	}

--- a/internal/server/chat_test.go
+++ b/internal/server/chat_test.go
@@ -1,6 +1,22 @@
 package restapi
 
-import "testing"
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/danielmiessler/fabric/internal/chat"
+	"github.com/danielmiessler/fabric/internal/core"
+	"github.com/danielmiessler/fabric/internal/domain"
+	"github.com/danielmiessler/fabric/internal/plugins"
+	"github.com/danielmiessler/fabric/internal/plugins/ai"
+	"github.com/danielmiessler/fabric/internal/plugins/db/fsdb"
+	"github.com/danielmiessler/fabric/internal/tools"
+	"github.com/gin-gonic/gin"
+)
 
 func TestBuildPromptChatRequest_PreservesStrategyAndUserInput(t *testing.T) {
 	prompt := PromptRequest{
@@ -41,5 +57,80 @@ func TestBuildPromptChatRequest_PreservesStrategyAndUserInput(t *testing.T) {
 	}
 	if got := request.PatternVariables["topic"]; got != "pipelines" {
 		t.Fatalf("expected variables to be preserved, got %q", got)
+	}
+}
+
+type serverTestVendor struct {
+	name   string
+	models []string
+}
+
+func (m *serverTestVendor) GetName() string                              { return m.name }
+func (m *serverTestVendor) GetSetupDescription() string                  { return m.name }
+func (m *serverTestVendor) IsConfigured() bool                           { return true }
+func (m *serverTestVendor) Configure() error                             { return nil }
+func (m *serverTestVendor) Setup() error                                 { return nil }
+func (m *serverTestVendor) SetupFillEnvFileContent(*bytes.Buffer)        {}
+func (m *serverTestVendor) ListModels(context.Context) ([]string, error) { return m.models, nil }
+func (m *serverTestVendor) SendStream(context.Context, []*chat.ChatCompletionMessage, *domain.ChatOptions, chan domain.StreamUpdate) error {
+	return nil
+}
+func (m *serverTestVendor) Send(context.Context, []*chat.ChatCompletionMessage, *domain.ChatOptions) (string, error) {
+	return "", nil
+}
+func (m *serverTestVendor) NeedsRawMode(string) bool { return false }
+
+type closeNotifierRecorder struct {
+	*httptest.ResponseRecorder
+	closeCh chan bool
+}
+
+func (r *closeNotifierRecorder) CloseNotify() <-chan bool {
+	return r.closeCh
+}
+
+func TestHandleChat_InvalidStrategyEmitsErrorAndSkipsComplete(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	gin.SetMode(gin.TestMode)
+
+	db := fsdb.NewDb(t.TempDir())
+	vendor := &serverTestVendor{name: "TestVendor", models: []string{"test-model"}}
+	vm := ai.NewVendorsManager()
+	vm.AddVendors(vendor)
+
+	registry := &core.PluginRegistry{
+		Db:            db,
+		VendorManager: vm,
+		Defaults: &tools.Defaults{
+			PluginBase:         &plugins.PluginBase{},
+			Vendor:             &plugins.Setting{Value: "TestVendor"},
+			Model:              &plugins.SetupQuestion{Setting: &plugins.Setting{Value: "test-model"}},
+			ModelContextLength: &plugins.SetupQuestion{Setting: &plugins.Setting{Value: "0"}},
+		},
+	}
+
+	router := gin.New()
+	NewChatHandler(router, registry, db)
+
+	body := `{"prompts":[{"userInput":"hello","vendor":"TestVendor","model":"test-model","strategyName":"missing-strategy"}]}`
+	req := httptest.NewRequest(http.MethodPost, "/chat", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	resp := &closeNotifierRecorder{
+		ResponseRecorder: httptest.NewRecorder(),
+		closeCh:          make(chan bool, 1),
+	}
+
+	router.ServeHTTP(resp, req)
+
+	if resp.Code != http.StatusOK {
+		t.Fatalf("expected status 200, got %d with body %q", resp.Code, resp.Body.String())
+	}
+
+	responseBody := resp.Body.String()
+	if !strings.Contains(responseBody, `"type":"error"`) {
+		t.Fatalf("expected SSE error event for missing strategy, got body %q", responseBody)
+	}
+	if strings.Contains(responseBody, `"type":"complete"`) {
+		t.Fatalf("expected no complete SSE event for missing strategy, got body %q", responseBody)
 	}
 }


### PR DESCRIPTION
## Summary

This PR fixes a REST `/chat` SSE contract bug where prompt/session setup failures could still end with a final `complete` event.

## Problem

When `chatter.Send()` fails before any stream-originated error update is emitted (for example, when `strategy.LoadStrategy()` fails during request assembly), the handler currently:

1. logs the error,
2. closes the stream channel, and then
3. emits a final `complete` event.

That means an SSE client can interpret the request as successful even though no valid response was produced.

## Fix

- forward an explicit `StreamTypeError` update when `chatter.Send()` returns an error that was not already surfaced through stream updates
- suppress the final `complete` event whenever an error was emitted for that prompt
- add regression coverage for the invalid-strategy path

## Files changed

- `internal/server/chat.go`
- `internal/server/chat_test.go`

## Tests

```bash
go test ./internal/server -v
```

## Related issues

Closes #2100
