### PR TITLE
fix(ollama): honor stream context cancellation

### DIFF
--- a/internal/plugins/ai/ollama/ollama.go
+++ b/internal/plugins/ai/ollama/ollama.go
@@ -104,8 +104,7 @@ func (o *Client) ListModels(_ context.Context) (ret []string, err error) {
 	return
 }
 
-func (o *Client) SendStream(_ context.Context, msgs []*chat.ChatCompletionMessage, opts *domain.ChatOptions, channel chan domain.StreamUpdate) (err error) {
-	ctx := context.Background()
+func (o *Client) SendStream(ctx context.Context, msgs []*chat.ChatCompletionMessage, opts *domain.ChatOptions, channel chan domain.StreamUpdate) (err error) {
 	defer close(channel)
 
 	var req ollamaapi.ChatRequest
@@ -114,20 +113,22 @@ func (o *Client) SendStream(_ context.Context, msgs []*chat.ChatCompletionMessag
 	}
 
 	respFunc := func(resp ollamaapi.ChatResponse) (streamErr error) {
-		channel <- domain.StreamUpdate{
+		if streamErr = sendStreamUpdate(ctx, channel, domain.StreamUpdate{
 			Type:    domain.StreamTypeContent,
 			Content: resp.Message.Content,
+		}); streamErr != nil {
+			return
 		}
 
 		if resp.Done {
-			channel <- domain.StreamUpdate{
+			streamErr = sendStreamUpdate(ctx, channel, domain.StreamUpdate{
 				Type: domain.StreamTypeUsage,
 				Usage: &domain.UsageMetadata{
 					InputTokens:  resp.PromptEvalCount,
 					OutputTokens: resp.EvalCount,
 					TotalTokens:  resp.PromptEvalCount + resp.EvalCount,
 				},
-			}
+			})
 		}
 		return
 	}
@@ -137,6 +138,15 @@ func (o *Client) SendStream(_ context.Context, msgs []*chat.ChatCompletionMessag
 	}
 
 	return
+}
+
+func sendStreamUpdate(ctx context.Context, channel chan domain.StreamUpdate, update domain.StreamUpdate) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case channel <- update:
+		return nil
+	}
 }
 
 func (o *Client) Send(ctx context.Context, msgs []*chat.ChatCompletionMessage, opts *domain.ChatOptions) (ret string, err error) {

--- a/internal/plugins/ai/ollama/ollama_test.go
+++ b/internal/plugins/ai/ollama/ollama_test.go
@@ -3,6 +3,7 @@ package ollama
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -88,4 +89,32 @@ func TestSendStreamClosesChannelOnChatError(t *testing.T) {
 	require.Error(t, err)
 	_, ok := <-channel
 	assert.False(t, ok, "stream channel should be closed when Ollama chat returns an error")
+}
+
+func TestSendStreamReturnsContextCanceledWhenReceiverStops(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done()
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	channel := make(chan domain.StreamUpdate)
+	client := &Client{client: ollamaapi.NewClient(baseURL, server.Client())}
+
+	err = client.SendStream(
+		ctx,
+		[]*chat.ChatCompletionMessage{{Role: chat.ChatMessageRoleUser, Content: "hello"}},
+		&domain.ChatOptions{Model: "test-model"},
+		channel,
+	)
+
+	require.Error(t, err)
+	assert.True(t, errors.Is(err, context.Canceled))
+	_, ok := <-channel
+	assert.False(t, ok, "stream channel should be closed when context is canceled")
 }


### PR DESCRIPTION
## What this Pull Request (PR) does

fixes an ollama streaming bug.. `sendstream` was replacing the caller context with `context.background()`.. so canceled cli sessions or disconnected http clients would not actually stop the in flight ollama request..

this pr makes the ollama stream path honor the incoming context.. and adds a regression test to verify the stream returns `context.canceled` and closes the channel cleanly when the caller is gone..

## Related issues

closes #2196