### PR TITLE
fix: always send user message with patterns for OpenAI-compatible providers

### DIFF
--- a/internal/core/chatter.go
+++ b/internal/core/chatter.go
@@ -261,7 +261,7 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 	}
 
 	var patternContent string
-	inputUsed := false
+
 	if request.PatternName != "" {
 		var pattern *fsdb.Pattern
 		if request.NoVariableReplacement {
@@ -274,7 +274,7 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 			return nil, fmt.Errorf(i18n.T("chatter_error_get_pattern"), request.PatternName, err)
 		}
 		patternContent = pattern.Pattern
-		inputUsed = true
+
 	}
 
 	systemMessage := joinPromptSections(contextContent, patternContent)
@@ -338,9 +338,9 @@ func (o *Chatter) BuildSession(request *domain.ChatRequest, raw bool) (session *
 		if systemMessage != "" {
 			session.Append(&chat.ChatCompletionMessage{Role: chat.ChatMessageRoleSystem, Content: systemMessage})
 		}
-		// If multi-part content, it is in the user message, and should be added.
-		// Otherwise, we should only add it if we have not already used it in the systemMessage.
-		if len(request.Message.MultiContent) > 0 || (request.Message != nil && !inputUsed) {
+		// Always append the user message so that OpenAI-compatible providers
+		// that require at least one user turn receive one.
+		if request.Message != nil {
 			session.Append(request.Message)
 		}
 	}

--- a/internal/core/chatter_test.go
+++ b/internal/core/chatter_test.go
@@ -244,8 +244,8 @@ func TestChatter_BuildSession_SeparatesSystemSections(t *testing.T) {
 	}
 
 	messages := session.GetVendorMessages()
-	if len(messages) != 1 {
-		t.Fatalf("expected 1 vendor message, got %d", len(messages))
+	if len(messages) != 2 {
+		t.Fatalf("expected 2 vendor messages (system + user), got %d", len(messages))
 	}
 
 	systemMessage := messages[0]
@@ -256,6 +256,14 @@ func TestChatter_BuildSession_SeparatesSystemSections(t *testing.T) {
 	expectedSystemMessage := "STRATEGY\nCONTEXT\nPATTERN\nuser input"
 	if systemMessage.Content != expectedSystemMessage {
 		t.Fatalf("expected system message %q, got %q", expectedSystemMessage, systemMessage.Content)
+	}
+
+	userMessage := messages[1]
+	if userMessage.Role != chat.ChatMessageRoleUser {
+		t.Fatalf("expected second message to be user, got %s", userMessage.Role)
+	}
+	if userMessage.Content != "user input" {
+		t.Fatalf("expected user message content %q, got %q", "user input", userMessage.Content)
 	}
 
 	if request.Message.Content != "user input" {
@@ -517,5 +525,53 @@ func TestChatter_Send_StreamingMetadataPropagation(t *testing.T) {
 
 	if !usageReceived {
 		t.Error("Expected to receive a usage metadata update, but didn't")
+	}
+}
+
+func TestBuildSession_PatternAlwaysSendsUserMessage(t *testing.T) {
+	// Regression test: OpenAI-compatible providers that require at least one
+	// user turn must receive one, even when a pattern embeds the user input
+	// into the system message. See https://github.com/danielmiessler/fabric/issues/2208
+	tempDir := t.TempDir()
+	db := fsdb.NewDb(tempDir)
+
+	if err := os.MkdirAll(filepath.Join(db.Patterns.Dir, "summarize"), 0o755); err != nil {
+		t.Fatalf("failed to create pattern directory: %v", err)
+	}
+	patternPath := filepath.Join(db.Patterns.Dir, "summarize", "system.md")
+	if err := os.WriteFile(patternPath, []byte("# IDENTITY and PURPOSE\nYou summarize text.\n# INPUT:\n\n{{input}}"), 0o644); err != nil {
+		t.Fatalf("failed to write pattern: %v", err)
+	}
+
+	chatter := &Chatter{db: db}
+	request := &domain.ChatRequest{
+		PatternName: "summarize",
+		Message: &chat.ChatCompletionMessage{
+			Role:    chat.ChatMessageRoleUser,
+			Content: "The quick brown fox jumps over the lazy dog.",
+		},
+	}
+
+	session, err := chatter.BuildSession(request, false)
+	if err != nil {
+		t.Fatalf("BuildSession returned error: %v", err)
+	}
+
+	messages := session.GetVendorMessages()
+	if len(messages) < 2 {
+		t.Fatalf("expected at least 2 messages (system + user), got %d", len(messages))
+	}
+
+	// First message must be system (contains the pattern)
+	if messages[0].Role != chat.ChatMessageRoleSystem {
+		t.Errorf("expected first message role to be system, got %s", messages[0].Role)
+	}
+
+	// Second message must be user (required by OpenAI-compatible providers)
+	if messages[1].Role != chat.ChatMessageRoleUser {
+		t.Errorf("expected second message role to be user, got %s", messages[1].Role)
+	}
+	if messages[1].Content == "" {
+		t.Error("expected non-empty user message content")
 	}
 }


### PR DESCRIPTION
## What this Pull Request (PR) does

When a pattern is active, `BuildSession` used to suppress the user message entirely because the user's input was already embedded in the system message through the `{{input}}` placeholder. That left the session with a single `role=system` message.

OpenAI-compatible providers like Ollama Cloud (`OPENAI_API_BASE_URL`) require at least one `role=user` turn to produce a response. Without it, they return empty responses.

The fix removes the `inputUsed` guard so the user message is always appended as a separate turn. The input still appears in the system message via the pattern (nothing changes there), and now the user message is also present so providers that need it get one.

## Related issues

Closes #2208

## How to test

1. Configure Fabric with an OpenAI-compatible provider:
   ```bash
   export OPENAI_API_BASE_URL=https://ollama.com/v1
   ```
2. Run any pattern:
   ```bash
   echo "The quick brown fox" | fabric -p summarize
   ```
3. Before this fix: empty response. After: normal summary output.

For unit tests:
```bash
go test ./internal/core/ -run TestBuildSession_PatternAlwaysSendsUserMessage -v
```

## Notes

The input appears twice when a pattern is loaded (once in the system message, once as the user message). This is intentional. Most models handle it fine, and it matches what most OpenAI wrappers do when combining a system prompt with user input. If a provider ever complains about duplicated content, that's a separate issue to address with per-provider message shaping.

The existing test `TestChatter_BuildSession_SeparatesSystemSections` was updated to expect 2 messages (system + user) instead of 1, matching the new behavior.