### PR TITLE
middleware: add NormalizeInputShape to handle system-only message arrays

### DIFF
--- a/cmd/generate_changelog/incoming/2137.txt
+++ b/cmd/generate_changelog/incoming/2137.txt
@@ -1,0 +1,7 @@
+### PR [#2137](https://github.com/danielmiessler/Fabric/pull/2137) by [genevera](https://github.com/genevera): middleware: add NormalizeInputShape to handle system-only message arrays
+
+- Added NormalizeInputShape middleware to handle system-only message arrays, since backends like vLLM and some Bedrock endpoints reject requests containing only system-role messages.
+- Made NormalizeInputShape idempotent: when a user message is already present it is a no-op, otherwise it promotes the last system message to a user message to satisfy strict backends.
+- Prevented silent session-history mutation by returning a new slice with a cloned last message instead of mutating the caller's slice in place.
+- Added nil safety by skipping nil messages during the scan and when selecting the last system message to promote.
+- Added regression and comprehensive tests covering mutation safety and nil-message handling across all edge cases.

--- a/internal/core/chatter.go
+++ b/internal/core/chatter.go
@@ -108,7 +108,7 @@ func (o *Chatter) Send(ctx context.Context, request *domain.ChatRequest, opts *d
 
 		go func() {
 			defer close(done)
-			if streamErr := o.vendor.SendStream(ctx, session.GetVendorMessages(), opts, responseChan); streamErr != nil {
+			if streamErr := o.vendor.SendStream(ctx, vendorMessages, opts, responseChan); streamErr != nil {
 				recordFirstStreamError(errChan, streamErr)
 			}
 		}()
@@ -169,7 +169,7 @@ func (o *Chatter) Send(ctx context.Context, request *domain.ChatRequest, opts *d
 			// No errors, continue
 		}
 	} else {
-		if message, err = o.vendor.Send(ctx, session.GetVendorMessages(), opts); err != nil {
+		if message, err = o.vendor.Send(ctx, vendorMessages, opts); err != nil {
 			return
 		}
 		if debuglog.GetLevel() >= debuglog.Wire {

--- a/internal/core/chatter.go
+++ b/internal/core/chatter.go
@@ -68,6 +68,7 @@ func (o *Chatter) Send(ctx context.Context, request *domain.ChatRequest, opts *d
 	}
 
 	vendorMessages := session.GetVendorMessages()
+	vendorMessages = domain.NormalizeInputShape(vendorMessages)
 
 	if debuglog.GetLevel() >= debuglog.Wire {
 		debuglog.Debug(debuglog.Wire, "FABRIC->LLM request messages (%d)\n", len(vendorMessages))

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -65,16 +65,32 @@ type ChatOptions struct {
 // the API contract.
 //
 // The function is idempotent: arrays that already contain a user message are
-// returned unchanged.
+// returned unchanged (returning the original slice). When no user message
+// exists, a new slice is returned with the last system message cloned and
+// its role changed to user.
 func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatCompletionMessage {
 	if len(msgs) == 0 {
 		return msgs
 	}
 
+	// Scan for existing user message, skipping nil entries.
 	for _, msg := range msgs {
-		if msg.Role == chat.ChatMessageRoleUser {
+		if msg != nil && msg.Role == chat.ChatMessageRoleUser {
 			return msgs
 		}
+	}
+
+	// Find the last non-nil system message to promote.
+	var lastIdx int
+	for i := len(msgs) - 1; i >= 0; i-- {
+		if msgs[i] != nil {
+			lastIdx = i
+			break
+		}
+	}
+	// If all entries are nil, return original slice (nothing to promote).
+	if lastIdx < 0 || msgs[lastIdx] == nil {
+		return msgs
 	}
 
 	// Build a new slice so the caller's original is not mutated.
@@ -83,11 +99,11 @@ func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatComplet
 	ret := make([]*chat.ChatCompletionMessage, len(msgs))
 	copy(ret, msgs)
 
-	// Clone the last message (shallow copy is sufficient since we only change Role).
-	orig := ret[len(ret)-1]
+	// Clone the last non-nil message (shallow copy is sufficient since we only change Role).
+	orig := ret[lastIdx]
 	newMsg := *orig
 	newMsg.Role = chat.ChatMessageRoleUser
-	ret[len(ret)-1] = &newMsg
+	ret[lastIdx] = &newMsg
 	return ret
 }
 

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -77,10 +77,23 @@ func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatComplet
 		}
 	}
 
-	msgs[len(msgs)-1].Role = chat.ChatMessageRoleUser
-	return msgs
+	// Build a new slice so the caller's original is not mutated.
+	// This prevents side effects when the caller reuses the slice
+	// as session history or passes it to multiple consumers.
+	ret := make([]*chat.ChatCompletionMessage, len(msgs))
+	copy(ret, msgs)
+
+	// Clone the last message (shallow copy is sufficient since we only change Role).
+	orig := ret[len(ret)-1]
+	newMsg := *orig
+	newMsg.Role = chat.ChatMessageRoleUser
+	ret[len(ret)-1] = &newMsg
+	return ret
 }
 
+// NormalizeMessages iterates over messages to enforce the odd-position rule for user
+// messages. Empty messages are dropped. When an even position would not contain a user
+// message, a synthetic user message with the provided default content is inserted.
 func NormalizeMessages(msgs []*chat.ChatCompletionMessage, defaultUserMessage string) (ret []*chat.ChatCompletionMessage) {
 	// Iterate over messages to enforce the odd position rule for user messages
 	fullMessageIndex := 0

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -60,13 +60,13 @@ type ChatOptions struct {
 // message. Some LLM backends (vLLM, certain Bedrock endpoints) reject
 // requests that contain only system-role messages.
 //
-// When all messages are system, the last system message is promoted to user.
-// This keeps the instructional content semantically similar while satisfying
-// the API contract.
+// When no user-role message exists, the last non-nil message (regardless of role)
+// is promoted to user. This keeps the instructional content semantically similar
+// while satisfying the API contract.
 //
 // The function is idempotent: arrays that already contain a user message are
 // returned unchanged (returning the original slice). When no user message
-// exists, a new slice is returned with the last system message cloned and
+// exists, a new slice is returned with the last non-nil message cloned and
 // its role changed to user.
 func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatCompletionMessage {
 	if len(msgs) == 0 {
@@ -80,7 +80,7 @@ func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatComplet
 		}
 	}
 
-	// Find the last non-nil system message to promote.
+	// Find the last non-nil message to promote.
 	var lastIdx int
 	for i := len(msgs) - 1; i >= 0; i-- {
 		if msgs[i] != nil {
@@ -93,13 +93,13 @@ func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatComplet
 		return msgs
 	}
 
-	// Build a new slice so the caller's original is not mutated.
+	// Build a new slice so the caller's original is not mutated (ret).
 	// This prevents side effects when the caller reuses the slice
 	// as session history or passes it to multiple consumers.
 	ret := make([]*chat.ChatCompletionMessage, len(msgs))
 	copy(ret, msgs)
 
-	// Clone the last non-nil message (shallow copy is sufficient since we only change Role).
+	// Clone the last non-nil message (orig, shallow copy is sufficient since we only change Role).
 	orig := ret[lastIdx]
 	newMsg := *orig
 	newMsg.Role = chat.ChatMessageRoleUser

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -81,7 +81,7 @@ func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatComplet
 	}
 
 	// Find the last non-nil message to promote.
-	var lastIdx int
+	lastIdx := -1
 	for i := len(msgs) - 1; i >= 0; i-- {
 		if msgs[i] != nil {
 			lastIdx = i
@@ -89,7 +89,7 @@ func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatComplet
 		}
 	}
 	// If all entries are nil, return original slice (nothing to promote).
-	if lastIdx < 0 || msgs[lastIdx] == nil {
+	if lastIdx < 0 {
 		return msgs
 	}
 

--- a/internal/domain/domain.go
+++ b/internal/domain/domain.go
@@ -56,7 +56,31 @@ type ChatOptions struct {
 	UpdateChan          chan StreamUpdate `json:"-"`
 }
 
-// NormalizeMessages remove empty messages and ensure messages order user-assist-user
+// NormalizeInputShape ensures every message array has at least one user-role
+// message. Some LLM backends (vLLM, certain Bedrock endpoints) reject
+// requests that contain only system-role messages.
+//
+// When all messages are system, the last system message is promoted to user.
+// This keeps the instructional content semantically similar while satisfying
+// the API contract.
+//
+// The function is idempotent: arrays that already contain a user message are
+// returned unchanged.
+func NormalizeInputShape(msgs []*chat.ChatCompletionMessage) []*chat.ChatCompletionMessage {
+	if len(msgs) == 0 {
+		return msgs
+	}
+
+	for _, msg := range msgs {
+		if msg.Role == chat.ChatMessageRoleUser {
+			return msgs
+		}
+	}
+
+	msgs[len(msgs)-1].Role = chat.ChatMessageRoleUser
+	return msgs
+}
+
 func NormalizeMessages(msgs []*chat.ChatCompletionMessage, defaultUserMessage string) (ret []*chat.ChatCompletionMessage) {
 	// Iterate over messages to enforce the odd position rule for user messages
 	fullMessageIndex := 0

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -122,7 +122,8 @@ func TestNormalizeInputShapeWithNilMessages(t *testing.T) {
 	// Test nil at beginning, user later - should return original slice (has user)
 	in1 := []*chat.ChatCompletionMessage{nil, sys("sys1"), usr("user1")}
 	got1 := NormalizeInputShape(in1)
-	assert.Equal(t, in1, got1) // Should return original slice (has user)
+	assert.Equal(t, in1, got1) // deep equality
+	assert.True(t, &in1[0] == &got1[0], "Should return original slice (same backing array)")
 
 	// Test nil at end, no user - should promote last non-nil system
 	in2 := []*chat.ChatCompletionMessage{sys("sys1"), sys("sys2"), nil}
@@ -138,10 +139,12 @@ func TestNormalizeInputShapeWithNilMessages(t *testing.T) {
 	// Test all nil
 	in3 := []*chat.ChatCompletionMessage{nil, nil, nil}
 	got3 := NormalizeInputShape(in3)
-	assert.Equal(t, in3, got3) // Should return original slice
+	assert.Equal(t, in3, got3) // deep equality
+	assert.True(t, &in3[0] == &got3[0], "Should return original slice (same backing array)")
 
 	// Test nil mixed with user (should return early due to user)
 	in4 := []*chat.ChatCompletionMessage{nil, usr("user1"), nil}
 	got4 := NormalizeInputShape(in4)
-	assert.Equal(t, in4, got4) // Should return original slice (has user)
+	assert.Equal(t, in4, got4) // deep equality
+	assert.True(t, &in4[0] == &got4[0], "Should return original slice (same backing array)")
 }

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -105,3 +105,14 @@ func TestNormalizeInputShape(t *testing.T) {
 		})
 	}
 }
+
+// Regression: ensure NormalizeInputShape does not mutate the caller's slice
+// or the message structs it points to (Copilot PR review #2137).
+func TestNormalizeInputShapeDoesNotMutateOriginal(t *testing.T) {
+	orig := []*chat.ChatCompletionMessage{sys("instruction")}
+	got := NormalizeInputShape(orig)
+	assert.Equal(t, chat.ChatMessageRoleUser, got[0].Role,
+		"normalized message should be user")
+	assert.Equal(t, chat.ChatMessageRoleSystem, orig[0].Role,
+		"original message should remain system")
+}

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -25,3 +25,83 @@ func TestNormalizeMessages(t *testing.T) {
 	actual := NormalizeMessages(msgs, "default")
 	assert.Equal(t, expected, actual)
 }
+
+func sys(c string) *chat.ChatCompletionMessage {
+	return &chat.ChatCompletionMessage{Role: chat.ChatMessageRoleSystem, Content: c}
+}
+
+func usr(c string) *chat.ChatCompletionMessage {
+	return &chat.ChatCompletionMessage{Role: chat.ChatMessageRoleUser, Content: c}
+}
+
+func asst(c string) *chat.ChatCompletionMessage {
+	return &chat.ChatCompletionMessage{Role: chat.ChatMessageRoleAssistant, Content: c}
+}
+
+func TestNormalizeInputShape(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []*chat.ChatCompletionMessage
+		want []*chat.ChatCompletionMessage
+	}{
+		{
+			// Single system message -- the most common failing case
+			name: "bare system",
+			in:   []*chat.ChatCompletionMessage{sys("instr")},
+			want: []*chat.ChatCompletionMessage{usr("instr")},
+		},
+		{
+			// Multiple system messages -- last one promoted to user
+			name: "multiple systems",
+			in:   []*chat.ChatCompletionMessage{sys("a"), sys("b")},
+			want: []*chat.ChatCompletionMessage{sys("a"), usr("b")},
+		},
+		{
+			// Already has user message -- unchanged
+			name: "system + user",
+			in:   []*chat.ChatCompletionMessage{sys("instr"), usr("input")},
+			want: []*chat.ChatCompletionMessage{sys("instr"), usr("input")},
+		},
+		{
+			// Multi-turn session -- unchanged
+			name: "multi-turn",
+			in:   []*chat.ChatCompletionMessage{sys("instr"), usr("q1"), asst("a1"), usr("q2")},
+			want: []*chat.ChatCompletionMessage{sys("instr"), usr("q1"), asst("a1"), usr("q2")},
+		},
+		{
+			// User only -- unchanged
+			name: "user only",
+			in:   []*chat.ChatCompletionMessage{usr("hello")},
+			want: []*chat.ChatCompletionMessage{usr("hello")},
+		},
+		{
+			// Session continuation -- unchanged
+			name: "assistant then user",
+			in:   []*chat.ChatCompletionMessage{asst("a"), usr("q")},
+			want: []*chat.ChatCompletionMessage{asst("a"), usr("q")},
+		},
+		{
+			// Empty -- unchanged
+			name: "empty",
+			in:   []*chat.ChatCompletionMessage{},
+			want: []*chat.ChatCompletionMessage{},
+		},
+		{
+			// System, assistant, system -- last system promoted
+			name: "sys-asst-sys",
+			in:   []*chat.ChatCompletionMessage{sys("s"), asst("a"), sys("s2")},
+			want: []*chat.ChatCompletionMessage{sys("s"), asst("a"), usr("s2")},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeInputShape(tt.in)
+			assert.Len(t, got, len(tt.want))
+			for i := range got {
+				assert.Equal(t, tt.want[i].Role, got[i].Role)
+				assert.Equal(t, tt.want[i].Content, got[i].Content)
+			}
+		})
+	}
+}

--- a/internal/domain/domain_test.go
+++ b/internal/domain/domain_test.go
@@ -95,6 +95,7 @@ func TestNormalizeInputShape(t *testing.T) {
 	}
 
 	for _, tt := range tests {
+		tt := tt // Capture range variable
 		t.Run(tt.name, func(t *testing.T) {
 			got := NormalizeInputShape(tt.in)
 			assert.Len(t, got, len(tt.want))
@@ -115,4 +116,32 @@ func TestNormalizeInputShapeDoesNotMutateOriginal(t *testing.T) {
 		"normalized message should be user")
 	assert.Equal(t, chat.ChatMessageRoleSystem, orig[0].Role,
 		"original message should remain system")
+}
+
+func TestNormalizeInputShapeWithNilMessages(t *testing.T) {
+	// Test nil at beginning, user later - should return original slice (has user)
+	in1 := []*chat.ChatCompletionMessage{nil, sys("sys1"), usr("user1")}
+	got1 := NormalizeInputShape(in1)
+	assert.Equal(t, in1, got1) // Should return original slice (has user)
+
+	// Test nil at end, no user - should promote last non-nil system
+	in2 := []*chat.ChatCompletionMessage{sys("sys1"), sys("sys2"), nil}
+	got2 := NormalizeInputShape(in2)
+	assert.Len(t, got2, 3)
+	assert.Equal(t, sys("sys1"), got2[0])
+	// Last non-nil (sys2) should be promoted to user
+	expectedPromoted := usr("sys2")
+	assert.Equal(t, expectedPromoted.Role, got2[1].Role)
+	assert.Equal(t, expectedPromoted.Content, got2[1].Content)
+	assert.Equal(t, (*chat.ChatCompletionMessage)(nil), got2[2])
+
+	// Test all nil
+	in3 := []*chat.ChatCompletionMessage{nil, nil, nil}
+	got3 := NormalizeInputShape(in3)
+	assert.Equal(t, in3, got3) // Should return original slice
+
+	// Test nil mixed with user (should return early due to user)
+	in4 := []*chat.ChatCompletionMessage{nil, usr("user1"), nil}
+	got4 := NormalizeInputShape(in4)
+	assert.Equal(t, in4, got4) // Should return original slice (has user)
 }


### PR DESCRIPTION
## What this Pull Request (PR) does

Some LLM backends (vLLM, certain Bedrock endpoints) reject requests that contain only system-role messages. NormalizeInputShape promotes the last system message to user when no user message is present, which transparently handles the case where a pattern absorbs {{input}} into its system message.

- domain.NormalizeInputShape is idempotent (no-op when user present)
- Called at the session boundary before vendor.Send()
- Makes the DeepSeek system-to-user fallback redundant
- 8 test cases covering all edge cases