### PR TITLE
fix(anthropic): adaptive thinking on Claude 5 + add --maxTokens flag

### DIFF
--- a/internal/cli/flags.go
+++ b/internal/cli/flags.go
@@ -49,6 +49,7 @@ type Flags struct {
 	Model                           string               `short:"m" long:"model" yaml:"model" description:"Choose model"`
 	Vendor                          string               `short:"V" long:"vendor" yaml:"vendor" description:"Specify vendor for the selected model (e.g., -V \"LM Studio\" -m openai/gpt-oss-20b)"`
 	ModelContextLength              int                  `long:"modelContextLength" yaml:"modelContextLength" description:"Model context length (only affects ollama)"`
+	MaxTokens                       int                  `long:"maxTokens" yaml:"maxTokens" description:"Maximum tokens the model may generate, including reasoning/thinking tokens (0 = vendor default)"`
 	Output                          string               `short:"o" long:"output" description:"Output to file" default:""`
 	OutputSession                   bool                 `long:"output-session" description:"Output the entire session (also a temporary one) to the output file"`
 	LatestPatterns                  string               `short:"n" long:"latest" description:"Number of latest patterns to list" default:"0"`
@@ -461,6 +462,7 @@ func (o *Flags) BuildChatOptions() (ret *domain.ChatOptions, err error) {
 		Seed:                o.Seed,
 		Thinking:            o.Thinking,
 		ModelContextLength:  o.ModelContextLength,
+		MaxTokens:           o.MaxTokens,
 		Search:              o.Search,
 		SearchLocation:      o.SearchLocation,
 		ImageFile:           o.ImageFile,

--- a/internal/plugins/ai/anthropic/anthropic.go
+++ b/internal/plugins/ai/anthropic/anthropic.go
@@ -41,6 +41,53 @@ func modelDisallowsSamplingParams(model string) bool {
 	})
 }
 
