### PR TITLE
fix(core): route user input to the user message in BuildSession

### DIFF
--- a/cmd/generate_changelog/incoming/2169.txt
+++ b/cmd/generate_changelog/incoming/2169.txt
@@ -1,0 +1,4 @@
+### PR [#2169](https://github.com/danielmiessler/Fabric/pull/2169) by [ksylvan](https://github.com/ksylvan): fix(core): route user input to the user message in BuildSession
+
+- Fixed system-only message sessions that some backends (vLLM, some Bedrock endpoints) reject or hang on. BuildSession no longer embeds the user input in the system message; the input now goes in the user message, one time.
+- Removed `ensureInput`. Patterns without an explicit `{{input}}` marker stay unchanged; explicit markers still work. The `/patterns/{name}/apply` endpoint keeps its response contract.

--- a/internal/core/chatter.go
+++ b/internal/core/chatter.go
@@ -261,7 +261,6 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 	}
 
 	var patternContent string
-	inputUsed := false
 	if request.PatternName != "" {
 		var pattern *fsdb.Pattern
 		if request.NoVariableReplacement {
@@ -274,7 +273,6 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 			return nil, fmt.Errorf(i18n.T("chatter_error_get_pattern"), request.PatternName, err)
 		}
 		patternContent = pattern.Pattern
-		inputUsed = true
 	}
 
 	systemMessage := joinPromptSections(contextContent, patternContent)
@@ -338,9 +336,12 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 		if systemMessage != "" {
 			session.Append(&chat.ChatCompletionMessage{Role: chat.ChatMessageRoleSystem, Content: systemMessage})
 		}
-		// If multi-part content, it is in the user message, and should be added.
-		// Otherwise, we should only add it if we have not already used it in the systemMessage.
-		if len(request.Message.MultiContent) > 0 || (request.Message != nil && !inputUsed) {
+		// Add the user message when it has content. The pattern does not
+		// contain the input, so the input goes to the model one time.
+		// The session keeps the usual system-plus-user shape. Some backends
+		// (vLLM, some Bedrock endpoints) reject sessions with system messages
+		// only.
+		if len(request.Message.MultiContent) > 0 || request.Message.Content != "" {
 			session.Append(request.Message)
 		}
 	}

--- a/internal/core/chatter_test.go
+++ b/internal/core/chatter_test.go
@@ -244,8 +244,8 @@ func TestChatter_BuildSession_SeparatesSystemSections(t *testing.T) {
 	}
 
 	messages := session.GetVendorMessages()
-	if len(messages) != 1 {
-		t.Fatalf("expected 1 vendor message, got %d", len(messages))
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 vendor messages, got %d", len(messages))
 	}
 
 	systemMessage := messages[0]
@@ -253,9 +253,20 @@ func TestChatter_BuildSession_SeparatesSystemSections(t *testing.T) {
 		t.Fatalf("expected first message to be system, got %s", systemMessage.Role)
 	}
 
