### PR TITLE
fix: omit Anthropic sampling params for Claude Opus 4.7

### DIFF
--- a/cmd/generate_changelog/incoming/2111.txt
+++ b/cmd/generate_changelog/incoming/2111.txt
@@ -1,0 +1,7 @@
+### PR [#2111](https://github.com/danielmiessler/Fabric/pull/2111) by [ksylvan](https://github.com/ksylvan): fix: omit Anthropic sampling params for Claude Opus 4.7
+
+- Fix: Omit Anthropic sampling parameters for Claude Opus 4.7 to ensure compatibility.
+- Add a sampling parameter guard specifically for Opus 4.7.
+- Omit `temperature` and `top_p` for models that do not support these parameters.
+- Preserve existing `TopP` and temperature selection behavior for compatible models.
+- Add unit test coverage for the Opus 4.7 sampling parameter omission.

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -24,6 +24,12 @@ const webSearchToolName = "web_search"
 const webSearchToolType = "web_search_20250305"
 const sourcesHeader = "## Sources"
 
+func modelDisallowsSamplingParams(model string) bool {
+	// Anthropic's Opus 4.7 models reject non-default sampling parameters.
+	// Omit these params entirely for safest compatibility.
+	return strings.HasPrefix(model, "claude-opus-4-7")
+}
+
 func NewClient() (ret *Client) {
 	vendorName := "Anthropic"
 	ret = &Client{}
@@ -222,9 +228,10 @@ func (an *Client) buildMessageParams(msgs []anthropic.MessageParam, opts *domain
 		Messages:  msgs,
 	}
 
-	// Only set one of Temperature or TopP as some models don't allow both
-	// Always set temperature to ensure consistent behavior (Anthropic default is 1.0, Fabric default is 0.7)
-	if opts.TopP != domain.DefaultTopP {
+	// Claude Opus 4.7 disallows sampling params; omit both temperature and top_p.
+	if modelDisallowsSamplingParams(opts.Model) {
+		// Intentionally omit both fields.
+	} else if opts.TopP != domain.DefaultTopP {
 		// User explicitly set TopP, so use that instead of temperature
 		params.TopP = anthropic.Opt(opts.TopP)
 	} else {

--- a/internal/plugins/ai/anthropic/anthropic_test.go
+++ b/internal/plugins/ai/anthropic/anthropic_test.go
@@ -170,6 +170,29 @@ func TestBuildMessageParams_WithSearchAndLocation(t *testing.T) {
 	}
 }
 
+func TestBuildMessageParams_Opus47OmitsSamplingParams(t *testing.T) {
+	client := NewClient()
+	opts := &domain.ChatOptions{
+		Model:       string(anthropic.ModelClaudeOpus4_7),
+		Temperature: 0.8,
+		TopP:        0.8,
+		Search:      false,
+	}
+
+	messages := []anthropic.MessageParam{
+		anthropic.NewUserMessage(anthropic.NewTextBlock("Hello")),
+	}
+
+	params := client.buildMessageParams(messages, opts)
+
+	if params.Temperature.Value != 0 {
+		t.Errorf("expected temperature to be omitted for %s, got %f", opts.Model, params.Temperature.Value)
+	}
+	if params.TopP.Value != 0 {
+		t.Errorf("expected top_p to be omitted for %s, got %f", opts.Model, params.TopP.Value)
+	}
+}
+
 func TestModelBetasConfiguration(t *testing.T) {
 	client := NewClient()
 	model := string(anthropic.ModelClaudeSonnet4_20250514)


### PR DESCRIPTION
# fix: omit Anthropic sampling params for Claude Opus 4.7

Fixes #2109 

## Summary

This PR updates the Anthropic client to omit sampling parameters for Claude Opus 4.7 models. Anthropic rejects non-default sampling parameters for these models, so the request builder now skips both `temperature` and `top_p` when the selected model is an Opus 4.7 variant.

See https://platform.claude.com/docs/en/about-claude/models/migration-guide

## Files Changed

### `internal/plugins/ai/anthropic/anthropic.go`

Added model-specific handling for Claude Opus 4.7 models and updated message parameter construction to omit sampling settings when required.

### `internal/plugins/ai/anthropic/anthropic_test.go`

Added a unit test to verify that `temperature` and `top_p` are not included for Claude Opus 4.7 requests.

## Code Changes

### Added Opus 4.7 sampling parameter guard

A new helper identifies Anthropic models that should not receive sampling parameters:

```go
func modelDisallowsSamplingParams(model string) bool {
	// Anthropic's Opus 4.7 models reject non-default sampling parameters.
	// Omit these params entirely for safest compatibility.
	return strings.HasPrefix(model, "claude-opus-4-7")
}
```

### Updated Anthropic message parameter construction

The request builder now checks for models that disallow sampling parameters before applying `temperature` or `top_p`:

```go
// Claude Opus 4.7 disallows sampling params; omit both temperature and top_p.
if modelDisallowsSamplingParams(opts.Model) {
	// Intentionally omit both fields.
} else if opts.TopP != domain.DefaultTopP {
	// User explicitly set TopP, so use that instead of temperature
	params.TopP = anthropic.Opt(opts.TopP)
} else {
```

This preserves the existing behavior for all other Anthropic models:
- If `top_p` is explicitly set, use `top_p`.
- Otherwise, set `temperature` to maintain Fabric’s default behavior.

### Added regression test coverage

The new test verifies that sampling parameters are omitted when using `claude-opus-4-7`:

```go
func TestBuildMessageParams_Opus47OmitsSamplingParams(t *testing.T) {
	client := NewClient()
	opts := &domain.ChatOptions{
		Model:       string(anthropic.ModelClaudeOpus4_7),
		Temperature: 0.8,
		TopP:        0.8,
		Search:      false,
	}

	messages := []anthropic.MessageParam{
		anthropic.NewUserMessage(anthropic.NewTextBlock("Hello")),
	}

	params := client.buildMessageParams(messages, opts)

	if params.Temperature.Value != 0 {
		t.Errorf("expected temperature to be omitted for %s, got %f", opts.Model, params.Temperature.Value)
	}
	if params.TopP.Value != 0 {
		t.Errorf("expected top_p to be omitted for %s, got %f", opts.Model, params.TopP.Value)
	}
}
```

## Reason for Changes

Claude Opus 4.7 models reject requests that include non-default sampling parameters. The existing implementation always set either `temperature` or `top_p`, which could cause Anthropic API requests to fail for these models.

This change improves compatibility with Anthropic’s Opus 4.7 API requirements by omitting those fields entirely.

## Impact of Changes

- Fixes request failures for Claude Opus 4.7 models caused by unsupported sampling parameters.
- Maintains existing sampling behavior for non-Opus 4.7 Anthropic models.
- User-provided `temperature` and `top_p` values are intentionally ignored for Opus 4.7 models to keep requests valid.
- The model detection uses a prefix match, so future model identifiers beginning with `claude-opus-4-7` will automatically receive the same compatibility handling.

## Test Plan

- Added unit coverage for Claude Opus 4.7 sampling parameter omission.
- Recommended test command:

```bash
go test ./internal/plugins/ai/anthropic
```

- Additional recommended validation:
  - Send a chat request using a Claude Opus 4.7 model with custom `temperature` and `top_p` values and confirm the Anthropic API accepts the request.
  - Send a chat request using a non-Opus 4.7 Anthropic model and confirm existing sampling behavior is unchanged.

## Additional Notes

- This change assumes all model names with the `claude-opus-4-7` prefix share the same sampling parameter restriction.
- If Anthropic changes this behavior for future Opus 4.7 variants, the helper function can be adjusted to use a more specific allowlist or denylist.
