### PR TITLE
fix(ollama): honor caller context in SendStream and ListModels

### DIFF
--- a/internal/plugins/ai/ollama/ollama.go
+++ b/internal/plugins/ai/ollama/ollama.go
@@ -90,9 +90,7 @@ func (o *Client) configure() (err error) {
 	return
 }
 
-func (o *Client) ListModels(_ context.Context) (ret []string, err error) {
-	ctx := context.Background()
-
+func (o *Client) ListModels(ctx context.Context) (ret []string, err error) {
 	var listResp *ollamaapi.ListResponse
 	if listResp, err = o.client.List(ctx); err != nil {
 		return
@@ -104,8 +102,7 @@ func (o *Client) ListModels(_ context.Context) (ret []string, err error) {
 	return
 }
 
-func (o *Client) SendStream(_ context.Context, msgs []*chat.ChatCompletionMessage, opts *domain.ChatOptions, channel chan domain.StreamUpdate) (err error) {
-	ctx := context.Background()
+func (o *Client) SendStream(ctx context.Context, msgs []*chat.ChatCompletionMessage, opts *domain.ChatOptions, channel chan domain.StreamUpdate) (err error) {
 	defer close(channel)
 
 	var req ollamaapi.ChatRequest

--- a/internal/plugins/ai/ollama/ollama_test.go
+++ b/internal/plugins/ai/ollama/ollama_test.go
@@ -3,12 +3,16 @@ package ollama
 import (
 	"context"
 	"encoding/base64"
+	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
 	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/danielmiessler/fabric/internal/chat"
 	"github.com/danielmiessler/fabric/internal/domain"
@@ -63,6 +67,85 @@ func TestLoadImageBytes_DataURLSuccess(t *testing.T) {
 	got, err := client.loadImageBytes(context.Background(), dataURL)
 	require.NoError(t, err)
 	assert.Equal(t, expected, got)
+}
+
+// TestSendStreamHonorsContextCancellation verifies that cancelling the caller's
+// context aborts an in-flight Ollama generation, instead of running the stream to
+// server completion. Regression test for issue #2196.
+func TestSendStreamHonorsContextCancellation(t *testing.T) {
+	const totalChunks = 20
+
+	var streamedAll atomic.Bool
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/x-ndjson")
+		flusher, ok := w.(http.Flusher)
+		require.True(t, ok, "test server ResponseWriter must support flushing")
+		enc := json.NewEncoder(w)
+
+		for i := range totalChunks {
+			select {
+			case <-r.Context().Done():
+				// Client disconnected (context cancelled): stop generating.
+				return
+			default:
+			}
+
+			_ = enc.Encode(ollamaapi.ChatResponse{
+				Model:   "test-model",
+				Message: ollamaapi.Message{Role: "assistant", Content: "chunk "},
+				Done:    i == totalChunks-1,
+			})
+			flusher.Flush()
+			time.Sleep(25 * time.Millisecond)
+		}
+		streamedAll.Store(true)
+	}))
+	t.Cleanup(server.Close)
+
+	baseURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	client := &Client{client: ollamaapi.NewClient(baseURL, server.Client())}
+	channel := make(chan domain.StreamUpdate)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- client.SendStream(
+			ctx,
+			[]*chat.ChatCompletionMessage{{Role: chat.ChatMessageRoleUser, Content: "hello"}},
+			&domain.ChatOptions{Model: "test-model"},
+			channel,
+		)
+	}()
+
+	// Consume the first chunk, then cancel mid-stream.
+	select {
+	case _, ok := <-channel:
+		require.True(t, ok, "expected at least one stream update before cancellation")
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for first stream update")
+	}
+	cancel()
+
+	// Drain any remaining updates so SendStream can return.
+	for range channel {
+	}
+
+	select {
+	case err = <-errCh:
+	case <-time.After(5 * time.Second):
+		t.Fatal("SendStream did not return after context cancellation")
+	}
+
+	require.Error(t, err, "SendStream should surface the cancellation error")
+	assert.True(t, errors.Is(err, context.Canceled),
+		"SendStream should return a context.Canceled error, got: %v", err)
+	assert.False(t, streamedAll.Load(),
+		"server should not have streamed every chunk; cancellation was ignored")
 }
 
 func TestSendStreamClosesChannelOnChatError(t *testing.T) {


### PR DESCRIPTION
`SendStream` and `ListModels` in `internal/plugins/ai/ollama/ollama.go` named their `context.Context` parameter `_` and replaced it with `context.Background()`, so caller cancellation never reached `o.client.Chat` / `o.client.List`.

In the SSE server path the cancelable Gin request context is threaded all the way down (`internal/server/chat.go` → `internal/core/chatter.go:110` → `o.vendor.SendStream(ctx, ...)`), so a disconnected web client left the Ollama generation running to completion — wasted compute and a leaked in-flight request. The sibling `Send` method already threads `ctx`, and the `Vendor` interface (`internal/plugins/ai/vendor.go`) declares `context.Context` parameters, so honoring it matches existing intent.

### Fix

Rename the discarded parameters to `ctx` and drop both `ctx := context.Background()` lines (Ollama only — 7 lines).

### Test

`TestSendStreamHonorsContextCancellation` (`ollama_test.go`): an `httptest` `/api/chat` NDJSON server emits 20 chunks at 25 ms each; the test cancels the context after the first chunk. Modeled on the existing `TestSendStreamClosesChannelOnChatError`.
- **Before:** runs the full ~0.51 s (all 20 chunks) and returns `nil` — cancellation ignored.
- **After:** returns promptly (~0.03 s) with `context.Canceled`; the server did not finish streaming.

Verified: `gofmt -l` clean, `go vet ./...` exit 0, `go build ./...` exit 0, `go test ./internal/plugins/ai/ollama/...` ok.

### Follow-up (out of scope here)

The same discard-the-context pattern exists in sibling vendors (e.g. perplexity, bedrock). I kept this PR minimal and Ollama-only; happy to send a follow-up sweeping the rest if desired.

Closes #2196
