### PR TITLE
fix: shell-escape extension values to prevent command injection

### DIFF
--- a/cmd/generate_changelog/incoming/2152.txt
+++ b/cmd/generate_changelog/incoming/2152.txt
@@ -1,0 +1,3 @@
+### PR [#2152](https://github.com/danielmiessler/Fabric/pull/2152) by [AUTHENSOR](https://github.com/AUTHENSOR): fix: shell-escape extension values to prevent command injection
+
+- **Fix:** Shell-escape extension values to prevent command injection in the extension executor, which previously ran commands via `sh -c` with unescaped, user-controlled values interpolated into the command string. All user-controlled values are now wrapped in single quotes with embedded-single-quote escaping prior to interpolation, ensuring the shell treats them as literal arguments. A regression test (`ShellInjectionBlocked`) has been added to verify that malicious input (e.g., `hello; touch /marker`) does not execute unintended shell commands.

--- a/internal/plugins/template/extension_executor.go
+++ b/internal/plugins/template/extension_executor.go
@@ -78,18 +78,30 @@ func (e *ExtensionExecutor) formatCommand(ext *ExtensionDefinition, operation st
 		return "", fmt.Errorf("%s", fmt.Sprintf(i18n.T("extension_operation_not_found"), operation, ext.Name))
 	}
 
+	// Shell-escape all user-controlled values to prevent command injection.
+	// The command string is ultimately passed to "sh -c", so any shell
+	// metacharacters (;, |, $(), backticks, etc.) in the value would be
+	// executed. Wrapping each value in single quotes and escaping embedded
+	// single quotes ensures the value is treated as a literal argument.
 	vars := make(map[string]string)
 	vars["executable"] = ext.Executable
 	vars["operation"] = operation
-	vars["value"] = value
+	vars["value"] = shellEscape(value)
 
 	// Split on pipe for numbered variables
 	values := strings.Split(value, "|")
 	for i, val := range values {
-		vars[fmt.Sprintf("%d", i+1)] = val
+		vars[fmt.Sprintf("%d", i+1)] = shellEscape(val)
 	}
 
 	return ApplyTemplate(opConfig.CmdTemplate, vars, "")
+}
+
+// shellEscape wraps a string in single quotes for safe use in a shell command,
+// escaping any embedded single quotes. This prevents command injection when
+// untrusted input is passed as an argument to "sh -c".
+func shellEscape(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
 }
 
 // executeStdout runs the command and captures its stdout

--- a/internal/plugins/template/extension_executor_test.go
+++ b/internal/plugins/template/extension_executor_test.go
@@ -21,6 +21,9 @@ case "$1" in
     "stdout")
         echo "Hello, $2!"
         ;;
+    "echo")
+        echo "$2"
+        ;;
     "file")
         echo "Hello, $2!" > "$3"
         echo "$3"  # Print the filename for path_from_stdout
@@ -38,6 +41,54 @@ esac`
 	// Create registry and register our test extensions
 	registry := NewExtensionRegistry(tmpDir)
 	executor := NewExtensionExecutor(registry)
+
+	// Test that shell metacharacters in user input are neutralized.
+	// Before the fix, value flowed unescaped into "sh -c", so input
+	// like "; touch /tmp/pwned" would execute arbitrary commands.
+	t.Run("ShellInjectionBlocked", func(t *testing.T) {
+		// Use a marker file to detect if injection succeeded.
+		markerFile := filepath.Join(tmpDir, "injection-marker")
+		_ = os.Remove(markerFile)
+
+		configPath := filepath.Join(tmpDir, "inject-test.yaml")
+		configContent := `name: inject-test
+executable: ` + testScript + `
+type: executable
+timeout: 5s
+operations:
+  echo:
+    cmd_template: "{{executable}} echo {{value}}"
+config:
+  output:
+    method: stdout`
+
+		if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+			t.Fatalf("Failed to create config: %v", err)
+		}
+
+		if err := registry.Register(configPath); err != nil {
+			t.Fatalf("Failed to register extension: %v", err)
+		}
+
+		// Malicious input: attempt to run a separate command after echo.
+		maliciousValue := "hello; touch " + markerFile
+
+		output, err := executor.Execute("inject-test", "echo", maliciousValue)
+		if err != nil {
+			t.Fatalf("Execute failed: %v", err)
+		}
+
+		// The output should contain the full malicious string as a literal
+		// argument (proving the shell did NOT interpret the semicolon).
+		if !strings.Contains(output, "hello; touch") {
+			t.Errorf("Expected literal value in output, got: %q", output)
+		}
+
+		// The marker file must NOT exist (injection was blocked).
+		if _, err := os.Stat(markerFile); !os.IsNotExist(err) {
+			t.Error("SECURITY: command injection succeeded — marker file was created")
+		}
+	})
 
 	// Test stdout-based extension
 	t.Run("StdoutExecution", func(t *testing.T) {


### PR DESCRIPTION
# fix: shell-escape extension values to prevent command injection

## Summary

The extension executor (`extension_executor.go:56`) runs commands via
`exec.Command("sh", "-c", cmdStr)` where `cmdStr` contains user-controlled
values interpolated **without escaping**. A value containing shell
metacharacters (`;`, `|`, `$()`, backticks) is executed by the shell,
enabling **command injection**.

User input flows from content processed through a pattern into the extension
system via the `InputSentinel` (`template.go:79`), then into `formatCommand`
which interpolates it into the `cmd_template`, then into `sh -c`. No escaping
is applied at any point in the chain.

**Fix:** wrap all user-controlled values in single quotes (with embedded
single-quote escaping) before interpolation. This ensures `sh -c` treats them
as literal arguments, not shell syntax.

## The vulnerability

```go
// extension_executor.go:56 (before)
cmd := exec.Command("sh", "-c", cmdStr)

