### PR TITLE
fix: prevent pattern loader temporary directory leaks

### DIFF
--- a/cmd/generate_changelog/incoming/2211.txt
+++ b/cmd/generate_changelog/incoming/2211.txt
@@ -1,0 +1,4 @@
+### PR [#2211](https://github.com/danielmiessler/Fabric/pull/2211) by [ksylvan](https://github.com/ksylvan): fix: prevent pattern loader temporary directory leaks
+
+- Prevent pattern loader leaks by lazily creating temporary directories during database population and cleaning them up after successful or failed downloads.
+- Add regression tests for lazy directory creation and cleanup.

--- a/internal/tools/patterns_loader.go
+++ b/internal/tools/patterns_loader.go
@@ -59,13 +59,6 @@ type PatternsLoader struct {
 
 func (o *PatternsLoader) configure() (err error) {
 	o.pathPatternsPrefix = fmt.Sprintf("%v/", o.DefaultFolder.Value)
-	// Use a consistent temp folder name regardless of the source path structure
-	tempDir, err := os.MkdirTemp("", "fabric-patterns-")
-	if err != nil {
-		return fmt.Errorf(i18n.T("patterns_failed_create_temp_folder"), err)
-	}
-	o.tempPatternsFolder = tempDir
-
 	return
 }
 
@@ -95,6 +88,15 @@ func (o *PatternsLoader) PopulateDB() (err error) {
 	fmt.Printf(i18n.T("patterns_downloading"), o.Patterns.Dir)
 	fmt.Println()
 	fmt.Println()
+
+	// Create the temp folder here, not in configure(), so invocations that
+	// do not download patterns do not leak an empty directory (issue #2190).
+	var tempDir string
+	if tempDir, err = os.MkdirTemp("", "fabric-patterns-"); err != nil {
+		return fmt.Errorf(i18n.T("patterns_failed_create_temp_folder"), err)
+	}
+	o.tempPatternsFolder = tempDir
+	defer os.RemoveAll(tempDir)
 
 	originalPath := o.DefaultFolder.Value
 	if err = o.gitCloneAndCopy(); err != nil {

--- a/internal/tools/patterns_loader_test.go
+++ b/internal/tools/patterns_loader_test.go
@@ -1,0 +1,63 @@
+package tools
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/danielmiessler/fabric/internal/plugins/db/fsdb"
+)
+
+// Configure runs on every fabric invocation via the plugin registry. It must
+// not create the patterns temp directory; only PopulateDB uses it.
+func TestConfigureDoesNotCreateTempDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	t.Setenv("TMP", tmp)
+	t.Setenv("TEMP", tmp)
+
+	loader := NewPatternsLoader(&fsdb.PatternsEntity{
+		StorageEntity: &fsdb.StorageEntity{Dir: t.TempDir()},
+	})
+	if err := loader.Configure(); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+
+	matches, err := filepath.Glob(filepath.Join(tmp, "fabric-patterns-*"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(matches) != 0 {
+		t.Errorf("Configure() created temp directories: %v", matches)
+	}
+}
+
+// PopulateDB must create the temp directory lazily and remove it when done,
+// even on failure.
+func TestPopulateDBCleansUpTempDir(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("TMPDIR", tmp)
+	t.Setenv("TMP", tmp)
+	t.Setenv("TEMP", tmp)
+
+	loader := NewPatternsLoader(&fsdb.PatternsEntity{
+		StorageEntity: &fsdb.StorageEntity{Dir: t.TempDir()},
+	})
+	if err := loader.Configure(); err != nil {
+		t.Fatalf("Configure() failed: %v", err)
+	}
+	// Point at an invalid repo so PopulateDB fails fast without network.
+	loader.DefaultGitRepoUrl.Value = filepath.Join(t.TempDir(), "no-such-repo")
+
+	if err := loader.PopulateDB(); err == nil {
+		t.Fatal("PopulateDB() unexpectedly succeeded with invalid repo")
+	}
+
+	entries, err := os.ReadDir(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		t.Errorf("PopulateDB() left temp entry behind: %v", e.Name())
+	}
+}


### PR DESCRIPTION
# fix: prevent pattern loader temporary directory leaks

Fixes #2190

## Summary

Move patterns temporary-directory creation from `PatternsLoader.configure()` to `PatternsLoader.PopulateDB()` and ensure the directory is removed after population completes or fails.

This prevents routine Fabric invocations from creating unused `fabric-patterns-*` directories and addresses the temporary-directory leak described in issue #2190.

## Files Changed

- **`internal/tools/patterns_loader.go`**
  - Removed eager temporary-directory creation from loader configuration.
  - Added lazy temporary-directory creation to `PopulateDB()`.
  - Added deferred cleanup with `os.RemoveAll()`.

- **`internal/tools/patterns_loader_test.go`**
  - Added regression coverage confirming that configuration does not create a temporary directory.
  - Added coverage confirming that `PopulateDB()` removes its temporary directory after an error.

## Code Changes

### `internal/tools/patterns_loader.go`

`configure()` now only initializes the patterns path prefix. It no longer creates filesystem resources during normal plugin initialization.

Temporary-directory creation now occurs immediately before patterns are downloaded:

```go
var tempDir string
if tempDir, err = os.MkdirTemp("", "fabric-patterns-"); err != nil {
	return fmt.Errorf(i18n.T("patterns_failed_create_temp_folder"), err)
}
o.tempPatternsFolder = tempDir
defer os.RemoveAll(tempDir)
```

This scopes the temporary directory to the operation that requires it. The deferred cleanup runs on both successful completion and early returns caused by clone, copy, or subsequent population errors.

### `internal/tools/patterns_loader_test.go`

Added `TestConfigureDoesNotCreateTempDir`, which redirects platform temporary-directory environment variables to a test-owned directory and verifies that `Configure()` does not create any `fabric-patterns-*` directories.

Added `TestPopulateDBCleansUpTempDir`, which:

1. Redirects temporary files to a test-owned directory.
2. Configures a patterns loader.
3. Uses an invalid local repository path to trigger a deterministic failure without network access.
4. Verifies that no temporary entries remain after `PopulateDB()` returns.

## Reason for Changes

`PatternsLoader.Configure()` runs through the plugin registry on every Fabric invocation, including commands that do not download or update patterns. Creating a temporary directory during configuration therefore produced unused directories that were not cleaned up.

Creating the directory lazily in `PopulateDB()` ensures that filesystem resources are allocated only when pattern population requires them. Deferring removal prevents stale directories from accumulating after either successful or failed operations.

## Impact of Changes

- Normal Fabric invocations that do not populate patterns no longer create empty temporary directories.
- Pattern population continues to use an isolated `fabric-patterns-*` directory.
- Temporary data is removed when `PopulateDB()` exits, including error paths.
- No command-line interface or configuration behavior changes are introduced.
- Pattern download and database population behavior remains otherwise unchanged.

## Test Plan

Automated regression tests cover the affected lifecycle behavior:

- Run `go test ./internal/tools`.
- Verify `Configure()` creates no patterns temporary directory.
- Verify a failed `PopulateDB()` invocation cleans up its temporary directory.
- Optionally run a successful pattern population flow and confirm:
  - Patterns are cloned and copied correctly.
  - The database is populated as expected.
  - No `fabric-patterns-*` directory remains afterward.

## Additional Notes

- Cleanup is intentionally registered immediately after successful temporary-directory creation so all later return paths are covered.
- `os.RemoveAll()` cleanup errors are currently ignored because cleanup is deferred and should not replace the primary population result. If cleanup failures need to be observable, they can be captured and joined with the returned error in a follow-up change.
- The added cleanup test exercises the failure path using an invalid local repository, avoiding external network dependencies.
