### PR TITLE
docs: add Scoop installation instructions

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,10 +8,13 @@
 		"anthropics",
 		"Aoede",
 		"apikey",
+		"APIM",
 		"aplicar",
+		"appuser",
 		"Astley",
 		"atotto",
 		"Autonoe",
+		"azurecommon",
 		"azureml",
 		"badfile",
 		"Behrens",
@@ -131,6 +134,7 @@
 		"modelines",
 		"Moltbot",
 		"mpga",
+		"MSAL",
 		"mvdan",
 		"mychat",
 		"mygroup",
@@ -222,6 +226,7 @@
 	"cSpell.ignorePaths": [
 		"go.mod",
 		".gitignore",
+		".vscode/**",
 		"CHANGELOG.md",
 		"scripts/installer/install.*",
 		"web/static/data/pattern_descriptions.json",
@@ -255,6 +260,7 @@
 				"module",
 				"p",
 				"summary",
+				"strong",
 				"sup"
 			]
 		},

--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Keep in mind that many of these were recorded when Fabric was Python-based, so r
       - [macOS (Homebrew)](#macos-homebrew)
       - [Arch Linux (AUR)](#arch-linux-aur)
       - [Windows](#windows)
+      - [Windows (Scoop)](#windows-scoop)
     - [From Source](#from-source)
     - [Docker](#docker)
     - [Environment Variables](#environment-variables)

--- a/README.md
+++ b/README.md
@@ -263,6 +263,10 @@ Use the official Microsoft supported `Winget` tool:
 
 `winget install danielmiessler.Fabric`
 
+#### Windows (Scoop)
+
+`scoop install fabric-ai`
+
 ### From Source
 
 To install Fabric, [make sure Go is installed](https://go.dev/doc/install), and then run the following command.

--- a/README.zh.md
+++ b/README.zh.md
@@ -131,6 +131,7 @@ Fabric 按照现实世界中的任务来组织 Prompt，允许人们在一个地
       - [macOS (Homebrew)](#macos-homebrew)
       - [Arch Linux (AUR)](#arch-linux-aur)
       - [Windows](#windows)
+      - [Windows (Scoop)](#windows-scoop)
     - [从源码构建](#从源码构建)
     - [Docker](#docker)
     - [环境变量](#环境变量)
@@ -258,6 +259,12 @@ yay -S fabric-ai
 
 ```bash
 winget install danielmiessler.Fabric
+```
+
+#### Windows (Scoop)
+
+```bash
+scoop install fabric-ai
 ```
 
 ### 从源码构建


### PR DESCRIPTION
## What this Pull Request (PR) does

Add [Scoop](https://scoop.sh/) installation instructions to the readme

## Related issues

- See https://github.com/danielmiessler/Fabric/issues/1722#issuecomment-4286610394

## Screenshots

<img width="673" height="156" alt="image" src="https://github.com/user-attachments/assets/ba93ba6c-b0e6-415f-ad89-53c32324949b" />