// cmdStr is built by formatCommand, which interpolates the raw value:
//   vars["value"] = value           // raw user input
//   vars["1"] = splitValue[0]       // raw user input (pipe-split)
//   return ApplyTemplate(opConfig.CmdTemplate, vars)
//
// No escaping is applied. If cmd_template is "{{executable}} echo {{value}}"
// and value is "hello; touch /tmp/pwned", cmdStr becomes:
//   /path/to/ext echo hello; touch /tmp/pwned
// sh -c executes BOTH commands.
```

### Attack chain

1. User processes content through a Fabric pattern that uses an extension
2. The pattern contains `{{ext:name:op:__FABRIC_INPUT_SENTINEL_TOKEN__}}`
3. The sentinel is replaced with raw user input (`template.go:79`)
4. `formatCommand` interpolates the input into `cmd_template` (no escaping)
5. The result is passed to `exec.Command("sh", "-c", cmdStr)` — injection

### Reproduction

```go
// Register a benign extension with cmd_template: "{{executable}} echo {{value}}"
// Then execute with malicious input:
output, _ := executor.Execute("echo-ext", "echo", "hello; touch /tmp/injected")

// Before fix: /tmp/injected is created (command injection)
// After fix:  the script receives "hello; touch /tmp/injected" as a literal
//             argument; /tmp/injected is NOT created
```

## The fix

```go
// after — shell-escape all user-controlled values
vars["value"] = shellEscape(value)
vars["1"] = shellEscape(splitValue[0])
// ...

// shellEscape wraps in single quotes, escaping embedded single quotes
func shellEscape(s string) string {
    return "'" + strings.ReplaceAll(s, "'", "'\"'\"'") + "'"
}
```

Single-quote wrapping is the standard POSIX approach for safely embedding
untrusted data in shell commands. The inner `sh` strips the quotes, so the
executed command receives the same argument values — existing extensions work
unchanged.

## Tests

Regression test `ShellInjectionBlocked` added to
`extension_executor_test.go`:

- Registers a benign `echo` extension
- Executes with input `hello; touch <marker_file>`
- Asserts the marker file is NOT created (injection blocked)
- Asserts the full malicious string appears in stdout (treated as literal)

All 30+ existing template tests pass unchanged — the `sh` inner shell strips
the single quotes, so executed commands receive identical arguments.

```
$ go test ./internal/plugins/template/ -v -run TestExtensionExecutor
--- PASS: TestExtensionExecutor (0.14s)
    --- PASS: TestExtensionExecutor/ShellInjectionBlocked (0.11s)
    --- PASS: TestExtensionExecutor/StdoutExecution (0.01s)
    --- PASS: TestExtensionExecutor/FileExecution (0.01s)
    --- PASS: TestExtensionExecutor/ExecutionErrors (0.01s)
```

## Impact

- **Command injection via processed content.** Any input that flows through
  a pattern using the extension system can execute arbitrary shell commands.
- **Severity:** high — arbitrary code execution on the user's machine via
  content processing.
- **Prerequisite:** the user must have at least one registered extension and
  use a pattern that invokes it with user input.

## Scope

Two files: `extension_executor.go` (the fix) and `extension_executor_test.go`
(the regression test). Diff: +65/−2.
