### PR TITLE
fix(core): always append user message in BuildSession

### DIFF
--- a/internal/core/chatter.go
+++ b/internal/core/chatter.go
@@ -261,7 +261,6 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 	}
 
 	var patternContent string
-	inputUsed := false
 	if request.PatternName != "" {
 		var pattern *fsdb.Pattern
 		if request.NoVariableReplacement {
@@ -274,7 +273,6 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 			return nil, fmt.Errorf(i18n.T("chatter_error_get_pattern"), request.PatternName, err)
 		}
 		patternContent = pattern.Pattern
-		inputUsed = true
 	}
 
 	systemMessage := joinPromptSections(contextContent, patternContent)
@@ -338,9 +336,9 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 		if systemMessage != "" {
 			session.Append(&chat.ChatCompletionMessage{Role: chat.ChatMessageRoleSystem, Content: systemMessage})
 		}
-		// If multi-part content, it is in the user message, and should be added.
-		// Otherwise, we should only add it if we have not already used it in the systemMessage.
-		if len(request.Message.MultiContent) > 0 || (request.Message != nil && !inputUsed) {
+		// Always include the user message: chat-completion APIs (OpenAI, llama.cpp, etc.)
+		// require at least one user turn; a system-only session causes silent hangs.
+		if len(request.Message.MultiContent) > 0 || request.Message != nil {
 			session.Append(request.Message)
 		}
 	}


### PR DESCRIPTION
## What

Removes the `inputUsed` flag from `BuildSession` so that the user message is always appended to the session, even when a pattern is loaded.

## Why it matters

Chat-completion APIs — including OpenAI, llama.cpp, and any other strict implementation — require at least one `user`-role message in every request. The spec does not allow a session consisting only of a `system` message.

**Current behaviour**: when a pattern is selected, `BuildSession` sets `inputUsed = true` and then skips appending the user message via `!inputUsed`. The result is a system-only session that causes silent hangs on llama.cpp and will fail on other strict servers.

**Fixed behaviour**: `inputUsed` is removed entirely. The user message is always appended. This matches what every compliant chat-completion server expects.

## Change

`internal/core/chatter.go` — remove `inputUsed` variable and simplify the append condition.

Note: `TestChatter_BuildSession_SeparatesSystemSections` fails in this environment due to a missing `test-strategy` file — this failure is pre-existing on `main` and unrelated to this change.