### PR TITLE
feat: add llmman to the OpenAI-compatible providers

### DIFF
--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -268,6 +268,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "http://localhost:4000",
 		ImplementsResponses: false,
 	},
+	"llmman": {
+		Name:                "llmman",
+		BaseURL:             "http://localhost:17434/v1",
+		ImplementsResponses: false,
+	},
 	"MiniMax": {
 		Name:                "MiniMax",
 		BaseURL:             "https://api.minimax.io/v1",

--- a/internal/plugins/ai/openai_compatible/providers_config_test.go
+++ b/internal/plugins/ai/openai_compatible/providers_config_test.go
@@ -41,6 +41,11 @@ func TestCreateClient(t *testing.T) {
 			exists:   true,
 		},
 		{
+			name:     "Existing provider - llmman",
+			provider: "llmman",
+			exists:   true,
+		},
+		{
 			name:     "Non-existent provider",
 			provider: "NonExistent",
 			exists:   false,


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), which runs local models distributed as OCI artifacts and serves an OpenAI-compatible API on port 17434.

It needs no special handling — no custom `ModelsURL`, no Responses API, no tool overrides — so it's just a `ProviderMap` entry. `LiteLLM` is the precedent for a localhost `BaseURL` in this map.

**Testing:**

```
$ go build ./...
$ go test ./internal/plugins/ai/openai_compatible/...
ok
```

I added a case to the existing `TestCreateClient` table and confirmed it runs by name (`TestCreateClient/Existing_provider_-_llmman ... PASS`) rather than just trusting the suite went green. `gofmt -l` clean.

Not verified: no request against a live llmman server.

> AI-assisted, reviewed before submitting.
