### PR TITLE
fix(patterns): patterns loader temp dir leak

### DIFF
--- a/internal/tools/patterns_loader.go
+++ b/internal/tools/patterns_loader.go
@@ -59,9 +59,21 @@ type PatternsLoader struct {
 
 func (o *PatternsLoader) configure() (err error) {
 	o.pathPatternsPrefix = fmt.Sprintf("%v/", o.DefaultFolder.Value)
+	return
+}
+
+// ensureTempPatternsFolder lazily creates the scratch folder used by the pattern
+// download path. Only PopulateDB and the helpers it calls need it, so it must not
+// be created in configure(): configure() runs on every plugin registry
+// construction, which leaked one empty temp directory per fabric invocation.
+func (o *PatternsLoader) ensureTempPatternsFolder() (err error) {
+	if o.tempPatternsFolder != "" {
+		return
+	}
+
 	// Use a consistent temp folder name regardless of the source path structure
-	tempDir, err := os.MkdirTemp("", "fabric-patterns-")
-	if err != nil {
+	var tempDir string
+	if tempDir, err = os.MkdirTemp("", "fabric-patterns-"); err != nil {
 		return fmt.Errorf(i18n.T("patterns_failed_create_temp_folder"), err)
 	}
 	o.tempPatternsFolder = tempDir
@@ -92,6 +104,16 @@ func (o *PatternsLoader) Setup() (err error) {
 
 // PopulateDB downloads patterns from the internet and populates the patterns folder
 func (o *PatternsLoader) PopulateDB() (err error) {
+	if err = o.ensureTempPatternsFolder(); err != nil {
+		return
+	}
+	// movePatterns removes the folder on success; this also covers the error paths
+	// and leaves the loader reusable if PopulateDB is called again.
+	defer func() {
+		os.RemoveAll(o.tempPatternsFolder)
+		o.tempPatternsFolder = ""
+	}()
+
 	fmt.Printf(i18n.T("patterns_downloading"), o.Patterns.Dir)
 	fmt.Println()
 	fmt.Println()

--- a/internal/tools/patterns_loader_test.go
+++ b/internal/tools/patterns_loader_test.go
@@ -1,0 +1,75 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/danielmiessler/fabric/internal/plugins/db/fsdb"
+)
+
+func newTestPatternsLoader(t *testing.T) *PatternsLoader {
+	t.Helper()
+
+	patternsDir := filepath.Join(t.TempDir(), "patterns")
+	return NewPatternsLoader(&fsdb.PatternsEntity{
+		StorageEntity: &fsdb.StorageEntity{
+			Label:     "Patterns",
+			Dir:       patternsDir,
+			ItemIsDir: true,
+		},
+	})
+}
+
+func countTempPatternsFolders(t *testing.T, dir string) int {
+	t.Helper()
+
+	matches, err := filepath.Glob(filepath.Join(dir, "fabric-patterns-*"))
+	require.NoError(t, err)
+	return len(matches)
+}
+
+// configure() runs on every plugin registry construction, i.e. on every fabric
+// invocation. It must not create the scratch folder that only the pattern
+// download path needs, otherwise each invocation leaks an empty temp directory.
+func TestPatternsLoader_ConfigureDoesNotCreateTempFolder(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+
+	loader := newTestPatternsLoader(t)
+	require.NoError(t, loader.configure())
+
+	assert.Empty(t, loader.tempPatternsFolder)
+	assert.Equal(t, 0, countTempPatternsFolders(t, tempRoot))
+
+	// Repeated invocations must not accumulate directories either.
+	for i := 0; i < 5; i++ {
+		require.NoError(t, loader.configure())
+	}
+	assert.Equal(t, 0, countTempPatternsFolders(t, tempRoot))
+}
+
+func TestPatternsLoader_EnsureTempPatternsFolderIsLazyAndIdempotent(t *testing.T) {
+	tempRoot := t.TempDir()
+	t.Setenv("TMPDIR", tempRoot)
+
+	loader := newTestPatternsLoader(t)
+	require.NoError(t, loader.configure())
+
+	require.NoError(t, loader.ensureTempPatternsFolder())
+	created := loader.tempPatternsFolder
+	require.NotEmpty(t, created)
+	assert.Equal(t, 1, countTempPatternsFolders(t, tempRoot))
+
+	info, err := os.Stat(created)
+	require.NoError(t, err)
+	assert.True(t, info.IsDir())
+
+	// Calling it again reuses the existing folder rather than creating another.
+	require.NoError(t, loader.ensureTempPatternsFolder())
+	assert.Equal(t, created, loader.tempPatternsFolder)
+	assert.Equal(t, 1, countTempPatternsFolders(t, tempRoot))
+}


### PR DESCRIPTION
## What this Pull Request (PR) does

Stops `PatternsLoader` from leaking one empty temp directory per fabric invocation.

`configure()` called `os.MkdirTemp` directly. It is wired as the plugin's
`ConfigureCustom`, so it runs on every `NewPluginRegistry` construction, which means
every fabric invocation created an empty `fabric-patterns-*` directory that nothing
removed. Details and measurements are in #2190.

Only `PopulateDB()` and the helpers it calls read `tempPatternsFolder`, and the
success path already removes the folder in `movePatterns`. So this moves creation into
`ensureTempPatternsFolder()`, called from `PopulateDB()`, plus a deferred cleanup that
also covers the error paths and leaves the loader reusable.

Worth noting for review: a plain `defer os.RemoveAll(tempDir)` inside `configure()`
looks like the obvious one-line fix but is wrong. It deletes the folder before
`gitCloneAndCopy` populates it. Lazy creation is the correct seam.

### Verification

- 20 invocations of `fabric -l` against a configured `~/.config/fabric/.env`:
  20 leaked directories before, 0 after.
- `fabric -U` behaves identically before and after: 255 patterns downloaded,
  257 entries installed, `loaded` marker written, 0 leftover temp directories.
- `go test ./internal/tools/... ./internal/core/... ./internal/plugins/...` passes,
  25 packages, exit 0. `gofmt` and `go vet` clean.
- The new tests fail against unpatched code, confirming they cover the regression
  rather than just passing alongside it.
- Verified on Linux amd64, source build of `main` at `338b89c`.

## Related issues

closes #2190

## Screenshots

N/A, no user-visible output changes.