+// These models reject the legacy `thinking.type=enabled` + `budget_tokens`
+// shape and require `thinking.type=adaptive` with `output_config.effort`.
+// Sending the legacy shape to one of them fails the request outright:
+//
+//	"thinking.type.enabled" is not supported for this model.
+//	Use "thinking.type.adaptive" and "output_config.effort" to control
+//	thinking behavior.
+var adaptiveThinkingPrefixes = []string{
+	"claude-opus-5",
+	"claude-sonnet-5",
+	"claude-fable-5",
+}
+
+func modelUsesAdaptiveThinking(model string) bool {
+	return slices.ContainsFunc(adaptiveThinkingPrefixes, func(prefix string) bool {
+		return strings.HasPrefix(model, prefix)
+	})
+}
+
+// effortForBudget buckets an explicit token budget onto the nearest effort
+// level, so a numeric --thinking value keeps working on adaptive-only models
+// (which have no budget_tokens concept). Thresholds are the same constants the
+// named levels use, so `--thinking=2048` and `--thinking=medium` agree.
+func effortForBudget(tokens int64) anthropic.OutputConfigEffort {
+	switch {
+	case tokens <= domain.TokenBudgetLow:
+		return anthropic.OutputConfigEffortLow
+	case tokens <= domain.TokenBudgetMedium:
+		return anthropic.OutputConfigEffortMedium
+	default:
+		return anthropic.OutputConfigEffortHigh
+	}
+}
+
+// effortForLevel maps a named thinking level onto an effort level.
+func effortForLevel(level domain.ThinkingLevel) (anthropic.OutputConfigEffort, bool) {
+	switch level {
+	case domain.ThinkingLow:
+		return anthropic.OutputConfigEffortLow, true
+	case domain.ThinkingMedium:
+		return anthropic.OutputConfigEffortMedium, true
+	case domain.ThinkingHigh:
+		return anthropic.OutputConfigEffortHigh, true
+	}
+	return "", false
+}
+
 func NewClient() (ret *Client) {
 	vendorName := "Anthropic"
 	ret = &Client{}
@@ -150,24 +197,45 @@ func (an *Client) ListModels(context.Context) (ret []string, err error) {
 	return an.models, nil
 }
 
-func parseThinking(level domain.ThinkingLevel) (anthropic.ThinkingConfigParamUnion, bool) {
+// parseThinking translates a thinking level into the request shape the given
+// model accepts. `effort` is non-empty only for adaptive-thinking models, in
+// which case the caller must also set params.OutputConfig.Effort -- adaptive
+// carries no budget, so effort is where the level actually lands.
+func parseThinking(level domain.ThinkingLevel, model string) (
+	thinking anthropic.ThinkingConfigParamUnion, effort anthropic.OutputConfigEffort, ok bool) {
+
 	lower := strings.ToLower(string(level))
+	adaptive := modelUsesAdaptiveThinking(model)
+
 	switch domain.ThinkingLevel(lower) {
 	case domain.ThinkingOff:
+		// `disabled` is accepted by both generations, so it needs no branch.
 		disabled := anthropic.NewThinkingConfigDisabledParam()
-		return anthropic.ThinkingConfigParamUnion{OfDisabled: &disabled}, true
+		return anthropic.ThinkingConfigParamUnion{OfDisabled: &disabled}, "", true
 	case domain.ThinkingLow, domain.ThinkingMedium, domain.ThinkingHigh:
-		if budget, ok := domain.ThinkingBudgets[domain.ThinkingLevel(lower)]; ok {
-			return anthropic.ThinkingConfigParamOfEnabled(budget), true
+		if adaptive {
+			if e, found := effortForLevel(domain.ThinkingLevel(lower)); found {
+				adaptiveParam := anthropic.ThinkingConfigAdaptiveParam{}
+				return anthropic.ThinkingConfigParamUnion{OfAdaptive: &adaptiveParam}, e, true
+			}
+			return anthropic.ThinkingConfigParamUnion{}, "", false
+		}
+		if budget, found := domain.ThinkingBudgets[domain.ThinkingLevel(lower)]; found {
+			return anthropic.ThinkingConfigParamOfEnabled(budget), "", true
 		}
 	default:
 		if tokens, err := strconv.ParseInt(lower, 10, 64); err == nil {
 			if tokens >= 1 && tokens <= 10000 {
-				return anthropic.ThinkingConfigParamOfEnabled(tokens), true
+				if adaptive {
+					adaptiveParam := anthropic.ThinkingConfigAdaptiveParam{}
+					return anthropic.ThinkingConfigParamUnion{OfAdaptive: &adaptiveParam},
+						effortForBudget(tokens), true
+				}
+				return anthropic.ThinkingConfigParamOfEnabled(tokens), "", true
 			}
 		}
 	}
-	return anthropic.ThinkingConfigParamUnion{}, false
+	return anthropic.ThinkingConfigParamUnion{}, "", false
 }
 
 func (an *Client) SendStream(
@@ -276,8 +344,11 @@ func (an *Client) buildMessageParams(msgs []anthropic.MessageParam, opts *domain
 		}
 	}
 
-	if t, ok := parseThinking(opts.Thinking); ok {
+	if t, effort, ok := parseThinking(opts.Thinking, opts.Model); ok {
 		params.Thinking = t
+		if effort != "" {
+			params.OutputConfig.Effort = effort
+		}
 	}
 
 	return

--- a/internal/plugins/ai/anthropic/anthropic_test.go
+++ b/internal/plugins/ai/anthropic/anthropic_test.go
@@ -424,3 +424,125 @@ func TestToMessages_MultiContentPDFAttachment(t *testing.T) {
 		t.Fatalf("Expected document data to match base64 payload, got %s", document.Source.OfBase64.Data)
 	}
 }
+
+func TestParseThinking_AdaptiveModelUsesAdaptivePlusEffort(t *testing.T) {
+	for _, tc := range []struct {
+		level  domain.ThinkingLevel
+		effort anthropic.OutputConfigEffort
+	}{
+		{domain.ThinkingLow, anthropic.OutputConfigEffortLow},
+		{domain.ThinkingMedium, anthropic.OutputConfigEffortMedium},
+		{domain.ThinkingHigh, anthropic.OutputConfigEffortHigh},
+	} {
+		thinking, effort, ok := parseThinking(tc.level, string(anthropic.ModelClaudeSonnet5))
+		if !ok {
+			t.Fatalf("parseThinking(%q) returned ok=false", tc.level)
+		}
+		if thinking.OfAdaptive == nil {
+			t.Errorf("level %q: expected OfAdaptive to be set on an adaptive model", tc.level)
+		}
+		if thinking.OfEnabled != nil {
+			t.Errorf("level %q: OfEnabled must NOT be set on an adaptive model; the API rejects it", tc.level)
+		}
+		if effort != tc.effort {
+			t.Errorf("level %q: expected effort %q, got %q", tc.level, tc.effort, effort)
+		}
+	}
+}
+
+func TestParseThinking_LegacyModelKeepsBudgetTokens(t *testing.T) {
+	thinking, effort, ok := parseThinking(domain.ThinkingMedium, string(anthropic.ModelClaudeOpus4_7))
+	if !ok {
+		t.Fatal("parseThinking returned ok=false")
+	}
+	if thinking.OfEnabled == nil {
+		t.Fatal("expected OfEnabled (budget_tokens) to be set on a non-adaptive model")
+	}
+	if thinking.OfEnabled.BudgetTokens != domain.TokenBudgetMedium {
+		t.Errorf("expected budget %d, got %d", domain.TokenBudgetMedium, thinking.OfEnabled.BudgetTokens)
+	}
+	if effort != "" {
+		t.Errorf("effort must be empty for a non-adaptive model, got %q", effort)
+	}
+}
+
+func TestParseThinking_OffIsDisabledOnBothGenerations(t *testing.T) {
+	for _, model := range []string{
+		string(anthropic.ModelClaudeSonnet5),
+		string(anthropic.ModelClaudeOpus4_7),
+	} {
+		thinking, effort, ok := parseThinking(domain.ThinkingOff, model)
+		if !ok {
+			t.Fatalf("model %s: parseThinking returned ok=false", model)
+		}
+		if thinking.OfDisabled == nil {
+			t.Errorf("model %s: expected OfDisabled to be set", model)
+		}
+		if effort != "" {
+			t.Errorf("model %s: effort must be empty when thinking is off, got %q", model, effort)
+		}
+	}
+}
+
+func TestParseThinking_NumericBudgetBucketsToEffortOnAdaptiveModel(t *testing.T) {
+	for _, tc := range []struct {
+		tokens string
+		effort anthropic.OutputConfigEffort
+	}{
+		{"512", anthropic.OutputConfigEffortLow},
+		{"1024", anthropic.OutputConfigEffortLow},
+		{"2048", anthropic.OutputConfigEffortMedium},
+		{"9000", anthropic.OutputConfigEffortHigh},
+	} {
+		thinking, effort, ok := parseThinking(domain.ThinkingLevel(tc.tokens), string(anthropic.ModelClaudeSonnet5))
+		if !ok {
+			t.Fatalf("tokens %s: parseThinking returned ok=false", tc.tokens)
+		}
+		if thinking.OfAdaptive == nil {
+			t.Errorf("tokens %s: expected OfAdaptive on an adaptive model", tc.tokens)
+		}
+		if effort != tc.effort {
+			t.Errorf("tokens %s: expected effort %q, got %q", tc.tokens, tc.effort, effort)
+		}
+	}
+}
+
+func TestBuildMessageParams_AdaptiveModelSetsOutputConfigEffort(t *testing.T) {
+	client := NewClient()
+	opts := &domain.ChatOptions{
+		Model:    string(anthropic.ModelClaudeSonnet5),
+		Thinking: domain.ThinkingMedium,
+	}
+	messages := []anthropic.MessageParam{
+		anthropic.NewUserMessage(anthropic.NewTextBlock("Hello")),
+	}
+
+	params := client.buildMessageParams(messages, opts)
+
+	if params.Thinking.OfAdaptive == nil {
+		t.Error("expected adaptive thinking config on the request")
+	}
+	if params.OutputConfig.Effort != anthropic.OutputConfigEffortMedium {
+		t.Errorf("expected output_config.effort=medium, got %q", params.OutputConfig.Effort)
+	}
+}
+
+func TestBuildMessageParams_LegacyModelLeavesOutputConfigEmpty(t *testing.T) {
+	client := NewClient()
+	opts := &domain.ChatOptions{
+		Model:    string(anthropic.ModelClaudeOpus4_7),
+		Thinking: domain.ThinkingMedium,
+	}
+	messages := []anthropic.MessageParam{
+		anthropic.NewUserMessage(anthropic.NewTextBlock("Hello")),
+	}
+
+	params := client.buildMessageParams(messages, opts)
+
+	if params.Thinking.OfEnabled == nil {
+		t.Error("expected legacy budget_tokens thinking config on the request")
+	}
+	if params.OutputConfig.Effort != "" {
+		t.Errorf("output_config.effort must stay empty for a legacy model, got %q", params.OutputConfig.Effort)
+	}
+}


### PR DESCRIPTION
Two independent changes to the Anthropic plugin's token and thinking control. Both are small, both are backwards compatible, and they can be split into separate PRs if you'd rather review them apart.

## 1. `--thinking` is broken on Claude 5 models (bug)

`claude-sonnet-5`, `claude-opus-5`, and `claude-fable-5` reject the legacy `thinking.type=enabled` + `budget_tokens` shape:

```
"thinking.type.enabled" is not supported for this model.
Use "thinking.type.adaptive" and "output_config.effort" to control thinking behavior.
```

`parseThinking` emits that shape for every value except `off`, so on the current flagship models `--thinking=low | medium | high` and every numeric budget return HTTP 400. Only `--thinking=off` works, because `thinking.type=disabled` is still accepted. The flag is effectively a boolean on the models most people are using.

Reproduce on `main`:

```
fabric -p <any-pattern> -m claude-sonnet-5 --thinking=medium
POST "https://api.anthropic.com/v1/messages": 400 Bad Request
```

`parseThinking` now takes the model and picks the shape that model accepts:

- `off` -> `thinking.type=disabled` on both generations, unchanged
- `low | medium | high` -> `adaptive` + `output_config.effort` on Claude 5, `enabled` + `budget_tokens` on older models
- numeric budget -> bucketed onto the nearest effort level on Claude 5, `enabled` + `budget_tokens` on older models

Numeric values keep working on adaptive models by bucketing at the same thresholds the named levels already use, so `--thinking=2048` and `--thinking=medium` agree instead of one of them erroring. Model detection follows the prefix-list idiom already in that file for `modelDisallowsSamplingParams`, which happens to already list the same three models.

## 2. No CLI flag can set `max_tokens` (missing flag)

`domain.ChatOptions.MaxTokens` already exists and the Anthropic plugin already honors it (`if opts.MaxTokens > 0`), but nothing ever populates it, so every Anthropic call is pinned to the plugin's hardcoded `ret.maxTokens = 4096` with no way to raise it.

4096 is not enough for a pattern that emits a large structured document AND lets the model think, because thinking tokens are billed against the same budget. Measured with `claude-sonnet-5` on a YAML-emitting pattern over a 34k-char transcript:

| max_tokens | stop_reason | output | thinking | text | result |
|---|---|---|---|---|---|
| 4096 | `max_tokens` | 4096 | 1562 | 2534 | YAML cut mid-scalar |
| 16384 | `end_turn` | 5679 | 2819 | 2860 | complete |

Worth calling out separately, because it bit me and it is not this PR's problem to fix: a `max_tokens` stop is not an error, so `fabric` prints the truncated text and exits 0. Anything parsing that output sees a silent partial. Happy to open an issue for it.

`--maxTokens` mirrors the existing `--modelContextLength` wiring exactly: declare the flag, pass it to `ChatOptions`. 0 keeps the vendor default, so nothing changes unless you set it.

## Testing

- 6 new unit tests in `internal/plugins/ai/anthropic/anthropic_test.go` covering adaptive vs legacy shape per model, `off` on both generations, numeric bucketing, and that `output_config.effort` is set on Claude 5 and left empty on older models.
- `go test ./internal/...` green across 30 packages, `gofmt` and `go vet` clean.
- Verified live against the API on both fixes: `--thinking=medium -m claude-sonnet-5` now exits 0 with a complete response, and the pattern that truncated at 4096 completes at `--maxTokens=16384`.
