### PR TITLE
feat: add TrustedRouter as an OpenAI-compatible provider

### DIFF
--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -299,6 +299,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "https://api.together.xyz/v1",
 		ImplementsResponses: false,
 	},
+	"TrustedRouter": {
+		Name:                "TrustedRouter",
+		BaseURL:             "https://api.trustedrouter.com/v1",
+		ImplementsResponses: false,
+	},
 	"Venice AI": {
 		Name:                "Venice AI",
 		BaseURL:             "https://api.venice.ai/api/v1",

--- a/internal/plugins/ai/openai_compatible/providers_config_test.go
+++ b/internal/plugins/ai/openai_compatible/providers_config_test.go
@@ -41,6 +41,11 @@ func TestCreateClient(t *testing.T) {
 			exists:   true,
 		},
 		{
+			name:     "Existing provider - TrustedRouter",
+			provider: "TrustedRouter",
+			exists:   true,
+		},
+		{
 			name:     "Non-existent provider",
 			provider: "NonExistent",
 			exists:   false,

--- a/internal/server/configuration.go
+++ b/internal/server/configuration.go
@@ -53,16 +53,17 @@ func (h *ConfigHandler) GetConfig(c *gin.Context) {
 
 	if !h.db.IsEnvFileExists() {
 		c.JSON(http.StatusOK, gin.H{
-			"openai":     "",
-			"anthropic":  "",
-			"groq":       "",
-			"mistral":    "",
-			"gemini":     "",
-			"ollama":     "",
-			"openrouter": "",
-			"silicon":    "",
-			"deepseek":   "",
-			"grokai":     "",
+			"openai":        "",
+			"anthropic":     "",
+			"groq":          "",
+			"mistral":       "",
+			"gemini":        "",
+			"ollama":        "",
+			"openrouter":    "",
+			"trustedrouter": "",
+			"silicon":       "",
+			"deepseek":      "",
+			"grokai":        "",
 		})
 		return
 	}
@@ -76,17 +77,18 @@ func (h *ConfigHandler) GetConfig(c *gin.Context) {
 	// API keys are masked to their last 4 characters (CWE-200).
 	// URLs are not secrets and are returned as-is so the UI can display them.
 	config := map[string]string{
-		"openai":     maskAPIKey(os.Getenv("OPENAI_API_KEY")),
-		"anthropic":  maskAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
-		"groq":       maskAPIKey(os.Getenv("GROQ_API_KEY")),
-		"mistral":    maskAPIKey(os.Getenv("MISTRAL_API_KEY")),
-		"gemini":     maskAPIKey(os.Getenv("GEMINI_API_KEY")),
-		"ollama":     os.Getenv("OLLAMA_URL"),
-		"openrouter": maskAPIKey(os.Getenv("OPENROUTER_API_KEY")),
-		"silicon":    maskAPIKey(os.Getenv("SILICON_API_KEY")),
-		"deepseek":   maskAPIKey(os.Getenv("DEEPSEEK_API_KEY")),
-		"grokai":     maskAPIKey(os.Getenv("GROKAI_API_KEY")),
-		"lmstudio":   os.Getenv("LM_STUDIO_API_BASE_URL"),
+		"openai":        maskAPIKey(os.Getenv("OPENAI_API_KEY")),
+		"anthropic":     maskAPIKey(os.Getenv("ANTHROPIC_API_KEY")),
+		"groq":          maskAPIKey(os.Getenv("GROQ_API_KEY")),
+		"mistral":       maskAPIKey(os.Getenv("MISTRAL_API_KEY")),
+		"gemini":        maskAPIKey(os.Getenv("GEMINI_API_KEY")),
+		"ollama":        os.Getenv("OLLAMA_URL"),
+		"openrouter":    maskAPIKey(os.Getenv("OPENROUTER_API_KEY")),
+		"trustedrouter": maskAPIKey(os.Getenv("TRUSTEDROUTER_API_KEY")),
+		"silicon":       maskAPIKey(os.Getenv("SILICON_API_KEY")),
+		"deepseek":      maskAPIKey(os.Getenv("DEEPSEEK_API_KEY")),
+		"grokai":        maskAPIKey(os.Getenv("GROKAI_API_KEY")),
+		"lmstudio":      os.Getenv("LM_STUDIO_API_BASE_URL"),
 	}
 
 	c.JSON(http.StatusOK, config)
@@ -99,17 +101,18 @@ func (h *ConfigHandler) UpdateConfig(c *gin.Context) {
 	}
 
 	var config struct {
-		OpenAIApiKey     string `json:"openai_api_key"`
-		AnthropicApiKey  string `json:"anthropic_api_key"`
-		GroqApiKey       string `json:"groq_api_key"`
-		MistralApiKey    string `json:"mistral_api_key"`
-		GeminiApiKey     string `json:"gemini_api_key"`
-		OllamaURL        string `json:"ollama_url"`
-		OpenRouterApiKey string `json:"openrouter_api_key"`
-		SiliconApiKey    string `json:"silicon_api_key"`
-		DeepSeekApiKey   string `json:"deepseek_api_key"`
-		GrokaiApiKey     string `json:"grokai_api_key"`
-		LMStudioURL      string `json:"lm_studio_base_url"`
+		OpenAIApiKey        string `json:"openai_api_key"`
+		AnthropicApiKey     string `json:"anthropic_api_key"`
+		GroqApiKey          string `json:"groq_api_key"`
+		MistralApiKey       string `json:"mistral_api_key"`
+		GeminiApiKey        string `json:"gemini_api_key"`
+		OllamaURL           string `json:"ollama_url"`
+		OpenRouterApiKey    string `json:"openrouter_api_key"`
+		TrustedRouterApiKey string `json:"trustedrouter_api_key"`
+		SiliconApiKey       string `json:"silicon_api_key"`
+		DeepSeekApiKey      string `json:"deepseek_api_key"`
+		GrokaiApiKey        string `json:"grokai_api_key"`
+		LMStudioURL         string `json:"lm_studio_base_url"`
 	}
 
 	if err := c.ShouldBindJSON(&config); err != nil {
@@ -125,6 +128,7 @@ func (h *ConfigHandler) UpdateConfig(c *gin.Context) {
 		"GEMINI_API_KEY":         config.GeminiApiKey,
 		"OLLAMA_URL":             config.OllamaURL,
 		"OPENROUTER_API_KEY":     config.OpenRouterApiKey,
+		"TRUSTEDROUTER_API_KEY":  config.TrustedRouterApiKey,
 		"SILICON_API_KEY":        config.SiliconApiKey,
 		"DEEPSEEK_API_KEY":       config.DeepSeekApiKey,
 		"GROKAI_API_KEY":         config.GrokaiApiKey,


### PR DESCRIPTION
Adds TrustedRouter to the OpenAI-compatible provider list.

TrustedRouter is an OpenAI-compatible router — one key reaches models from OpenAI, Anthropic, Google, DeepSeek and others, with per-request routing and failover. Base URL is `https://api.trustedrouter.com/v1`.

Since it speaks Chat Completions, this is a single `ProviderMap` entry; `plugin_registry.go` already iterates that map, so no registration code is needed. `BuildEnvVariable` derives `TRUSTEDROUTER_API_KEY` from the provider name automatically.

The REST config handlers get the matching field next to the other providers, so the key can be set through `/config/update` and shows up masked in `GET /config`.

`ImplementsResponses` is false — TrustedRouter exposes Chat Completions, not the Responses API.

Verified: `go build ./...` clean, `go test ./internal/plugins/ai/openai_compatible/... ./internal/server/...` passes, `gofmt` clean. Added a `TestCreateClient` case alongside the existing provider cases.
