### PR TITLE
fix: include Grok in localized --search help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -723,7 +723,7 @@ Application Options:
       --liststrategies              List all strategies
       --listvendors                 List all vendors
       --shell-complete-list         Output raw list without headers/formatting (for shell completion)
-      --search                      Enable web search tool for supported models (Anthropic, OpenAI, Gemini)
+      --search                      Enable web search tool for supported models (Anthropic, OpenAI, Gemini, Grok)
       --search-location=            Set location for web search results (e.g., 'America/Los_Angeles')
       --image-file=                 Save generated image to specified file path (e.g., 'output.png')
       --image-size=                 Image dimensions: 1024x1024, 1536x1024, 1024x1536, auto (default: auto)

--- a/cmd/generate_changelog/incoming/2180.txt
+++ b/cmd/generate_changelog/incoming/2180.txt
@@ -1,0 +1,3 @@
+### PR [#2180](https://github.com/danielmiessler/Fabric/pull/2180) by [ksylvan](https://github.com/ksylvan): fix: include Grok in localized --search help text
+
+- Fix: Updated all 11 locale entries in the i18n message catalog to include "Grok" in the `enable_web_search_tool` help text, ensuring Grok (xAI) web search support is discoverable via `fabric --help`. Also updates the generated README help block to match. No functional change.

--- a/internal/i18n/locales/de.json
+++ b/internal/i18n/locales/de.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "DigitalOcean-Modellanfrage fehlgeschlagen mit Status %d: %s",
   "disable_openai_responses_api": "OpenAI Responses API deaktivieren (Standard: false)",
   "disable_pattern_variable_replacement": "Mustervariablenersetzung deaktivieren",
-  "enable_web_search_tool": "Web-Such-Tool für unterstützte Modelle aktivieren (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Web-Such-Tool für unterstützte Modelle aktivieren (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "End-Tag für Denk-Abschnitte",
   "error_creating_audio_file": "Fehler beim Erstellen der Audio-Datei: %v",
   "error_creating_file": "Fehler beim Erstellen der Datei: %v",

--- a/internal/i18n/locales/en.json
+++ b/internal/i18n/locales/en.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "DigitalOcean models request failed with status %d: %s",
   "disable_openai_responses_api": "Disable OpenAI Responses API (default: false)",
   "disable_pattern_variable_replacement": "Disable pattern variable replacement",
-  "enable_web_search_tool": "Enable web search tool for supported models (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Enable web search tool for supported models (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "End tag for thinking sections",
   "error_creating_audio_file": "error creating audio file: %v",
   "error_creating_file": "error creating file: %v",

--- a/internal/i18n/locales/es.json
+++ b/internal/i18n/locales/es.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "solicitud de modelos de DigitalOcean falló con estado %d: %s",
   "disable_openai_responses_api": "Deshabilitar API de Respuestas de OpenAI (predeterminado: false)",
   "disable_pattern_variable_replacement": "Deshabilitar reemplazo de variables de patrón",
-  "enable_web_search_tool": "Habilitar herramienta de búsqueda web para modelos soportados (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Habilitar herramienta de búsqueda web para modelos soportados (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Etiqueta de fin para secciones de pensamiento",
   "error_creating_audio_file": "error al crear el archivo de audio: %v",
   "error_creating_file": "error al crear el archivo: %v",

--- a/internal/i18n/locales/fa.json
+++ b/internal/i18n/locales/fa.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "درخواست مدل‌های DigitalOcean با وضعیت %d ناموفق بود: %s",
   "disable_openai_responses_api": "غیرفعال کردن API OpenAI Responses (پیش‌فرض: false)",
   "disable_pattern_variable_replacement": "غیرفعال کردن جایگزینی متغیرهای الگو",
