### PR TITLE
fix: handle carriage return input in interactive setup prompts

### DIFF
--- a/internal/plugins/plugin.go
+++ b/internal/plugins/plugin.go
@@ -2,6 +2,7 @@ package plugins
 
 import (
 	"bytes"
+	"bufio"
 	"fmt"
 	"os"
 	"strings"
@@ -226,7 +227,7 @@ func (o *SetupQuestion) Ask(label string) (err error) {
 		fmt.Printf(i18n.T("plugin_question_optional"), prefix, o.Question)
 	}
 	var answer string
-	fmt.Scanln(&answer)
+	answer, _ = readLine()
 	answer = strings.TrimRight(answer, "\n")
 	isReset := strings.ToLower(answer) == AnswerReset
 	if answer == "" {
@@ -347,4 +348,23 @@ func BuildEnvVariable(name string) string {
 	name = strings.ReplaceAll(name, " ", "_")
 	name = strings.ReplaceAll(name, "-", "_")
 	return name
+}
+
+// readLine reads a single line from stdin, handling both \n and \r line endings.
+// This fixes interactive input on terminals (e.g. kitty, some macOS terminals)
+// that send \r instead of \n when the user presses Enter.
+func readLine() (string, error) {
+	reader := bufio.NewReader(os.Stdin)
+	var line []rune
+	for {
+		ch, _, err := reader.ReadRune()
+		if err != nil {
+			return string(line), err
+		}
+		if ch == '\n' || ch == '\r' {
+			break
+		}
+		line = append(line, ch)
+	}
+	return string(line), nil
 }

--- a/internal/plugins/plugin_test.go
+++ b/internal/plugins/plugin_test.go
@@ -296,3 +296,41 @@ func captureInput(input string) func() {
 		os.Stdin = stdin
 	}
 }
+
+func TestSetupQuestion_Ask_CarriageReturn(t *testing.T) {
+	// Test that \r (carriage return) alone is accepted as line ending.
+	// Some terminals (kitty, macOS default) send \r instead of \n on Enter.
+	setting := &Setting{
+		EnvVariable: "TEST_CR_SETTING",
+		Required:    true,
+	}
+	question := &SetupQuestion{
+		Setting:  setting,
+		Question: "Enter test setting:",
+	}
+	input := "user_value\r"
+	fmtInput := captureInput(input)
+	defer fmtInput()
+	err := question.Ask("TestConfigurable")
+	assert.NoError(t, err)
+	assert.Equal(t, "user_value", setting.Value)
+}
+
+func TestSetupQuestion_Ask_EmptyCarriageReturn(t *testing.T) {
+	// Test that pressing Enter (\r) with a default value uses the default.
+	setting := &Setting{
+		EnvVariable: "TEST_CR_DEFAULT",
+		Value:       "default_value",
+		Required:    true,
+	}
+	question := &SetupQuestion{
+		Setting:  setting,
+		Question: "Enter test setting:",
+	}
+	input := "\r"
+	fmtInput := captureInput(input)
+	defer fmtInput()
+	err := question.Ask("TestConfigurable")
+	assert.NoError(t, err)
+	assert.Equal(t, "default_value", setting.Value)
+}


### PR DESCRIPTION
## What this Pull Request (PR) does

Fixes interactive setup prompts hanging on terminals that send `\r` (carriage return) instead of `\n` (newline) when the user presses Enter. Replaces `fmt.Scanln` with a `bufio`-based `readLine()` function that accepts both line ending styles.

## Related issues

Closes #2139

## Screenshots

Before: `fabric --setup` hangs at the patterns Git repo URL prompt on kitty terminal (macOS). User sees `^M` characters and input is never accepted.

After: Enter key works immediately on all terminals — kitty, macOS default Terminal, and standard Linux terminals.

## Type

🐛 Bug Fix

## Changes

- **`internal/plugins/plugin.go`**: Replace `fmt.Scanln(&answer)` with `readLine()` — a `bufio.NewReader`-based function that reads stdin byte-by-byte and treats both `\r` and `\n` as line terminators.
- **`internal/plugins/plugin_test.go`**: Add 2 tests covering `\r` input (`TestSetupQuestion_Ask_CarriageReturn`) and empty `\r` with default value (`TestSetupQuestion_Ask_EmptyCarriageReturn`).
