### PR TITLE
Security: fix remote file write and shell injection in template extensions

### DIFF
--- a/internal/core/chatter.go
+++ b/internal/core/chatter.go
@@ -187,7 +187,9 @@ func (o *Chatter) Send(ctx context.Context, request *domain.ChatRequest, opts *d
 	}
 
 	// Process file changes for create_coding_feature pattern
-	if request.PatternName == "create_coding_feature" {
+	// Only auto-apply in CLI mode (UpdateChan is nil); API mode streams responses
+	// and must not perform unsupervised file writes.
+	if request.PatternName == "create_coding_feature" && opts.UpdateChan == nil {
 		summary, fileChanges, parseErr := domain.ParseFileChanges(message)
 		if parseErr != nil {
 			fmt.Printf("%s\n", fmt.Sprintf(i18n.T("chatter_warning_parse_file_changes_failed"), parseErr))

--- a/internal/domain/file_manager.go
+++ b/internal/domain/file_manager.go
@@ -94,7 +94,7 @@ func ParseFileChanges(output string) (changeSummary string, changes []FileChange
 		}
 
 		// Check for suspicious paths (directory traversal)
-		if strings.Contains(change.Path, "..") {
+		if strings.Contains(change.Path, "..") || filepath.IsAbs(change.Path) {
 			return changeSummary, nil, fmt.Errorf(i18n.T("file_manager_suspicious_path"), i, change.Path)
 		}
 
@@ -169,9 +169,25 @@ func fixInvalidEscapes(jsonStr string) string {
 
 // ApplyFileChanges applies the parsed file changes to the file system
 func ApplyFileChanges(projectRoot string, changes []FileChange) error {
+	absProjectRoot, err := filepath.Abs(projectRoot)
+	if err != nil {
+		return fmt.Errorf("failed to resolve project root: %w", err)
+	}
+	absProjectRoot = filepath.Clean(absProjectRoot)
+
 	for i, change := range changes {
-		// Get the absolute path
-		absPath := filepath.Join(projectRoot, change.Path)
+		// Reject absolute paths
+		if filepath.IsAbs(change.Path) {
+			return fmt.Errorf(i18n.T("file_manager_suspicious_path"), i, change.Path)
+		}
+
+		// Get the absolute path and clean it
+		absPath := filepath.Clean(filepath.Join(absProjectRoot, change.Path))
+
+		// Ensure the resolved path is within the project root
+		if !strings.HasPrefix(absPath+string(filepath.Separator), absProjectRoot+string(filepath.Separator)) && absPath != absProjectRoot {
+			return fmt.Errorf(i18n.T("file_manager_suspicious_path"), i, change.Path)
+		}
 
 		// Create directories if necessary
 		dir := filepath.Dir(absPath)

--- a/internal/domain/file_manager.go
+++ b/internal/domain/file_manager.go
@@ -185,7 +185,8 @@ func ApplyFileChanges(projectRoot string, changes []FileChange) error {
 		absPath := filepath.Clean(filepath.Join(absProjectRoot, change.Path))
 
 		// Ensure the resolved path is within the project root
-		if !strings.HasPrefix(absPath+string(filepath.Separator), absProjectRoot+string(filepath.Separator)) && absPath != absProjectRoot {
+		rel, err := filepath.Rel(absProjectRoot, absPath)
+		if err != nil || strings.HasPrefix(rel, "..") {
 			return fmt.Errorf(i18n.T("file_manager_suspicious_path"), i, change.Path)
 		}
 

--- a/internal/plugins/template/extension_executor.go
+++ b/internal/plugins/template/extension_executor.go
@@ -53,8 +53,7 @@ func (e *ExtensionExecutor) Execute(name, operation, value string) (string, erro
 	}
 
 	// Create command with the Executable and formatted arguments
-	cmd := exec.Command("sh", "-c", cmdStr)
-	//cmd := exec.Command(cmdParts[0], cmdParts[1:]...)
+	cmd := exec.Command(cmdParts[0], cmdParts[1:]...)
 
 	// Set up environment if specified
 	if len(ext.Env) > 0 {


### PR DESCRIPTION
Fixes two critical security findings:

1. **Remote arbitrary file write via **: Added  guard so file changes are only auto-applied in CLI mode, not via REST API. Hardened path containment checks in  using  + .
2. **Arbitrary shell execution via template extensions**: Replaced  with direct command execution using , eliminating command injection.

Changes are minimal and backward-compatible.