### PR TITLE
fix: respect Anthropic chat option max token overrides

### DIFF
--- a/cmd/generate_changelog/incoming/2161.txt
+++ b/cmd/generate_changelog/incoming/2161.txt
@@ -1,0 +1,11 @@
+### PR [#2161](https://github.com/danielmiessler/Fabric/pull/2161) by [ksylvan](https://github.com/ksylvan): fix: respect Anthropic chat option max token overrides
+
+- Fix: respect Anthropic chat option max token overrides
+
+- Use configured Anthropic max tokens as default
+- Apply chat option max tokens when provided
+
+- Preserve existing behavior for missing token overrides
+- Add tests for default max token selection
+
+- Add tests for explicit max token overrides

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -233,9 +233,14 @@ func (an *Client) SendStream(
 func (an *Client) buildMessageParams(msgs []anthropic.MessageParam, opts *domain.ChatOptions) (
 	params anthropic.MessageNewParams) {
 
+	maxTokens := an.maxTokens
+	if opts.MaxTokens > 0 {
+		maxTokens = opts.MaxTokens
+	}
+
 	params = anthropic.MessageNewParams{
 		Model:     anthropic.Model(opts.Model),
-		MaxTokens: int64(an.maxTokens),
+		MaxTokens: int64(maxTokens),
 		Messages:  msgs,
 	}
 

--- a/internal/plugins/ai/anthropic/anthropic_test.go
+++ b/internal/plugins/ai/anthropic/anthropic_test.go
@@ -99,6 +99,43 @@ func TestBuildMessageParams_WithoutSearch(t *testing.T) {
 	}
 }
 
+func TestBuildMessageParams_UsesConfiguredMaxTokensByDefault(t *testing.T) {
+	client := NewClient()
+	opts := &domain.ChatOptions{
+		Model:       "claude-3-5-sonnet-latest",
+		Temperature: domain.DefaultTemperature,
+		TopP:        domain.DefaultTopP,
+	}
+	messages := []anthropic.MessageParam{
+		anthropic.NewUserMessage(anthropic.NewTextBlock("Hello")),
+	}
+
+	params := client.buildMessageParams(messages, opts)
+
+	if params.MaxTokens != int64(client.maxTokens) {
+		t.Errorf("Expected default max_tokens %d, got %d", client.maxTokens, params.MaxTokens)
+	}
+}
+
+func TestBuildMessageParams_UsesChatOptionsMaxTokens(t *testing.T) {
+	client := NewClient()
+	opts := &domain.ChatOptions{
+		Model:       "claude-3-5-sonnet-latest",
+		Temperature: domain.DefaultTemperature,
+		TopP:        domain.DefaultTopP,
+		MaxTokens:   8192,
+	}
+	messages := []anthropic.MessageParam{
+		anthropic.NewUserMessage(anthropic.NewTextBlock("Hello")),
+	}
+
+	params := client.buildMessageParams(messages, opts)
+
+	if params.MaxTokens != int64(opts.MaxTokens) {
+		t.Errorf("Expected max_tokens %d, got %d", opts.MaxTokens, params.MaxTokens)
+	}
+}
+
 func TestBuildMessageParams_WithSearch(t *testing.T) {
 	client := NewClient()
 	opts := &domain.ChatOptions{


### PR DESCRIPTION
# fix: respect Anthropic chat option max token overrides

Closes #2148 

## Summary

Update the Anthropic client to honor a positive per-request `ChatOptions.MaxTokens` value when building message parameters. Requests that do not specify a positive value continue to use the client’s configured default token limit.

## Files Changed

- `internal/plugins/ai/anthropic/anthropic.go`
  - Added per-request maximum-token selection in `buildMessageParams`.
  - Preserved the configured client default as the fallback.

- `internal/plugins/ai/anthropic/anthropic_test.go`
  - Added coverage for the default maximum-token behavior.
  - Added coverage for overriding the token limit through `ChatOptions.MaxTokens`.

## Code Changes

### `internal/plugins/ai/anthropic/anthropic.go`

`buildMessageParams` now resolves the maximum output token limit before constructing `anthropic.MessageNewParams`:

```go
maxTokens := an.maxTokens
if opts.MaxTokens > 0 {
	maxTokens = opts.MaxTokens
}
```

The resolved value is then passed to the Anthropic API:

```go
MaxTokens: int64(maxTokens),
```

This maintains existing behavior when `MaxTokens` is unset, zero, or negative, while allowing callers to provide a positive request-specific limit.

### `internal/plugins/ai/anthropic/anthropic_test.go`

Added `TestBuildMessageParams_UsesConfiguredMaxTokensByDefault` to verify that the client’s configured `maxTokens` value remains the fallback when `ChatOptions.MaxTokens` is not set.

Added `TestBuildMessageParams_UsesChatOptionsMaxTokens` to verify that a positive request-specific value, such as `8192`, is propagated to `anthropic.MessageNewParams.MaxTokens`.

## Reason for Changes

The Anthropic integration previously ignored `ChatOptions.MaxTokens` and always used the client-level configured token limit. This prevented callers from controlling the maximum response size on an individual request.

The change aligns Anthropic request construction with the shared chat options contract while retaining backward-compatible default behavior.

## Impact of Changes

- Callers can now set a per-request maximum output token limit for Anthropic requests.
- Existing callers that do not set `ChatOptions.MaxTokens` are unaffected.
- Zero and negative values do not override the configured client default.
- The selected value is converted to `int64` as required by the Anthropic SDK.
- No changes are made to model, temperature, top-p, message, or search configuration handling.

## Test Plan

- Run the Anthropic plugin test suite:

```bash
go test ./internal/plugins/ai/anthropic/...
```

- Verify that:
  - An unset `ChatOptions.MaxTokens` uses `client.maxTokens`.
  - A positive `ChatOptions.MaxTokens` overrides `client.maxTokens`.
  - Existing message parameter and search-related tests continue to pass.

## Additional Notes

Potential edge cases to consider:

- Negative and zero request values intentionally fall back to the client default.
- Values above the selected Anthropic model’s supported output limit may still be rejected by the upstream API.
- The method assumes `opts` is non-nil, consistent with its existing behavior; this change does not add nil handling.
