### PR TITLE
feat: add Eden AI as an OpenAI-compatible provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,7 @@ Fabric supports a wide range of AI providers:
 - Cerebras
 - DeepSeek
 - DigitalOcean
+- Eden AI
 - GitHub Models
 - GrokAI
 - Groq

--- a/cmd/generate_changelog/incoming/2165.txt
+++ b/cmd/generate_changelog/incoming/2165.txt
@@ -1,0 +1,3 @@
+### PR [#2165](https://github.com/danielmiessler/Fabric/pull/2165) by [MVS-source](https://github.com/MVS-source): feat: add Eden AI as an OpenAI-compatible provider
+
+- Feat: add Eden AI as an OpenAI-compatible provider

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -232,6 +232,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "https://api.deepseek.com",
 		ImplementsResponses: false,
 	},
+	"Eden AI": {
+		Name:                "Eden AI",
+		BaseURL:             "https://api.edenai.run/v3",
+		ImplementsResponses: false,
+	},
 	"GitHub": {
 		Name:                "GitHub",
 		BaseURL:             "https://models.github.ai/inference",

--- a/internal/plugins/ai/openai_compatible/providers_config_test.go
+++ b/internal/plugins/ai/openai_compatible/providers_config_test.go
@@ -16,6 +16,11 @@ func TestCreateClient(t *testing.T) {
 			exists:   true,
 		},
 		{
+			name:     "Existing provider - Eden AI",
+			provider: "Eden AI",
+			exists:   true,
+		},
+		{
 			name:     "Existing provider - Groq",
 			provider: "Groq",
 			exists:   true,


### PR DESCRIPTION
## What this PR does

Adds Eden AI as an OpenAI-compatible provider. Eden AI (https://www.edenai.co) is an EU based, OpenAI-compatible LLM gateway: one API key reaches models from many providers (OpenAI, Anthropic, Google, Mistral, Cohere and more) with vendor prefixed ids like `openai/gpt-4o-mini`, and it offers EU data residency, zero data retention, a DPA and SOC 2 / ISO 27001.

Since Eden AI speaks the OpenAI `/chat/completions` and `/models` schema, it drops straight into the existing `openai_compatible` `ProviderMap`, so this is a single entry with no new package:

```go
"Eden AI": {
    Name:                "Eden AI",
    BaseURL:             "https://api.edenai.run/v3",
    ImplementsResponses: false,
},
```

The API key is read from `EDEN_AI_API_KEY` (derived from the provider name, matching the convention of other two word providers like `NOVITA_AI_API_KEY`). EU users can point at the EU endpoint by setting `EDEN_AI_API_BASE_URL=https://api.eu.edenai.run/v3`, no code change needed. Also added the README entry and a case in the provider table test.

## How I tested it

Built locally and tested live against the real Eden AI API with a key:

- `fabric --listvendors` lists **Eden AI**.
- `fabric --listmodels` fetches the live Eden AI catalog through `GET /v3/models`.
- A completion works end to end: `echo "..." | fabric -m "openai/gpt-4o-mini"` returned the expected text, and an Anthropic model through the same key worked too.
- `go test ./internal/plugins/ai/openai_compatible/` passes, and `gofmt` is clean on the changed files.

## Related issues

None (single provider addition).

We will maintain the provider.