-  "enable_web_search_tool": "فعال‌سازی ابزار جستجوی وب برای مدل‌های پشتیبانی شده (Anthropic، OpenAI، Gemini)",
+  "enable_web_search_tool": "فعال‌سازی ابزار جستجوی وب برای مدل‌های پشتیبانی شده (Anthropic، OpenAI، Gemini، Grok)",
   "end_tag_thinking_sections": "تگ پایان برای بخش‌های تفکر",
   "error_creating_audio_file": "خطا در ایجاد فایل صوتی: %v",
   "error_creating_file": "خطا در ایجاد فایل: %v",

--- a/internal/i18n/locales/fr.json
+++ b/internal/i18n/locales/fr.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "échec de la requête de modèles DigitalOcean avec le statut %d : %s",
   "disable_openai_responses_api": "Désactiver l'API OpenAI Responses (par défaut : false)",
   "disable_pattern_variable_replacement": "Désactiver le remplacement des variables de motif",
-  "enable_web_search_tool": "Activer l'outil de recherche web pour les modèles pris en charge (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Activer l'outil de recherche web pour les modèles pris en charge (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Balise de fin pour les sections de réflexion",
   "error_creating_audio_file": "erreur lors de la création du fichier audio : %v",
   "error_creating_file": "erreur lors de la création du fichier : %v",

--- a/internal/i18n/locales/it.json
+++ b/internal/i18n/locales/it.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "richiesta modelli DigitalOcean fallita con stato %d: %s",
   "disable_openai_responses_api": "Disabilita API OpenAI Responses (predefinito: false)",
   "disable_pattern_variable_replacement": "Disabilita sostituzione variabili pattern",
-  "enable_web_search_tool": "Abilita strumento di ricerca web per modelli supportati (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Abilita strumento di ricerca web per modelli supportati (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Tag di fine per sezioni di pensiero",
   "error_creating_audio_file": "errore nella creazione del file audio: %v",
   "error_creating_file": "errore nella creazione del file: %v",

--- a/internal/i18n/locales/ja.json
+++ b/internal/i18n/locales/ja.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "DigitalOceanモデルリクエストがステータス%dで失敗しました: %s",
   "disable_openai_responses_api": "OpenAI Responses APIを無効化（デフォルト：false）",
   "disable_pattern_variable_replacement": "パターン変数の置換を無効化",
-  "enable_web_search_tool": "サポートされているモデル（Anthropic、OpenAI、Gemini）でウェブ検索ツールを有効化",
+  "enable_web_search_tool": "サポートされているモデル（Anthropic、OpenAI、Gemini、Grok）でウェブ検索ツールを有効化",
   "end_tag_thinking_sections": "思考セクションの終了タグ",
   "error_creating_audio_file": "音声ファイルの作成エラー: %v",
   "error_creating_file": "ファイルの作成エラー: %v",

--- a/internal/i18n/locales/pl.json
+++ b/internal/i18n/locales/pl.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "Żądanie modeli DigitalOcean nie powiodło się ze statusem %d: %s",
   "disable_openai_responses_api": "Wyłącz API odpowiedzi OpenAI (domyślnie: false)",
   "disable_pattern_variable_replacement": "Wyłącz zastępowanie zmiennych wzorców",
-  "enable_web_search_tool": "Włącz narzędzie wyszukiwania internetowego dla obsługiwanych modeli (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Włącz narzędzie wyszukiwania internetowego dla obsługiwanych modeli (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Tag końcowy dla sekcji myślenia",
   "error_creating_audio_file": "błąd podczas tworzenia pliku audio: %v",
   "error_creating_file": "błąd podczas tworzenia pliku: %v",

--- a/internal/i18n/locales/pt-BR.json
+++ b/internal/i18n/locales/pt-BR.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "requisição de modelos do DigitalOcean falhou com status %d: %s",
   "disable_openai_responses_api": "Desabilitar API OpenAI Responses (padrão: false)",
   "disable_pattern_variable_replacement": "Desabilitar substituição de variáveis de padrão",
-  "enable_web_search_tool": "Habilitar ferramenta de busca web para modelos suportados (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Habilitar ferramenta de busca web para modelos suportados (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Tag final para seções de pensamento",
   "error_creating_audio_file": "erro ao criar arquivo de áudio: %v",
   "error_creating_file": "erro ao criar arquivo: %v",

