### PR TITLE
fix: clearer error when binary name used as pattern fallback

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -110,7 +110,11 @@ func Cli(version string) (err error) {
 	}
 
 	// Handle chat processing
-	err = handleChatProcessing(currentFlags, registry, messageTools)
+	if err = handleChatProcessing(currentFlags, registry, messageTools); err != nil {
+		if patternFromBinaryName(currentFlags.Pattern) {
+			err = fmt.Errorf("%w\n%s", err, fmt.Sprintf(i18n.T("pattern_from_binary_name_hint"), currentFlags.Pattern))
+		}
+	}
 	return
 }
 

--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -555,6 +555,14 @@ func (o *Flags) IsChatRequest() (ret bool) {
 	return
 }
 
+// patternFromBinaryName returns true when the pattern matches the binary name fallback
+// (i.e., no -p flag was given and the binary was not named "fabric", "main", or "cmd").
+func patternFromBinaryName(patternName string) bool {
+	execName := filepath.Base(os.Args[0])
+	execName = strings.TrimSuffix(execName, filepath.Ext(execName))
+	return execName != "fabric" && execName != "main" && execName != "cmd" && execName != "" && patternName == execName
+}
+
 func (o *Flags) WriteOutput(message string) (err error) {
 	fmt.Println(message)
 	if o.Output != "" {

--- a/internal/cli/flags_test.go
+++ b/internal/cli/flags_test.go
@@ -482,3 +482,30 @@ func TestExtractFlag(t *testing.T) {
 		})
 	}
 }
