### PR TITLE
Make it possible to back-fill missing ChangeLog entries

### DIFF
--- a/cmd/generate_changelog/incoming/2155.txt
+++ b/cmd/generate_changelog/incoming/2155.txt
@@ -1,0 +1,7 @@
+### PR [#2155](https://github.com/danielmiessler/Fabric/pull/2155) by [ksylvan](https://github.com/ksylvan): Claude Sonnet 5 Anthropic support
+
+- Add Claude Sonnet 5 to supported Anthropic models
+- Enable one-million-token context beta for Claude 5 models
+- Omit sampling parameters for Claude Sonnet 5 requests
+- Centralize Anthropic sampling restrictions behind prefix matching
+- Remove older Claude 4 aliases from model listings

--- a/cmd/generate_changelog/incoming/2156.txt
+++ b/cmd/generate_changelog/incoming/2156.txt
@@ -1,0 +1,7 @@
+### PR [#2156](https://github.com/danielmiessler/Fabric/pull/2156) by [ksylvan](https://github.com/ksylvan): Make it possible to back-fill missing ChangeLog entries
+
+- Added Claude Sonnet 5 to the Anthropic model list, with sampling parameters omitted for compatibility.
+- Enabled the 1M context beta for Claude Sonnet 5, significantly expanding its context window support.
+- Removed deprecated Sonnet and Opus model variants, cleaning up outdated model references.
+- Updated Anthropic, AWS, Google, and Ollama dependencies, and refreshed Go module checksums.
+- Added a `--closed-ok` flag to the changelog generator, allowing it to process closed or merged PRs by skipping the open-state validation check.

--- a/cmd/generate_changelog/incoming/2156.txt
+++ b/cmd/generate_changelog/incoming/2156.txt
@@ -1,7 +1,7 @@
 ### PR [#2156](https://github.com/danielmiessler/Fabric/pull/2156) by [ksylvan](https://github.com/ksylvan): Make it possible to back-fill missing ChangeLog entries
 
-- Added Claude Sonnet 5 to the Anthropic model list, with sampling parameters omitted for compatibility.
-- Enabled the 1M context beta for Claude Sonnet 5, significantly expanding its context window support.
-- Removed deprecated Sonnet and Opus model variants, cleaning up outdated model references.
-- Updated Anthropic, AWS, Google, and Ollama dependencies, and refreshed Go module checksums.
-- Added a `--closed-ok` flag to the changelog generator, allowing it to process closed or merged PRs by skipping the open-state validation check.
+- Add support for changelog generation for closed pull requests via a new `--closed-ok` flag, bypassing open-state validation.
+- Skip mergeability checks when processing closed pull requests to allow smooth back-filling of missing entries.
+- Store the closed pull request allowance setting in the generator configuration for consistent behavior.
+- Improve error messaging to guide users toward using `--closed-ok` when validation errors occur on closed PRs.
+- Introduce the `--closed-ok` flag as the primary mechanism for enabling back-fill workflows on previously closed pull requests.

--- a/cmd/generate_changelog/internal/changelog/processing.go
+++ b/cmd/generate_changelog/internal/changelog/processing.go
@@ -381,11 +381,13 @@ func (g *Generator) validatePRState(prNumber int) error {
 		return fmt.Errorf("failed to fetch PR %d: %w", prNumber, err)
 	}
 