-	expectedSystemMessage := "STRATEGY\nCONTEXT\nPATTERN\nuser input"
+	// The system message has the strategy, the context, and the pattern.
+	// It must not contain the user input.
+	expectedSystemMessage := "STRATEGY\nCONTEXT\nPATTERN"
 	if systemMessage.Content != expectedSystemMessage {
 		t.Fatalf("expected system message %q, got %q", expectedSystemMessage, systemMessage.Content)
+	}
+
+	// The user input goes in the user message, one time only.
+	userMessage := messages[1]
+	if userMessage.Role != chat.ChatMessageRoleUser {
+		t.Fatalf("expected second message to be user, got %s", userMessage.Role)
+	}
+	if userMessage.Content != "user input" {
+		t.Fatalf("expected user message %q, got %q", "user input", userMessage.Content)
 	}
 
 	if request.Message.Content != "user input" {

--- a/internal/plugins/db/fsdb/patterns.go
+++ b/internal/plugins/db/fsdb/patterns.go
@@ -81,24 +81,12 @@ func (o *PatternsEntity) loadPattern(source string) (pattern *Pattern, err error
 	return
 }
 
-func (o *PatternsEntity) ensureInput(pattern *Pattern) {
-	if !strings.Contains(pattern.Pattern, "{{input}}") {
-		if !strings.HasSuffix(pattern.Pattern, "\n") {
-			pattern.Pattern += "\n"
-		}
-		pattern.Pattern += "{{input}}"
-	}
-}
-
 func (o *PatternsEntity) applyInput(pattern *Pattern, input string) {
-	o.ensureInput(pattern)
 	pattern.Pattern = strings.ReplaceAll(pattern.Pattern, "{{input}}", input)
 }
 
 func (o *PatternsEntity) applyVariables(
 	pattern *Pattern, variables map[string]string, input string) (err error) {
-
-	o.ensureInput(pattern)
 
 	// Temporarily replace {{input}} with a sentinel token to protect it
 	// from recursive variable resolution

--- a/internal/plugins/db/fsdb/patterns_test.go
+++ b/internal/plugins/db/fsdb/patterns_test.go
@@ -64,7 +64,7 @@ func TestApplyVariables(t *testing.T) {
 			want:  "You are a security expert.\nCheck this code\nPlease analyze.",
 		},
 		{
-			name: "pattern without input variable gets input appended",
+			name: "pattern without input placeholder stays unchanged",
 			pattern: &Pattern{
 				Pattern: "You are a {{role}}.\nPlease analyze.",
 			},
@@ -72,7 +72,7 @@ func TestApplyVariables(t *testing.T) {
 				"role": "code reviewer",
 			},
 			input: "Review this PR",
-			want:  "You are a code reviewer.\nPlease analyze.\nReview this PR",
+			want:  "You are a code reviewer.\nPlease analyze.",
 		},
 		// ... previous test cases ...
 	}
@@ -158,7 +158,7 @@ func TestGetWithoutVariables(t *testing.T) {
 	createTestPattern(t, entity, "no-input", "Static content")
 	result, err = entity.GetWithoutVariables("no-input", "hi")
 	require.NoError(t, err)
-	assert.Equal(t, "Static content\nhi", result.Pattern)
+	assert.Equal(t, "Static content", result.Pattern)
 }
 
 func TestPatternsEntity_Save(t *testing.T) {

--- a/internal/server/patterns.go
+++ b/internal/server/patterns.go
@@ -3,6 +3,7 @@ package restapi
 import (
 	"maps"
 	"net/http"
+	"strings"
 
 	"github.com/danielmiessler/fabric/internal/plugins/db/fsdb"
 	"github.com/gin-gonic/gin"
@@ -96,5 +97,13 @@ func (h *PatternsHandler) ApplyPattern(c *gin.Context) {
 		c.JSON(http.StatusInternalServerError, err.Error())
 		return
 	}
+
+	// Patterns without an explicit {{input}} marker do not contain the input
+	// now. Add the input at the end to keep the response contract of this
+	// endpoint.
+	if request.Input != "" && !strings.Contains(pattern.Pattern, request.Input) {
+		pattern.Pattern = strings.TrimSuffix(pattern.Pattern, "\n") + "\n" + request.Input
+	}
+
 	c.JSON(http.StatusOK, pattern)
 }


### PR DESCRIPTION
## Summary

`BuildSession` put the user input inside the system message. This change moves the input to the user message. The session now has the usual system-plus-user shape.

## Problem

Some backends (vLLM, some Bedrock endpoints) reject or hang on a request that has system messages only. Fabric made this shape for almost every pattern call.

Related: #2130 and #2137 address the same problem at the session layer and at the send layer. This change fixes the cause: the input routing itself.

## Cause

`ensureInput` added `{{input}}` to the end of each pattern that did not have it. Only 2 of 255 patterns have an explicit `{{input}}` marker. Then `BuildSession` skipped the user message to prevent duplication. The result was one system message with the input inside it.

## Fix

- Removed `ensureInput`. A pattern without an explicit `{{input}}` marker now stays unchanged. Explicit markers still work.
- `BuildSession` now adds the user message when it has content. The input goes to the model one time.
- The `/patterns/{name}/apply` endpoint keeps its response contract. It appends the input when the pattern did not consume it.

Net change to production code: more lines removed than added. No new functions.

## Behavior changes

- A pattern call with input now sends `[system: instructions]` plus `[user: input]`. Before, it sent `[system: instructions + input]`.
- The input goes to the model one time. The token count stays the same.
- Stored sessions now record the user turn.
- Known limit, accepted: the 2 patterns with an explicit `{{input}}` marker send the input two times, once in the pattern and once in the user message.
- Known limit, accepted: a pattern call with empty input keeps the old system-only shape.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `gofmt`, `go vet`, and the `modernize` analyzer — clean
- [x] Updated `TestChatter_BuildSession_SeparatesSystemSections`: the session now has a system message without the input, plus a user message with the input
- [x] Updated `TestApplyVariables` and `TestGetWithoutVariables`: a pattern without `{{input}}` stays unchanged
- [x] Manual check: `echo "text" | fabric -p extract_wisdom --dry-run` shows a system message and a user message, and the input text appears one time
