### PR TITLE
feat: add FuturMix as OpenAI-compatible provider

### DIFF
--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -237,6 +237,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "https://api.deepseek.com",
 		ImplementsResponses: false,
 	},
+	"FuturMix": {
+		Name:                "FuturMix",
+		BaseURL:             "https://futurmix.ai/v1",
+		ImplementsResponses: false,
+	},
 	"GitHub": {
 		Name:                "GitHub",
 		BaseURL:             "https://models.github.ai/inference",

--- a/internal/plugins/ai/openai_compatible/providers_config_test.go
+++ b/internal/plugins/ai/openai_compatible/providers_config_test.go
@@ -41,6 +41,11 @@ func TestCreateClient(t *testing.T) {
 			exists:   true,
 		},
 		{
+			name:     "Existing provider - FuturMix",
+			provider: "FuturMix",
+			exists:   true,
+		},
+		{
 			name:     "Non-existent provider",
 			provider: "NonExistent",
 			exists:   false,


### PR DESCRIPTION
## Summary

- Add [FuturMix](https://futurmix.ai) as a model provider in the provider map
- FuturMix is an enterprise AI agent platform providing access to 22+ models (GPT-4o, Claude, Gemini, etc.) with 99.99% SLA

## Changes

- Added `FuturMix` entry to `ProviderMap` in `providers_config.go` (alphabetical, between DeepSeek and GitHub)
- Added test case in `providers_config_test.go`

## Testing

- Verified FuturMix API endpoint provides standard API access (`/v1/chat/completions`, `/v1/models`)
- Added corresponding test case for provider existence check