### PR TITLE
feat: add OrcaRouter as OpenAI-compatible provider

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -151,6 +151,7 @@
 		"opencode",
 		"opencontainers",
 		"openrouter",
+		"OrcaRouter",
 		"organise",
 		"Orus",
 		"osascript",

--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Fabric supports a wide range of AI providers:
 - Mistral
 - Novita AI
 - OpenRouter
+- OrcaRouter
 - SiliconCloud
 - Together
 - Venice AI

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -289,6 +289,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "https://openrouter.ai/api/v1",
 		ImplementsResponses: false,
 	},
+	"OrcaRouter": {
+		Name:                "OrcaRouter",
+		BaseURL:             "https://api.orcarouter.ai/v1",
+		ImplementsResponses: false,
+	},
 	"SiliconCloud": {
 		Name:                "SiliconCloud",
 		BaseURL:             "https://api.siliconflow.cn/v1",

--- a/internal/plugins/ai/openai_compatible/providers_config_test.go
+++ b/internal/plugins/ai/openai_compatible/providers_config_test.go
@@ -36,6 +36,11 @@ func TestCreateClient(t *testing.T) {
 			exists:   true,
 		},
 		{
+			name:     "Existing provider - OrcaRouter",
+			provider: "OrcaRouter",
+			exists:   true,
+		},
+		{
 			name:     "Existing provider - MiniMax",
 			provider: "MiniMax",
 			exists:   true,


### PR DESCRIPTION
# Add OrcaRouter as new OpenAI-compatible AI provider

## Summary

Add first-class support for the **OrcaRouter** OpenAI-compatible provider by registering it in the provider configuration map ([OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible model routing gateway). The provider is registered in `ProviderMap` with base URL `https://api.orcarouter.ai/v1`, so users can configure it via `fabric --setup` / `--listvendors` and route through OrcaRouter (including its `orcarouter/auto` named router) with the same OpenAI-compatible interface as the existing OpenRouter entry.

It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

I'm an engineer on the OrcaRouter team.

## Related Issues

None.

## Files Changed

- **`.vscode/settings.json`**
  - Added `"OrcaRouter"` to the cSpell dictionary to prevent false-positive spelling warnings in the editor.
- **`internal/plugins/ai/openai_compatible/providers_config.go`**
  - Added a new `ProviderConfig` entry for **OrcaRouter** with its base API URL and capability flags.
- **`internal/plugins/ai/openai_compatible/providers_config_test.go`**
  - Added an `OrcaRouter` test case to `TestCreateClient`.
- **`README.md`**
  - Added **OrcaRouter** to the "OpenAI-Compatible Providers" list.

## Code Changes

### `.vscode/settings.json`

Added OrcaRouter to the project-specific spellchecker allowlist:

```json
"openrouter",
"OrcaRouter",
"organise",
```

### `internal/plugins/ai/openai_compatible/providers_config.go`

Registered OrcaRouter in `ProviderMap` so it can be resolved via provider-name lookup:

```go
"OrcaRouter": {
    Name:                "OrcaRouter",
    BaseURL:             "https://api.orcarouter.ai/v1",
    ImplementsResponses: false,
},
```

### `internal/plugins/ai/openai_compatible/providers_config_test.go`

Added a matching `OrcaRouter` case to the existing `TestCreateClient` provider table.

### `README.md`

Added `- OrcaRouter` to the OpenAI-Compatible providers list.

## Usage

1. Get an API key from https://www.orcarouter.ai/console.
2. Run `fabric --setup` and select the `OrcaRouter` vendor (or set `ORCAROUTER_API_KEY`), then pick a model (e.g. `openai/gpt-5.5` or `orcarouter/auto`).

## Verification

- `go build ./...` passes.
- `go test ./internal/plugins/ai/openai_compatible/...` passes.
- Live against OrcaRouter: `POST https://api.orcarouter.ai/v1/chat/completions` with `openai/gpt-5.5` returned 200 (`ORCA-OK`); `GET https://api.orcarouter.ai/v1/models` returned 200.
