### PR TITLE
chore: extend sampling param exclusion to Opus 4.8 models

### DIFF
--- a/cmd/generate_changelog/incoming/2136.txt
+++ b/cmd/generate_changelog/incoming/2136.txt
@@ -1,0 +1,35 @@
+GitHub unexpected status code: 429 from provider GitHub, response body: <html>
+  <head>
+    <meta content="origin" name="referrer">
+    <title>Rate limit &middot; GitHub</title>
+    <meta name="viewport" content="width=device-width">
+    <style type="text/css" media="screen">
+      body {
+        background-color: #f6f8fa;
+        color: rgba(0, 0, 0, 0.5);
+        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
+        font-size: 14px;
+        line-height: 1.5;
+      }
+      .c { margin: 50px auto; max-width: 600px; text-align: center; padding: 0 24px; }
+      a { text-decoration: none; }
+      a:hover { text-decoration: underline; }
+      h1 { color: #24292e; line-height: 60px; font-size: 48px; font-weight: 300; margin: 0px; }
+      p { margin: 20px 0 40px; }
+      #s { margin-top: 35px; }
+      #s a {
+        color: #666666;
+        font-weight: 200;
+        font-size: 14px;
+        margin: 0 10px;
+      }
+    </style>
+  </head>
+  <body>
+    <div class="c">
+      <h1>Whoa there!</h1>
+      <p>Y
+### PR [#2136](https://github.com/danielmiessler/Fabric/pull/2136) by [ksylvan](https://github.com/ksylvan): chore: extend sampling param exclusion to Opus 4.8 models
+
+- Extended sampling parameter exclusion logic to cover Opus 4.8 models, matching the `claude-opus-4-8` model prefix alongside the existing `claude-opus-4-7` prefix.
+- Updated the relevant code comment to explicitly reference both Opus 4.7 and Opus 4.8 models for improved clarity.

--- a/cmd/generate_changelog/incoming/2136.txt
+++ b/cmd/generate_changelog/incoming/2136.txt
@@ -1,35 +1,5 @@
-GitHub unexpected status code: 429 from provider GitHub, response body: <html>
-  <head>
-    <meta content="origin" name="referrer">
-    <title>Rate limit &middot; GitHub</title>
-    <meta name="viewport" content="width=device-width">
-    <style type="text/css" media="screen">
-      body {
-        background-color: #f6f8fa;
-        color: rgba(0, 0, 0, 0.5);
-        font-family: -apple-system,BlinkMacSystemFont,Segoe UI,Helvetica,Arial,sans-serif,Apple Color Emoji,Segoe UI Emoji,Segoe UI Symbol;
-        font-size: 14px;
-        line-height: 1.5;
-      }
-      .c { margin: 50px auto; max-width: 600px; text-align: center; padding: 0 24px; }
-      a { text-decoration: none; }
-      a:hover { text-decoration: underline; }
-      h1 { color: #24292e; line-height: 60px; font-size: 48px; font-weight: 300; margin: 0px; }
-      p { margin: 20px 0 40px; }
-      #s { margin-top: 35px; }
-      #s a {
-        color: #666666;
-        font-weight: 200;
-        font-size: 14px;
-        margin: 0 10px;
-      }
-    </style>
-  </head>
-  <body>
-    <div class="c">
-      <h1>Whoa there!</h1>
-      <p>Y
 ### PR [#2136](https://github.com/danielmiessler/Fabric/pull/2136) by [ksylvan](https://github.com/ksylvan): chore: extend sampling param exclusion to Opus 4.8 models
 
-- Extended sampling parameter exclusion logic to cover Opus 4.8 models, matching the `claude-opus-4-8` model prefix alongside the existing `claude-opus-4-7` prefix.
-- Updated the relevant code comment to explicitly reference both Opus 4.7 and Opus 4.8 models for improved clarity.
+- Extends the sampling parameter exclusion logic to cover Opus 4.8 models, ensuring consistent behavior alongside the existing Opus 4.7 exclusion.
+- Adds the `claude-opus-4-8` model prefix to the sampling parameter exclusion check.
+- Updates the associated code comment to explicitly reference Opus 4.8 models.

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -25,9 +25,9 @@ const webSearchToolType = "web_search_20250305"
 const sourcesHeader = "## Sources"
 
 func modelDisallowsSamplingParams(model string) bool {
-	// Anthropic's Opus 4.7 models reject non-default sampling parameters.
+	// Anthropic's Opus 4.7 and Opus 4.8 models reject non-default sampling parameters.
 	// Omit these params entirely for safest compatibility.
-	return strings.HasPrefix(model, "claude-opus-4-7")
+	return strings.HasPrefix(model, "claude-opus-4-7") || strings.HasPrefix(model, "claude-opus-4-8")
 }
 
 func NewClient() (ret *Client) {


### PR DESCRIPTION
## What this Pull Request (PR) does

- Add Opus 4.8 to sampling param exclusion check
- Update comment to mention Opus 4.8 models
- Match `claude-opus-4-8` model prefix alongside 4.7

