### PR TITLE
fix(copilot): grow SSE scanner buffer to avoid truncating long responses

### DIFF
--- a/internal/plugins/ai/copilot/copilot.go
+++ b/internal/plugins/ai/copilot/copilot.go
@@ -354,6 +354,11 @@ func (c *Client) sendChatMessageStream(ctx context.Context, conversationID, mess
 // parseSSEStream parses the Server-Sent Events stream from Copilot.
 func (c *Client) parseSSEStream(reader io.Reader, channel chan domain.StreamUpdate) error {
 	scanner := bufio.NewScanner(reader)
+	// Copilot SSE frames carry the cumulative message-so-far on a single
+	// "data: {json}" line, so a long response can exceed the default 64 KiB
+	// token limit and abort the scan with bufio.ErrTooLong. Grow the buffer,
+	// mirroring internal/server/ollama.go.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 	var lastMessageText string
 
 	for scanner.Scan() {

--- a/internal/plugins/ai/copilot/copilot_test.go
+++ b/internal/plugins/ai/copilot/copilot_test.go
@@ -1,0 +1,56 @@
+package copilot
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/danielmiessler/fabric/internal/domain"
+)
+
+// TestParseSSEStreamLargeFrame reproduces the buffer-size failure in
+// parseSSEStream. Each Copilot SSE frame carries the cumulative message-so-far
+// on a single "data: {json}" line. Once the accumulated response exceeds
+// bufio.MaxScanTokenSize (64 KiB) the default scanner aborts with
+// bufio.ErrTooLong, parseSSEStream returns copilot_error_reading_stream, and
+// the response is silently truncated.
+//
+// parseSSEStream is unexported; this in-package test calls it directly on a
+// zero-value *Client (it only reaches c.extractResponseText, which reads no
+// Client state).
+func TestParseSSEStreamLargeFrame(t *testing.T) {
+	// Build a response text larger than the default 64 KiB scanner token.
+	largeText := strings.Repeat("A", 100*1024)
+
+	// One SSE frame: a conversationResponse whose single assistant message
+	// carries the whole cumulative text on one line.
+	frame := `data: {"messages":[{"@odata.type":"#microsoft.graph.copilotConversationResponseMessage","text":"` +
+		largeText + `"}]}` + "\n"
+
+	reader := strings.NewReader(frame)
+	channel := make(chan domain.StreamUpdate, 64)
+
+	c := &Client{}
+
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- c.parseSSEStream(reader, channel)
+		close(channel)
+	}()
+
+	var got strings.Builder
+	for update := range channel {
+		if update.Type == domain.StreamTypeContent {
+			got.WriteString(update.Content)
+		}
+	}
+
+	if err := <-errCh; err != nil {
+		t.Fatalf("parseSSEStream returned error on a >64KiB frame: %v", err)
+	}
+
+	// parseSSEStream appends a trailing newline after the stream ends.
+	want := largeText + "\n"
+	if got.String() != want {
+		t.Fatalf("content truncated: got %d bytes, want %d bytes", got.Len(), len(want))
+	}
+}


### PR DESCRIPTION
Copilot streaming (`parseSSEStream`, `internal/plugins/ai/copilot/copilot.go`) uses a default `bufio.Scanner`, whose 64 KiB token limit is hit because each Copilot SSE frame carries the full **cumulative** message on a single `data:` line (confirmed by the `strings.CutPrefix(newText, lastMessageText)` delta logic). A long response — routine for code generation — trips `bufio.ErrTooLong`, so the stream fails with `copilot_error_reading_stream` and the response is silently truncated.

### Fix

Grow the scanner buffer to 1 MiB, mirroring the existing in-repo precedent `internal/server/ollama.go:425`:

```go
scanner := bufio.NewScanner(reader)
scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
```

### Test

Adds an in-package regression test (`copilot_test.go`, 100 KiB single frame):
- **Before:** `parseSSEStream returned error on a >64KiB frame: ... bufio.Scanner: token too long` (`bufio.ErrTooLong` surfaced as `copilot_error_reading_stream`).
- **After:** full 100 KiB content delivered.

Sibling to the merged SSE reliability fix #2203. Verified: `go test ./internal/plugins/ai/copilot/...` ok, `gofmt`/`go vet`/`go build` clean, and the repo's `modernize` pass is clean on the changed files.
