### PR TITLE
fix: validate user input at HTTP boundary to prevent path traversal (…

### DIFF
--- a/internal/cli/setup_server.go
+++ b/internal/cli/setup_server.go
@@ -22,7 +22,7 @@ func handleSetupAndServerCommands(currentFlags *Flags, registry *core.PluginRegi
 
 	if currentFlags.ServeOllama {
 		registry.ConfigureVendors()
-		err = restapi.ServeOllama(registry, currentFlags.ServeAddress, version)
+		err = restapi.ServeOllama(registry, currentFlags.ServeAddress, version, currentFlags.ServeAPIKey)
 		return true, err
 	}
 

--- a/internal/server/chat.go
+++ b/internal/server/chat.go
@@ -78,6 +78,14 @@ func (h *ChatHandler) HandleChat(c *gin.Context) {
 		return
 	}
 
+	for _, p := range request.Prompts {
+		if strings.HasPrefix(p.PatternName, "/") || strings.HasPrefix(p.PatternName, "~") ||
+			strings.HasPrefix(p.PatternName, `\`) || strings.HasPrefix(p.PatternName, ".") {
+			c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid pattern name: %q", p.PatternName)})
+			return
+		}
+	}
+
 	// Add log to check received language field
 	log.Printf("Received chat request - Language: '%s', Prompts: %d", request.Language, len(request.Prompts))
 

--- a/internal/server/ollama.go
+++ b/internal/server/ollama.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"log"
+	"log/slog"
 	"math"
 	"net/http"
 	"net/url"
@@ -188,12 +189,18 @@ func parseOllamaNumCtx(options map[string]any) (int, error) {
 	return contextLength, nil
 }
 
-func ServeOllama(registry *core.PluginRegistry, address string, version string) (err error) {
+func ServeOllama(registry *core.PluginRegistry, address string, version string, apiKey string) (err error) {
 	r := gin.New()
 
 	// Middleware
 	r.Use(gin.Logger())
 	r.Use(gin.Recovery())
+
+	if apiKey != "" {
+		r.Use(APIKeyMiddleware(apiKey))
+	} else {
+		slog.Warn("Starting Ollama API server without API key authentication.")
+	}
 
 	// Register routes
 	fabricDb := registry.Db
@@ -305,13 +312,20 @@ func (f APIConvert) ollamaChat(c *gin.Context) {
 		}
 	}
 
+	patternName := strings.Split(prompt.Model, ":")[0]
+	if strings.HasPrefix(patternName, "/") || strings.HasPrefix(patternName, "~") ||
+		strings.HasPrefix(patternName, `\`) || strings.HasPrefix(patternName, ".") {
+		c.JSON(http.StatusBadRequest, gin.H{"error": fmt.Sprintf("invalid pattern name: %q", patternName)})
+		return
+	}
+
 	if len(prompt.Messages) == 1 {
 		chat.Prompts = []PromptRequest{{
 			UserInput:   prompt.Messages[0].Content,
 			Vendor:      "",
 			Model:       "",
 			ContextName: "",
-			PatternName: strings.Split(prompt.Model, ":")[0],
+			PatternName: patternName,
 			Variables:   variables,
 		}}
 	} else if len(prompt.Messages) > 1 {
@@ -324,7 +338,7 @@ func (f APIConvert) ollamaChat(c *gin.Context) {
 			Vendor:      "",
 			Model:       "",
 			ContextName: "",
-			PatternName: strings.Split(prompt.Model, ":")[0],
+			PatternName: patternName,
 			Variables:   variables,
 		}}
 	}

--- a/internal/server/storage.go
+++ b/internal/server/storage.go
@@ -4,10 +4,18 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	"github.com/danielmiessler/fabric/internal/plugins/db"
 	"github.com/gin-gonic/gin"
 )
+
+func rejectTraversal(name string) error {
+	if strings.Contains(name, "..") || strings.ContainsAny(name, `/\`) {
+		return fmt.Errorf("invalid name: %q", name)
+	}
+	return nil
+}
 
 // StorageHandler defines the handler for storage-related operations
 type StorageHandler[T any] struct {
@@ -50,6 +58,10 @@ func (h *StorageHandler[T]) GetNames(c *gin.Context) {
 // Delete handles the DELETE /storage/:name route
 func (h *StorageHandler[T]) Delete(c *gin.Context) {
 	name := c.Param("name")
+	if err := rejectTraversal(name); err != nil {
+		c.JSON(http.StatusBadRequest, err.Error())
+		return
+	}
 	err := h.storage.Delete(name)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, err.Error())
@@ -69,6 +81,14 @@ func (h *StorageHandler[T]) Exists(c *gin.Context) {
 func (h *StorageHandler[T]) Rename(c *gin.Context) {
 	oldName := c.Param("oldName")
 	newName := c.Param("newName")
+	if err := rejectTraversal(oldName); err != nil {
+		c.JSON(http.StatusBadRequest, err.Error())
+		return
+	}
+	if err := rejectTraversal(newName); err != nil {
+		c.JSON(http.StatusBadRequest, err.Error())
+		return
+	}
 	err := h.storage.Rename(oldName, newName)
 	if err != nil {
 		c.JSON(http.StatusInternalServerError, err.Error())
@@ -80,6 +100,10 @@ func (h *StorageHandler[T]) Rename(c *gin.Context) {
 // Save handles the POST /storage/save/:name route
 func (h *StorageHandler[T]) Save(c *gin.Context) {
 	name := c.Param("name")
+	if err := rejectTraversal(name); err != nil {
+		c.JSON(http.StatusBadRequest, err.Error())
+		return
+	}
 
 	// Read the request body
 	body := c.Request.Body


### PR DESCRIPTION
## What this Pull Request (PR) does

Add rejectTraversal() guard to CRUD handlers blocking ".." and path separators. Add HasPrefix checks on PatternName/Model in chat and Ollama endpoints to prevent loadPattern's file-path branch from reading arbitrary files. Pass apiKey to ServeOllama so the Ollama API respects --api-key configuration.

## Related issues

I opened a security form in the security page and sent an email to whom it may concern

## Screenshots

<img width="2256" height="450" alt="image" src="https://github.com/user-attachments/assets/d5e38d04-5c6c-4b1d-b676-eaba70619992" />
