### PR TITLE
fix(server): correct SSE Content-Type header (text/readystream → text/event-stream)

### DIFF
--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -82,10 +82,9 @@ func (h *ChatHandler) HandleChat(c *gin.Context) {
 	log.Printf("Received chat request - Language: '%s', Prompts: %d", request.Language, len(request.Prompts))
 
 	// Set headers for SSE
-	c.Writer.Header().Set("Content-Type", "text/readystream")
+	c.Writer.Header().Set("Content-Type", "text/event-stream")
 	c.Writer.Header().Set("Cache-Control", "no-cache")
 	c.Writer.Header().Set("Connection", "keep-alive")
-	c.Writer.Header().Set("Access-Control-Allow-Origin", "http://localhost:5173")
 	c.Writer.Header().Set("X-Accel-Buffering", "no")
 
 	clientGone := c.Writer.CloseNotify()


### PR DESCRIPTION
## What

The `/chat` SSE endpoint sets `Content-Type: text/readystream`, which is not a valid MIME type.

## Why it matters

Strict SSE clients — including browser `EventSource`, Tauri WebView2, and some reverse proxies — check the `Content-Type` header before parsing the stream. An invalid type causes them to treat the response as a plain HTTP body rather than an event stream, breaking streaming entirely for those clients.

The correct MIME type for Server-Sent Events is `text/event-stream` (per the WHATWG SSE spec).

This also removes a hardcoded `Access-Control-Allow-Origin: http://localhost:5173` header on the same handler, which has no effect in production and points to a specific dev-server port.

## Change

`internal/server/chat.go` — one-line fix to the Content-Type string, remove stale CORS header.