### PR TITLE
feat: add Pzero as an OpenAI-compatible AI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,7 @@ Fabric supports a wide range of AI providers:
 - Mistral
 - Novita AI
 - OpenRouter
+- Pzero
 - SiliconCloud
 - Synthorai
 - Together

--- a/cmd/generate_changelog/incoming/2210.txt
+++ b/cmd/generate_changelog/incoming/2210.txt
@@ -1,0 +1,5 @@
+### PR [#2210](https://github.com/danielmiessler/Fabric/pull/2210) by [ksylvan](https://github.com/ksylvan): feat: add Pzero as an OpenAI-compatible AI provider
+
+- Added Pzero as an OpenAI-compatible AI provider.
+- Registered Pzero with its OpenAI-compatible API base URL.
+- Added Pzero to the README’s list of supported AI providers.

--- a/internal/plugins/ai/openai_compatible/providers_config.go
+++ b/internal/plugins/ai/openai_compatible/providers_config.go
@@ -289,6 +289,11 @@ var ProviderMap = map[string]ProviderConfig{
 		BaseURL:             "https://openrouter.ai/api/v1",
 		ImplementsResponses: false,
 	},
+	"Pzero": {
+		Name:                "Pzero",
+		BaseURL:             "https://api.pzero.studio/v1",
+		ImplementsResponses: false,
+	},
 	"SiliconCloud": {
 		Name:                "SiliconCloud",
 		BaseURL:             "https://api.siliconflow.cn/v1",


### PR DESCRIPTION
# feat: add Pzero as an OpenAI-compatible AI provider

Closes #2202 

## Summary

Add Pzero as a supported OpenAI-compatible AI provider. The provider uses Pzero’s `/v1` API endpoint and does not enable the OpenAI Responses API.

## Files Changed

- **`README.md`**
  - Added Pzero to the documented list of supported AI providers.

- **`internal/plugins/ai/openai_compatible/providers_config.go`**
  - Added Pzero to the OpenAI-compatible provider configuration map.

## Code Changes

### `README.md`

Added Pzero to the supported provider list:

```markdown
- Pzero
```

### `internal/plugins/ai/openai_compatible/providers_config.go`

Registered Pzero with its API base URL:

```go
"Pzero": {
    Name:                "Pzero",
    BaseURL:             "https://api.pzero.studio/v1",
    ImplementsResponses: false,
},
```

The provider is configured to use the existing OpenAI-compatible integration. `ImplementsResponses` is disabled because Pzero is not configured to support the OpenAI Responses API.

## Reason for Changes

This change enables Fabric users to select Pzero as an AI provider through the existing OpenAI-compatible provider infrastructure. Documentation is updated at the same time so that the public provider list remains consistent with the available configuration.

## Impact of Changes

- Adds Pzero as a selectable OpenAI-compatible provider.
- Routes Pzero requests to `https://api.pzero.studio/v1`.
- Retains the existing behavior for all other providers.
- Does not add support for the Responses API when using Pzero.
- Introduces no migrations or breaking configuration changes.

Potential issues to verify include:

- The provider name must be supplied with the expected capitalization: `Pzero`.
- The configured base URL must expose the OpenAI-compatible endpoints expected by the integration.
- Pzero credentials must be accepted through the existing API-key configuration flow.
- Features dependent on the Responses API will remain unavailable for this provider.

## Test Plan

- Confirm Pzero appears in provider discovery or selection where `ProviderMap` is used.
- Configure a valid Pzero API key and issue a standard chat-completions request.
- Verify requests are sent to `https://api.pzero.studio/v1`.
- Confirm the provider does not attempt to use the Responses API.
- Run the existing OpenAI-compatible provider test suite and verify no regressions for other providers.
- Review the README provider list to confirm Pzero is included in the expected alphabetical position.

## Additional Notes

No automated tests are included in this diff. Validation requires valid Pzero credentials for an end-to-end request.
