### PR TITLE
docs: clarify yt() helper outputs transcript for piping (fixes #2112)

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,6 +413,7 @@ yt() {
     if [ "$#" -eq 0 ] || [ "$#" -gt 2 ]; then
         echo "Usage: yt [-t | --timestamps] youtube-link"
         echo "Use the '-t' flag to get the transcript with timestamps."
+        echo "Pipe to a pattern: yt URL | fabric -p extract_wisdom"
         return 1
     fi
 
@@ -422,6 +423,8 @@ yt() {
         shift
     fi
     local video_link="$1"
+    # Outputs the raw transcript to stdout so it can be piped to a pattern:
+    #   yt URL | fabric -p extract_wisdom
     fabric -y "$video_link" $transcript_flag
 }
 ```
@@ -500,20 +503,28 @@ function yt {
     process {
         if (-not $videoLink) {
             Write-Error "Usage: yt [-t | --timestamps] youtube-link"
+            Write-Host "Pipe to a pattern: yt URL | fabric -p extract_wisdom"
             return
         }
     }
 
     end {
         if ($videoLink) {
-            # Execute and allow output to flow through the pipeline
+            # Outputs the raw transcript to stdout so it can be piped to a pattern:
+            #   yt URL | fabric -p extract_wisdom
             fabric -y $videoLink $transcriptFlag
         }
     }
 }
 ```
 
-This also creates a `yt` alias that allows you to use `yt https://www.youtube.com/watch?v=4b0iet22VIk` to get transcripts, comments, and metadata.
+This also creates a `yt` helper that outputs a YouTube transcript to stdout. Pipe it to a pattern to process it with fabric:
+
+```shell
+yt https://www.youtube.com/watch?v=4b0iet22VIk | fabric -p extract_wisdom
+```
+
+Use `yt` without a pipe to review the raw transcript first.
 
 #### Save your files in markdown using aliases
 


### PR DESCRIPTION
Replaces #2119 — same commits, resubmitted from a **personal** fork.

On #2123 you were unable to push maintainer fixes to my branch:

```
ERROR: Permission to AnsibleBBridge/Fabric.git denied to ksylvan.
```

That fork is owned by an organization, and GitHub's "allow edits by maintainers" grant only works for personally-owned forks — the API still reports `maintainerCanModify: true`, so there was no signal from my side that anything was wrong. All of my open PRs were on that fork and had the same problem, so I've moved them to `OdinKral/fabric-contrib`, which is a personal fork. You should be able to push to these.

---

## Problem

The README `yt()` shell helper (bash/zsh and PowerShell) calls `fabric -y URL --transcript` without a `-p` pattern. For Homebrew users with the `fabric-ai` binary, this silently used the binary name as the pattern and failed with:

```
could not get pattern fabric-ai: pattern 'fabric-ai' not found.
```

There was also no indication in the README or the usage string that `yt` is a transcript extractor meant to be piped — not a standalone AI tool.

## Changes

- Updated the `yt()` usage error to show `yt URL | fabric -p extract_wisdom`
- Added a comment in the function body explaining the stdout-pipe intent
- Updated the prose description after the PowerShell snippet to show the piped workflow

The `fabric -y URL --transcript` call itself is unchanged — it already works correctly when the binary is named `fabric` (the name is in the exclusion list). This change focuses on documentation clarity.

## Test plan

- [ ] Verify `yt` without args prints updated usage including the pipe example
- [ ] Verify `yt URL | fabric -p extract_wisdom` works end-to-end

Partially addresses #2112 (the error message fix is in #2117).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