--- a/internal/i18n/locales/pt-PT.json
+++ b/internal/i18n/locales/pt-PT.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "pedido de modelos do DigitalOcean falhou com estado %d: %s",
   "disable_openai_responses_api": "Desabilitar API OpenAI Responses (por omissão: false)",
   "disable_pattern_variable_replacement": "Desabilitar substituição de variáveis de padrão",
-  "enable_web_search_tool": "Habilitar ferramenta de pesquisa web para modelos suportados (Anthropic, OpenAI, Gemini)",
+  "enable_web_search_tool": "Habilitar ferramenta de pesquisa web para modelos suportados (Anthropic, OpenAI, Gemini, Grok)",
   "end_tag_thinking_sections": "Tag final para secções de pensamento",
   "error_creating_audio_file": "erro ao criar ficheiro de áudio: %v",
   "error_creating_file": "erro ao criar ficheiro: %v",

--- a/internal/i18n/locales/zh.json
+++ b/internal/i18n/locales/zh.json
@@ -178,7 +178,7 @@
   "digitalocean_models_request_failed_with_status": "DigitalOcean 模型请求失败，状态码 %d：%s",
   "disable_openai_responses_api": "禁用 OpenAI 响应 API（默认：false）",
   "disable_pattern_variable_replacement": "禁用模式变量替换",
-  "enable_web_search_tool": "为支持的模型启用网络搜索工具（Anthropic、OpenAI、Gemini）",
+  "enable_web_search_tool": "为支持的模型启用网络搜索工具（Anthropic、OpenAI、Gemini、Grok）",
   "end_tag_thinking_sections": "思考部分的结束标签",
   "error_creating_audio_file": "创建音频文件时出错：%v",
   "error_creating_file": "创建文件时出错：%v",


### PR DESCRIPTION
## What this Pull Request (PR) does

PR #2092 added Grok (xAI) web search support. It also changed the go-flags struct tag in `internal/cli/flags.go`.

But `fabric --help` does not show the struct tag. For the `search` flag, `internal/cli/help.go` gives the key `enable_web_search_tool`. The i18n message catalog then supplies the description that the user sees. The struct tag is only a fallback value.

The catalog value showed only Anthropic, OpenAI, and Gemini. Because of this, users cannot find the Grok support in `--help`. The support works correctly.

This PR makes these changes:

- Add `Grok` to the `enable_web_search_tool` value in all 11 locale files. Each locale keeps its own list separator.
- Change the help block in `README.md` to agree with the new values.

This PR does not change program function.

## Related issues

This PR completes the work in PR #2140 by @Resistor52. PR #2179 corrected the zsh and fish completion strings. Thus this PR includes only the locale files and `README.md`. You can close PR #2140 after you merge this PR.

`README.zh.md` does not need a change. That file has no `Application Options` help block.

## Tests

All 11 locale files are correct JSON. The build is successful. The tests in `internal/i18n` and `internal/cli` pass.

```text
JSON OK
BUILD OK
ok  github.com/danielmiessler/fabric/internal/i18n  0.228s
ok  github.com/danielmiessler/fabric/internal/cli   0.675s
```

`fabric --help` shows `Grok` for the `--search` flag in each locale. The locales that do not use the Latin script keep their own list separator.

```text
en  --search   Enable web search tool for supported models (Anthropic, OpenAI, Gemini, Grok)
de  --search   Web-Such-Tool für unterstützte Modelle aktivieren (Anthropic, OpenAI, Gemini, Grok)
ja  --search   サポートされているモデル（Anthropic、OpenAI、Gemini、Grok）でウェブ検索ツールを有効化
fa  --search   فعال‌سازی ابزار جستجوی وب برای مدل‌های پشتیبانی شده (Anthropic، OpenAI، Gemini، Grok)
zh  --search   为支持的模型启用网络搜索工具（Anthropic、OpenAI、Gemini、Grok）
```

## Screenshots

Not applicable. The test output above shows the change to the help text.
