### PR TITLE
fix: enable raw mode for GPT-6 models

### DIFF
--- a/cmd/generate_changelog/incoming/2216.txt
+++ b/cmd/generate_changelog/incoming/2216.txt
@@ -1,0 +1,3 @@
+### PR [#2216](https://github.com/danielmiessler/Fabric/pull/2216) by [ctbaum](https://github.com/ctbaum): fix: enable raw mode for GPT-6 models
+
+- Fix: enable raw mode for GPT-6 models

--- a/internal/plugins/ai/openai/openai.go
+++ b/internal/plugins/ai/openai/openai.go
@@ -223,6 +223,7 @@ func (o *Client) NeedsRawMode(modelName string) bool {
 	openaiModelsPrefixes := []string{
 		"glm",
 		"gpt-5",
+		"gpt-6",
 		"o1",
 		"o3",
 		"o4",

--- a/internal/plugins/ai/openai/openai_test.go
+++ b/internal/plugins/ai/openai/openai_test.go
@@ -12,6 +12,12 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestNeedsRawModeGPT6(t *testing.T) {
+	if !NewClient().NeedsRawMode("gpt-6-astra") {
+		t.Fatal("gpt-6 models should use raw mode")
+	}
+}
+
 func TestBuildResponseRequestWithMaxTokens(t *testing.T) {
 
 	var msgs []*chat.ChatCompletionMessage


### PR DESCRIPTION
## Summary

- enable automatic raw mode for `gpt-6` models
- add a regression test for `gpt-6-astra`

Without raw mode, Fabric sends `temperature` and `top_p`; the Codex backend rejects the request with HTTP 400 (`Unsupported parameter: temperature`).

Fixes #2215.

## Testing

```sh
go test ./...
```