+
+func TestPatternFromBinaryName(t *testing.T) {
+	oldArgs := os.Args
+	defer func() { os.Args = oldArgs }()
+
+	tests := []struct {
+		name        string
+		binaryName  string
+		patternName string
+		expected    bool
+	}{
+		{"renamed binary matches pattern", "fabric-ai", "fabric-ai", true},
+		{"renamed binary does not match pattern", "fabric-ai", "summarize", false},
+		{"standard fabric binary", "fabric", "fabric", false},
+		{"main binary skipped", "main", "main", false},
+		{"cmd binary skipped", "cmd", "cmd", false},
+		{"binary with extension stripped", "analyze.exe", "analyze", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			os.Args = []string{"/usr/local/bin/" + tt.binaryName}
+			result := patternFromBinaryName(tt.patternName)
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "Pfad zur YAML-Konfigurationsdatei",
   "pattern_not_found_list_available": "Pattern '%s' nicht gefunden. Führen Sie 'fabric -l' aus, um verfügbare Patterns anzuzeigen",
   "pattern_invalid_name": "Ungültiger Pattern-Name: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "Pattern '%s' nicht gefunden.\n\nKeine Patterns installiert! Um dies zu beheben:\n  • Führen Sie 'fabric --setup' aus, um Patterns zu konfigurieren und herunterzuladen\n  • Oder führen Sie 'fabric -U' aus, um Patterns direkt herunterzuladen/zu aktualisieren",
   "pattern_variables_help": "Werte für Mustervariablen, z.B. -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "Repository %s wird geklont (Pfad: %s)...\\n",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "Path to YAML config file",
   "pattern_not_found_list_available": "pattern '%s' not found. Run 'fabric -l' to see available patterns",
   "pattern_invalid_name": "invalid pattern name: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "pattern '%s' not found.\n\nNo patterns are installed! To fix this:\n  • Run 'fabric --setup' to configure and download patterns\n  • Or run 'fabric -U' to download/update patterns directly",
   "pattern_variables_help": "Values for pattern variables, e.g. -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "Cloning repository %s (path: %s)...\n",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "Ruta al archivo de configuración YAML",
   "pattern_not_found_list_available": "patrón '%s' no encontrado. Ejecuta 'fabric -l' para ver los patrones disponibles",
   "pattern_invalid_name": "nombre de patrón inválido: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "patrón '%s' no encontrado.\n\n¡No hay patrones instalados! Para solucionar esto:\n  • Ejecuta 'fabric --setup' para configurar y descargar patrones\n  • O ejecuta 'fabric -U' para descargar/actualizar patrones directamente",
   "pattern_variables_help": "Valores para variables de patrón, ej. -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "Clonando el repositorio %s (ruta: %s)...\\n",

--- a/internal/i18n/locales/fa.json
+++ b/internal/i18n/locales/fa.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "مسیر فایل پیکربندی YAML",
   "pattern_not_found_list_available": "الگوی '%s' یافت نشد. برای مشاهده الگوهای موجود 'fabric -l' را اجرا کنید",
   "pattern_invalid_name": "نام الگوی نامعتبر: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "الگوی '%s' یافت نشد.\n\nهیچ الگویی نصب نشده است! برای رفع این مشکل:\n  • 'fabric --setup' را برای پیکربندی و دانلود الگوها اجرا کنید\n  • یا 'fabric -U' را برای دانلود/به‌روزرسانی الگوها اجرا کنید",
   "pattern_variables_help": "مقادیر برای متغیرهای الگو، مثال: -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "در حال کلون کردن مخزن %s (مسیر: %s)...\\n",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "Chemin vers le fichier de configuration YAML",
   "pattern_not_found_list_available": "modèle '%s' non trouvé. Exécutez 'fabric -l' pour voir les modèles disponibles",
   "pattern_invalid_name": "nom de modèle invalide : %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "modèle '%s' non trouvé.\n\nAucun modèle n'est installé ! Pour résoudre ce problème :\n  • Exécutez 'fabric --setup' pour configurer et télécharger les modèles\n  • Ou exécutez 'fabric -U' pour télécharger/mettre à jour les modèles directement",
   "pattern_variables_help": "Valeurs pour les variables de motif, ex. -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "Clonage du dépôt %s (chemin : %s)...\\n",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "Percorso del file di configurazione YAML",
   "pattern_not_found_list_available": "pattern '%s' non trovato. Esegui 'fabric -l' per vedere i pattern disponibili",
   "pattern_invalid_name": "nome pattern non valido: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "pattern '%s' non trovato.\n\nNessun pattern installato! Per risolvere:\n  • Esegui 'fabric --setup' per configurare e scaricare i pattern\n  • Oppure esegui 'fabric -U' per scaricare/aggiornare i pattern direttamente",
   "pattern_variables_help": "Valori per le variabili pattern, es. -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "Clonazione del repository %s (percorso: %s)...\\n",

--- a/internal/i18n/locales/ja.json
+++ b/internal/i18n/locales/ja.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "YAML設定ファイルのパス",
   "pattern_not_found_list_available": "パターン '%s' が見つかりません。'fabric -l'で利用可能なパターンを確認してください",
   "pattern_invalid_name": "無効なパターン名: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "パターン '%s' が見つかりません。\n\nパターンがインストールされていません！解決するには:\n  • 'fabric --setup'を実行してパターンを設定・ダウンロード\n  • または'fabric -U'を実行してパターンをダウンロード/更新",
   "pattern_variables_help": "パターン変数の値、例：-v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "リポジトリ %s をクローン中 (パス: %s)...\\n",

--- a/internal/i18n/locales/pl.json
+++ b/internal/i18n/locales/pl.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "Ścieżka do pliku konfiguracyjnego YAML",
   "pattern_not_found_list_available": "wzorzec '%s' nie został znaleziony. Uruchom 'fabric -l', aby zobaczyć dostępne wzorce",
   "pattern_invalid_name": "nieprawidłowa nazwa wzorca: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "wzorzec '%s' nie został znaleziony.\n\nNie zainstalowano żadnych wzorców! Aby to naprawić:\n  • Uruchom 'fabric --setup', aby skonfigurować i pobrać wzorce\n  • Lub uruchom 'fabric -U', aby bezpośrednio pobrać/zaktualizować wzorce",
   "pattern_variables_help": "Wartości dla zmiennych wzorców, np. -v=#role:ekspert -v=#points:30",
   "patterns_cloning_repository": "Klonowanie repozytorium %s (ścieżka: %s)...\n",

--- a/internal/i18n/locales/pt-BR.json
+++ b/internal/i18n/locales/pt-BR.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "Caminho para arquivo de configuração YAML",
   "pattern_not_found_list_available": "padrão '%s' não encontrado. Execute 'fabric -l' para ver os padrões disponíveis",
   "pattern_invalid_name": "nome de padrão inválido: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "padrão '%s' não encontrado.\n\nNenhum padrão instalado! Para resolver:\n  • Execute 'fabric --setup' para configurar e baixar padrões\n  • Ou execute 'fabric -U' para baixar/atualizar padrões diretamente",
   "pattern_variables_help": "Valores para variáveis do padrão, ex. -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "Clonando repositório %s (caminho: %s)...\\n",

--- a/internal/i18n/locales/pt-PT.json
+++ b/internal/i18n/locales/pt-PT.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "Caminho para ficheiro de configuração YAML",
   "pattern_not_found_list_available": "padrão '%s' não encontrado. Execute 'fabric -l' para ver os padrões disponíveis",
   "pattern_invalid_name": "nome de padrão inválido: %q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "padrão '%s' não encontrado.\n\nNenhum padrão instalado! Para resolver:\n  • Execute 'fabric --setup' para configurar e descarregar padrões\n  • Ou execute 'fabric -U' para descarregar/atualizar padrões diretamente",
   "pattern_variables_help": "Valores para variáveis de padrão, ex. -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "A clonar repositório %s (caminho: %s)...\\n",

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -419,6 +419,7 @@
   "path_to_yaml_config": "YAML 配置文件路径",
   "pattern_not_found_list_available": "未找到模式 '%s'。运行 'fabric -l' 查看可用模式",
   "pattern_invalid_name": "无效的模式名称：%q",
+  "pattern_from_binary_name_hint": "Hint: no -p flag was given; binary name '%s' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.",
   "pattern_not_found_no_patterns": "未找到模式 '%s'。\n\n未安装任何模式！要解决此问题：\n  • 运行 'fabric --setup' 配置并下载模式\n  • 或运行 'fabric -U' 直接下载/更新模式",
   "pattern_variables_help": "模式变量的值，例如 -v=#role:expert -v=#points:30",
   "patterns_cloning_repository": "正在克隆仓库 %s（至路径：%s）...\\n",


### PR DESCRIPTION
Replaces #2117 — same commits, resubmitted from a **personal** fork.

On #2123 you were unable to push maintainer fixes to my branch:

```
ERROR: Permission to AnsibleBBridge/Fabric.git denied to ksylvan.
```

That fork is owned by an organization, and GitHub's "allow edits by maintainers" grant only works for personally-owned forks — the API still reports `maintainerCanModify: true`, so there was no signal from my side that anything was wrong. All of my open PRs were on that fork and had the same problem, so I've moved them to `OdinKral/fabric-contrib`, which is a personal fork. You should be able to push to these.

Also rebased onto current main. #2117 had gone `CONFLICTING` because #2167 added `pattern_invalid_name` to the locale files this PR also touches; both keys are kept. `go build ./internal/cli/` passes and the added `TestPatternFromBinaryName` passes all 6 subtests. (Note `TestBuildChatOptionsWithImageParameters` fails, but it fails identically on a clean `upstream/main` — pre-existing, unrelated to this PR.)

---

## Problem

Closes #2112.

When `fabric` is invoked via a symlink or renamed binary (e.g. `fabric-ai`) **without `-p`**, the binary name is silently used as the pattern name. If that pattern doesn't exist, the user sees:

```
could not get pattern fabric-ai: pattern 'fabric-ai' not found. Run 'fabric -l' to see available patterns
```

There is no hint that the binary name was used as the fallback, so the user doesn't know to add `-p`.

## Fix

Adds a `patternFromBinaryName()` helper in `flags.go` that checks whether the current pattern matches the binary-name fallback condition (mirrors the existing fallback logic). When `handleChatProcessing` returns an error and this condition is true, the error is wrapped with a hint:

```
Hint: no -p flag was given; binary name 'fabric-ai' was used as the pattern name. Use -p <pattern> to specify a pattern explicitly.
```

The symlink use-case (intentionally naming a binary after a pattern) is **not broken** — it still works the same way; the hint only appears when the pattern lookup fails.

## Changes

- `internal/cli/flags.go` — add `patternFromBinaryName()` helper
- `internal/cli/cli.go` — wrap chat error with hint when binary-name fallback is the likely cause
- `internal/i18n/locales/en.json` — add `pattern_from_binary_name_hint` i18n key
- `internal/cli/flags_test.go` — 6 unit tests for `patternFromBinaryName()`

## Test plan

- [ ] Run `go test ./internal/cli/...` — new `TestPatternFromBinaryName` tests pass
- [ ] Symlink `fabric` to `fabric-ai`, run `echo "hi" | fabric-ai` without patterns installed — verify new hint appears in error output
- [ ] Run with `-p summarize` as normal — verify no change in behavior
