### PR TITLE
Add Requesty as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Fabric supports a wide range of AI providers:
 - Mistral
 - Novita AI
 - OpenRouter
+- Requesty
 - SiliconCloud
 - Together
 - Venice AI

--- a/README.md
+++ b/README.md
@@ -375,6 +375,7 @@ Fabric supports a wide range of AI providers:
 - Novita AI
 - OpenRouter
 - Pzero
+- Requesty
 - SiliconCloud
 - Synthorai
 - Together

--- a/README.zh.md
+++ b/README.zh.md
@@ -358,7 +358,7 @@ fabric --setup
 
 **OpenAI 兼容供应商：**
 
-- Abacus、AIML、Cerebras、DeepSeek、DigitalOcean、GitHub Models、GrokAI、Groq、Langdock、LiteLLM、MiniMax、Mistral、Novita AI、OpenRouter、SiliconCloud、Together、Venice AI、Z AI
+- Abacus、AIML、Cerebras、DeepSeek、DigitalOcean、GitHub Models、GrokAI、Groq、Langdock、LiteLLM、MiniMax、Mistral、Novita AI、OpenRouter、Requesty、SiliconCloud、Together、Venice AI、Z AI
 
 运行 `fabric --setup` 配置首选供应商，或使用 `fabric --listvendors` 查看所有可用供应商。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -358,7 +358,7 @@ fabric --setup
 
 **OpenAI 兼容供应商：**
 
-- Abacus、AIML、Cerebras、DeepSeek、DigitalOcean、GitHub Models、GrokAI、Groq、Langdock、LiteLLM、MiniMax、Mistral、Novita AI、OpenRouter、SiliconCloud、Synthorai、Together、Venice AI、Z AI
+- Abacus、AIML、Cerebras、DeepSeek、DigitalOcean、GitHub Models、GrokAI、Groq、Langdock、LiteLLM、MiniMax、Mistral、Novita AI、OpenRouter、Requesty、SiliconCloud、Synthorai、Together、Venice AI、Z AI
 
 运行 `fabric --setup` 配置首选供应商，或使用 `fabric --listvendors` 查看所有可用供应商。
 

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -289,6 +289,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "https://openrouter.ai/api/v1",
 		ImplementsResponses: false,
 	},
+	"Requesty": {
+		Name:                "Requesty",
+		BaseURL:             "https://router.requesty.ai/v1",
+		ImplementsResponses: false,
+	},
 	"SiliconCloud": {
 		Name:                "SiliconCloud",
 		BaseURL:             "https://api.siliconflow.cn/v1",

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -294,6 +294,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "https://api.pzero.studio/v1",
 		ImplementsResponses: false,
 	},
+	"Requesty": {
+		Name:                "Requesty",
+		BaseURL:             "https://router.requesty.ai/v1",
+		ImplementsResponses: false,
+	},
 	"SiliconCloud": {
 		Name:                "SiliconCloud",
 		BaseURL:             "https://api.siliconflow.cn/v1",


### PR DESCRIPTION
## Add Requesty as an OpenAI-compatible provider

This adds [Requesty](https://requesty.ai) as an OpenAI-compatible AI provider by mirroring the existing OpenRouter entry.

Requesty is an OpenAI-compatible LLM router that exposes 400+ models behind a single endpoint using `provider/model` naming, so it fits the existing `openai_compatible` provider mechanism directly.

### Changes
- `internal/plugins/ai/openai_compatible/providers_config.go`: add a `Requesty` entry to `ProviderMap`, mirroring `OpenRouter`: name `Requesty`, base URL `https://router.requesty.ai/v1`. The provider is auto-registered by the existing registry loop, and the `REQUESTY_API_KEY` env var is derived from the provider name by the existing plugin machinery (same as `OPENROUTER_API_KEY`).
- `README.md` / `README.zh.md`: list Requesty in the OpenAI-compatible providers section.

### Testing
- `go build ./...`: clean
- `go vet ./internal/plugins/ai/openai_compatible/`: clean
- `gofmt -l` on the changed file, no output
- `go test ./internal/plugins/ai/openai_compatible/`: ok
- Verified live against the Requesty endpoint (same base URL + Bearer auth): a call to `openai/gpt-4o-mini` returned the expected completion with HTTP 200.

Note: `internal/server/configuration.go` (web-UI config endpoint) only lists a subset of the compatible providers, so I left it untouched to keep the diff minimal and matching the actual OpenRouter wiring, happy to add the web-UI key field too if you'd like.

Config: get a key at https://app.requesty.ai/api-keys, model list at https://app.requesty.ai/router/list, docs at https://docs.requesty.ai.

---

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.

