### PR TITLE
fix: remove obsolete claude code spoofing comment in anthropic plugin

### DIFF
--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -359,8 +359,6 @@ func (an *Client) toMessages(msgs []*chat.ChatCompletionMessage) (ret []anthropi
 	var anthropicMessages []anthropic.MessageParam
 	var systemContent string
 
-	// Note: Claude Code spoofing is now handled in buildMessageParams
-
 	isFirstUserMessage := true
 	lastRoleWasUser := false
 


### PR DESCRIPTION
**Key Changes:**

- Removed a stale code comment referencing outdated Claude Code spoofing behavior in the Anthropic plugin

**Removed:**

- Obsolete inline comment - Deleted the outdated note about Claude Code spoofing in `toMessages`, as this behavior is now handled in `buildMessageParams` and the comment no longer provided useful context (`internal/plugins/ai/anthropic/anthropic.go`)