### PR TITLE
fix: include Grok in --search help text, completions, and locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -719,7 +719,7 @@ Application Options:
       --liststrategies              List all strategies
       --listvendors                 List all vendors
       --shell-complete-list         Output raw list without headers/formatting (for shell completion)
-      --search                      Enable web search tool for supported models (Anthropic, OpenAI, Gemini)
+      --search                      Enable web search tool for supported models (Anthropic, OpenAI, Gemini, Grok)
       --search-location=            Set location for web search results (e.g., 'America/Los_Angeles')
       --image-file=                 Save generated image to specified file path (e.g., 'output.png')
       --image-size=                 Image dimensions: 1024x1024, 1536x1024, 1024x1536, auto (default: auto)

--- a/cmd/generate_changelog/incoming/2140.txt
+++ b/cmd/generate_changelog/incoming/2140.txt
@@ -1,0 +1,14 @@
+### PR [#2140](https://github.com/danielmiessler/Fabric/pull/2140) by [Resistor52](https://github.com/Resistor52): fix: include Grok in --search help text, completions, and locales
+
+- Fix: include Grok in --search help text, completions, and locales
+PR #2092 added Grok (xAI) web search support and updated the go-flags
+struct tag in internal/cli/flags.go, but `fabric --help` renders flag
+descriptions from the i18n message catalog (internal/cli/help.go maps
+"search" -> "enable_web_search_tool"), not from the struct tag. The
+catalog value was never updated, so --help, the zsh/fish completions,
+and the README help block still listed only Anthropic, OpenAI, Gemini,
+leaving the Grok support undiscoverable even though it works.
+Append "Grok" to the enable_web_search_tool value in all 11 locales
+(matching each locale's list separator), the zsh and fish completions,
+and the generated README help block. No functional change.
+Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

--- a/completions/_fabric
+++ b/completions/_fabric
@@ -126,7 +126,7 @@ _fabric() {
     '(--api-key)--api-key[API key used to secure server routes]:api-key:' \
     '(--config)--config[Path to YAML config file]:config file:_files -g "*.yaml *.yml"' \
     '(--version)--version[Print current version]' \
-    '(--search)--search[Enable web search tool for supported models (Anthropic, OpenAI, Gemini)]' \
+    '(--search)--search[Enable web search tool for supported models (Anthropic, OpenAI, Gemini, Grok)]' \
     '(--search-location)--search-location[Set location for web search results]:location:' \
     '(--image-file)--image-file[Save generated image to specified file path]:image file:_files -g "*.png *.webp *.jpeg *.jpg"' \
     '(--image-size)--image-size[Image dimensions]:size:(1024x1024 1536x1024 1024x1536 auto)' \

--- a/completions/fabric.fish
+++ b/completions/fabric.fish
@@ -128,7 +128,7 @@ function __fabric_register_completions
         complete -c $cmd -l input-has-vars -d "Apply variables to user input"
         complete -c $cmd -l no-variable-replacement -d "Disable pattern variable replacement"
         complete -c $cmd -l dry-run -d "Show what would be sent to the model without actually sending it"
-        complete -c $cmd -l search -d "Enable web search tool for supported models (Anthropic, OpenAI, Gemini)"
+        complete -c $cmd -l search -d "Enable web search tool for supported models (Anthropic, OpenAI, Gemini, Grok)"
         complete -c $cmd -l serve -d "Serve the Fabric Rest API"
         complete -c $cmd -l serveOllama -d "Serve the Fabric Rest API with ollama endpoints"
         complete -c $cmd -l version -d "Print current version"

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "DigitalOcean-Modellanfrage fehlgeschlagen mit Status %d: %s",
   "disable_openai_responses_api": "OpenAI Responses API deaktivieren (Standard: false)",
   "disable_pattern_variable_replacement": "Mustervariablenersetzung deaktivieren",
-  "enable_web_search_tool": "Web-Such-Tool für unterstützte Modelle aktivieren (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Web-Such-Tool für unterstützte Modelle aktivieren (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "End-Tag für Denk-Abschnitte",
   "error_creating_audio_file": "Fehler beim Erstellen der Audio-Datei: %v",
   "error_creating_file": "Fehler beim Erstellen der Datei: %v",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "DigitalOcean models request failed with status %d: %s",
   "disable_openai_responses_api": "Disable OpenAI Responses API (default: false)",
   "disable_pattern_variable_replacement": "Disable pattern variable replacement",
-  "enable_web_search_tool": "Enable web search tool for supported models (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Enable web search tool for supported models (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "End tag for thinking sections",
   "error_creating_audio_file": "error creating audio file: %v",
   "error_creating_file": "error creating file: %v",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "solicitud de modelos de DigitalOcean falló con estado %d: %s",
   "disable_openai_responses_api": "Deshabilitar API de Respuestas de OpenAI (predeterminado: false)",
   "disable_pattern_variable_replacement": "Deshabilitar reemplazo de variables de patrón",
-  "enable_web_search_tool": "Habilitar herramienta de búsqueda web para modelos soportados (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Habilitar herramienta de búsqueda web para modelos soportados (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Etiqueta de fin para secciones de pensamiento",
   "error_creating_audio_file": "error al crear el archivo de audio: %v",
   "error_creating_file": "error al crear el archivo: %v",

--- a/internal/i18n/locales/fa.json
+++ b/internal/i18n/locales/fa.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "درخواست مدل‌های DigitalOcean با وضعیت %d ناموفق بود: %s",
   "disable_openai_responses_api": "غیرفعال کردن API OpenAI Responses (پیش‌فرض: false)",
   "disable_pattern_variable_replacement": "غیرفعال کردن جایگزینی متغیرهای الگو",
-  "enable_web_search_tool": "فعال‌سازی ابزار جستجوی وب برای مدل‌های پشتیبانی شده (Anthropic، OpenAI، Gemini)",
+  "enable_web_search_tool": "فعال‌سازی ابزار جستجوی وب برای مدل‌های پشتیبانی شده (Anthropic، OpenAI، Gemini، Grok)",
   "end_tag_thinking_sections": "تگ پایان برای بخش‌های تفکر",
   "error_creating_audio_file": "خطا در ایجاد فایل صوتی: %v",
   "error_creating_file": "خطا در ایجاد فایل: %v",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "échec de la requête de modèles DigitalOcean avec le statut %d : %s",
   "disable_openai_responses_api": "Désactiver l'API OpenAI Responses (par défaut : false)",
   "disable_pattern_variable_replacement": "Désactiver le remplacement des variables de motif",
-  "enable_web_search_tool": "Activer l'outil de recherche web pour les modèles pris en charge (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Activer l'outil de recherche web pour les modèles pris en charge (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Balise de fin pour les sections de réflexion",
   "error_creating_audio_file": "erreur lors de la création du fichier audio : %v",
   "error_creating_file": "erreur lors de la création du fichier : %v",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "richiesta modelli DigitalOcean fallita con stato %d: %s",
   "disable_openai_responses_api": "Disabilita API OpenAI Responses (predefinito: false)",
   "disable_pattern_variable_replacement": "Disabilita sostituzione variabili pattern",
-  "enable_web_search_tool": "Abilita strumento di ricerca web per modelli supportati (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Abilita strumento di ricerca web per modelli supportati (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Tag di fine per sezioni di pensiero",
   "error_creating_audio_file": "errore nella creazione del file audio: %v",
   "error_creating_file": "errore nella creazione del file: %v",

--- a/internal/i18n/locales/ja.json
+++ b/internal/i18n/locales/ja.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "DigitalOceanモデルリクエストがステータス%dで失敗しました: %s",
   "disable_openai_responses_api": "OpenAI Responses APIを無効化（デフォルト：false）",
   "disable_pattern_variable_replacement": "パターン変数の置換を無効化",
-  "enable_web_search_tool": "サポートされているモデル（Anthropic、OpenAI、Gemini）でウェブ検索ツールを有効化",
+  "enable_web_search_tool": "サポートされているモデル（Anthropic、OpenAI、Gemini、Grok）でウェブ検索ツールを有効化",
   "end_tag_thinking_sections": "思考セクションの終了タグ",
   "error_creating_audio_file": "音声ファイルの作成エラー: %v",
   "error_creating_file": "ファイルの作成エラー: %v",

--- a/internal/i18n/locales/pl.json
+++ b/internal/i18n/locales/pl.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "Żądanie modeli DigitalOcean nie powiodło się ze statusem %d: %s",
   "disable_openai_responses_api": "Wyłącz API odpowiedzi OpenAI (domyślnie: false)",
   "disable_pattern_variable_replacement": "Wyłącz zastępowanie zmiennych wzorców",
-  "enable_web_search_tool": "Włącz narzędzie wyszukiwania internetowego dla obsługiwanych modeli (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Włącz narzędzie wyszukiwania internetowego dla obsługiwanych modeli (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Tag końcowy dla sekcji myślenia",
   "error_creating_audio_file": "błąd podczas tworzenia pliku audio: %v",
   "error_creating_file": "błąd podczas tworzenia pliku: %v",

--- a/internal/i18n/locales/pt-BR.json
+++ b/internal/i18n/locales/pt-BR.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "requisição de modelos do DigitalOcean falhou com status %d: %s",
   "disable_openai_responses_api": "Desabilitar API OpenAI Responses (padrão: false)",
   "disable_pattern_variable_replacement": "Desabilitar substituição de variáveis de padrão",
-  "enable_web_search_tool": "Habilitar ferramenta de busca web para modelos suportados (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Habilitar ferramenta de busca web para modelos suportados (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Tag final para seções de pensamento",
   "error_creating_audio_file": "erro ao criar arquivo de áudio: %v",
   "error_creating_file": "erro ao criar arquivo: %v",

--- a/internal/i18n/locales/pt-PT.json
+++ b/internal/i18n/locales/pt-PT.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "pedido de modelos do DigitalOcean falhou com estado %d: %s",
   "disable_openai_responses_api": "Desabilitar API OpenAI Responses (por omissão: false)",
   "disable_pattern_variable_replacement": "Desabilitar substituição de variáveis de padrão",
-  "enable_web_search_tool": "Habilitar ferramenta de pesquisa web para modelos suportados (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Habilitar ferramenta de pesquisa web para modelos suportados (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Tag final para secções de pensamento",
   "error_creating_audio_file": "erro ao criar ficheiro de áudio: %v",
   "error_creating_file": "erro ao criar ficheiro: %v",

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "DigitalOcean 模型请求失败，状态码 %d：%s",
   "disable_openai_responses_api": "禁用 OpenAI 响应 API（默认：false）",
   "disable_pattern_variable_replacement": "禁用模式变量替换",
-  "enable_web_search_tool": "为支持的模型启用网络搜索工具（Anthropic、OpenAI、Gemini）",
+  "enable_web_search_tool": "为支持的模型启用网络搜索工具（Anthropic、OpenAI、Gemini、Grok）",
   "end_tag_thinking_sections": "思考部分的结束标签",
   "error_creating_audio_file": "创建音频文件时出错：%v",
   "error_creating_file": "创建文件时出错：%v",


### PR DESCRIPTION
## What

`--search` supports Grok (xAI) web search since #2092, but `fabric --help` still shows:

```
--search    Enable web search tool for supported models (Anthropic, OpenAI, Gemini)
```

The capability works (`-V GrokAI -m grok-4.3 --search` grounds correctly), but the help text, shell completions, and README still omit Grok, so the support is undiscoverable.

## Root cause

`--help` renders flag descriptions from the i18n message catalog, not the go-flags struct tag. `internal/cli/help.go` maps the flag to a key:

```go
"search": "enable_web_search_tool",
```

#2092 updated the struct tag in `internal/cli/flags.go` (`...Gemini, Grok)`) but not the catalog value, so the rendered help kept the old vendor list.

## Change

Append `Grok` to the `enable_web_search_tool` value in all 11 locales (matching each locale's list separator, including the full-width `、` for `ja`/`zh` and the Arabic comma for `fa`), the zsh and fish completions, and the generated README help block. No functional change; 14 files, one line each.

## Test plan

- `go build ./cmd/fabric && ./fabric --help | grep -- --search` now shows `(Anthropic, OpenAI, Gemini, Grok)`.
- `go test ./internal/i18n/...` passes.
- All locale JSON files validate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)