-	if details.State != "open" {
-		return fmt.Errorf("PR %d is not open (current state: %s)", prNumber, details.State)
+	if details.State != "open" && !g.cfg.ClosedOK {
+		return fmt.Errorf("PR %d is not open (current state: %s); use --closed-ok to process it anyway", prNumber, details.State)
 	}
 
-	if !details.Mergeable {
+	// Only check mergeability for open PRs; GitHub returns nil for closed/merged PRs
+	// which would incorrectly trigger this check even when using --closed-ok
+	if details.State == "open" && !details.Mergeable {
 		return fmt.Errorf("PR %d is not mergeable - please resolve conflicts first", prNumber)
 	}
 

--- a/cmd/generate_changelog/internal/config/config.go
+++ b/cmd/generate_changelog/internal/config/config.go
@@ -18,4 +18,5 @@ type Config struct {
 	Push              bool
 	SyncDB            bool
 	Release           string
+	ClosedOK          bool
 }

--- a/cmd/generate_changelog/main.go
+++ b/cmd/generate_changelog/main.go
@@ -45,6 +45,7 @@ func init() {
 	rootCmd.Flags().BoolVar(&cfg.Push, "push", false, "Enable automatic git push after creating an incoming entry")
 	rootCmd.Flags().BoolVar(&cfg.SyncDB, "sync-db", false, "Synchronize and validate database integrity with git history and GitHub PRs")
 	rootCmd.Flags().StringVar(&cfg.Release, "release", "", "Update GitHub release description with AI summary for version (e.g., v1.2.3)")
+	rootCmd.Flags().BoolVar(&cfg.ClosedOK, "closed-ok", false, "Allow processing a PR that is already closed/merged (skips open-state check)")
 }
 
 func run(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
# Make it possible to back-fill missing ChangeLog entries

## Summary

This PR adds support for Claude Sonnet 5 in the Anthropic provider, updates Anthropic model sampling/beta handling, adds a changelog-generator escape hatch for processing closed or merged PRs, and refreshes Go module dependencies/checksums.

## Files Changed

- `internal/plugins/ai/anthropic/anthropic.go`
  - Adds Claude Sonnet 5 to the supported Anthropic model list.
  - Enables the 1M context beta for Claude Sonnet 5 and Claude Fable 5.
  - Centralizes Anthropic model sampling restrictions using prefix matching.
  - Removes older Claude 4 aliases from the exposed model list.

- `internal/plugins/ai/anthropic/anthropic_test.go`
  - Updates the beta configuration test to validate Claude Sonnet 5 1M context beta support.

- `cmd/generate_changelog/internal/config/config.go`
  - Adds a `ClosedOK` configuration field.

- `cmd/generate_changelog/main.go`
  - Adds a new `--closed-ok` CLI flag for the changelog generator.

- `cmd/generate_changelog/internal/changelog/processing.go`
  - Allows changelog generation for closed or merged PRs when `--closed-ok` is provided.
  - Skips mergeability validation for closed PRs because GitHub can return no mergeability value for those PRs.

- `cmd/generate_changelog/incoming/2155.txt`
  - Adds an incoming changelog entry for Claude Sonnet 5 Anthropic support.

- `cmd/generate_changelog/incoming/2156.txt`
  - Adds an incoming changelog entry for changelog backfill support and related dependency/model updates.

- `go.mod`
  - Updates direct and indirect Go dependencies, including Anthropic, AWS, Google, Ollama, Azure identity, SQLite, and `golang.org/x/*` packages.

- `go.sum`
  - Refreshes checksums for the updated dependency graph.

## Code Changes

### Anthropic sampling restrictions are centralized

The hard-coded sampling restriction check was replaced with a prefix list and `slices.ContainsFunc`, making future additions easier and less error-prone.

```go
var samplingParamsDisallowedPrefixes = []string{
	"claude-opus-4-7",
	"claude-opus-4-8",
	"claude-sonnet-5",
	"claude-fable-5",
}

func modelDisallowsSamplingParams(model string) bool {
	return slices.ContainsFunc(samplingParamsDisallowedPrefixes, func(prefix string) bool {
		return strings.HasPrefix(model, prefix)
	})
}
```

This also adds Claude Sonnet 5 to the set of models where sampling parameters should be omitted for compatibility.

### Claude Sonnet 5 is added to the Anthropic model list

```go
ret.models = []string{
	string(anthropic.ModelClaudeFable5),
	string(anthropic.ModelClaudeSonnet5),
	string(anthropic.ModelClaudeOpus4_8),
	...
}
```

Older Claude 4 aliases were removed from the model list to avoid presenting deprecated or redundant model options.

### Claude Sonnet 5 and Fable 5 receive 1M context beta headers

```go
string(anthropic.ModelClaudeFable5): {"context-1m-2025-08-07"},

string(anthropic.ModelClaudeSonnet5): {"context-1m-2025-08-07"},
```

This enables the Anthropic 1M context beta for the new Claude 5 models.

### Changelog generator can process closed or merged PRs

A new `ClosedOK` config option and CLI flag were added:

```go
rootCmd.Flags().BoolVar(&cfg.ClosedOK, "closed-ok", false, "Allow processing a PR that is already closed/merged (skips open-state check)")
```

PR state validation now permits closed PRs when explicitly requested:

```go
if details.State != "open" && !g.cfg.ClosedOK {
	return fmt.Errorf("PR %d is not open (current state: %s); use --closed-ok to process it anyway", prNumber, details.State)
}
```

Mergeability is only checked for open PRs:

```go
if details.State == "open" && !details.Mergeable {
	return fmt.Errorf("PR %d is not mergeable - please resolve conflicts first", prNumber)
}
```

This avoids incorrectly failing closed or merged PRs when GitHub does not provide mergeability information.

## Reason for Changes

Claude Sonnet 5 requires updated Anthropic SDK support and model-specific request handling. In particular, some newer Anthropic models reject non-default sampling parameters, so those parameters need to be omitted entirely for affected models.

The changelog generator change supports backfilling missing changelog entries for PRs that have already been closed or merged. Previously, the tool required PRs to be open, which prevented retrospective changelog generation.

Dependency updates are included to pick up newer provider SDKs and module checksums required for the new model constants and updated integrations.

## Impact of Changes

- Users can select and use Claude Sonnet 5 through the Anthropic provider.
- Claude Sonnet 5 and Claude Fable 5 requests can use the Anthropic 1M context beta.
- Sampling parameters are omitted for Claude Sonnet 5, Claude Fable 5, and affected Opus 4 variants, improving request compatibility.
- Deprecated Claude 4 aliases are no longer listed as supported Anthropic models.
- Maintainers can run changelog generation against already closed or merged PRs by passing `--closed-ok`.
- Dependency updates may include upstream behavior changes from Anthropic, AWS, Google, Ollama, Azure, SQLite, and related transitive packages.

## Test Plan

Recommended validation:

- Run the Go test suite:

```sh
go test ./...
```

- Verify Anthropic model listing includes Claude Sonnet 5.
- Verify Claude Sonnet 5 requests omit sampling parameters.
- Verify Claude Sonnet 5 receives the expected beta header configuration.
- Run changelog generation against:
  - an open PR without `--closed-ok`
  - a closed or merged PR with `--closed-ok`
  - a closed or merged PR without `--closed-ok` to confirm it still fails with the new guidance message

## Additional Notes

Potential areas to watch:

- The new sampling restriction logic depends on model ID prefixes. If Anthropic changes model naming conventions, affected models may need to be added to `samplingParamsDisallowedPrefixes`.
- Removing older Claude 4 aliases may affect users who explicitly configured one of the removed alias names.
- The dependency refresh is broad; provider SDK behavior should be smoke-tested in environments that use Anthropic, AWS Bedrock, Google GenAI, Ollama, and Azure authentication paths.
